### PR TITLE
feat(ir): Support signed and unsigned integers; aliases for floats.

### DIFF
--- a/ploidy-codegen-rust/src/naming.rs
+++ b/ploidy-codegen-rust/src/naming.rs
@@ -202,8 +202,14 @@ impl ToTokens for CodegenUntaggedVariantName {
         use IrUntaggedVariantNameHint::*;
         let s = match self.0 {
             Primitive(PrimitiveIrType::String) => "String".into(),
+            Primitive(PrimitiveIrType::I8) => "I8".into(),
+            Primitive(PrimitiveIrType::U8) => "U8".into(),
+            Primitive(PrimitiveIrType::I16) => "I16".into(),
+            Primitive(PrimitiveIrType::U16) => "U16".into(),
             Primitive(PrimitiveIrType::I32) => "I32".into(),
+            Primitive(PrimitiveIrType::U32) => "U32".into(),
             Primitive(PrimitiveIrType::I64) => "I64".into(),
+            Primitive(PrimitiveIrType::U64) => "U64".into(),
             Primitive(PrimitiveIrType::F32) => "F32".into(),
             Primitive(PrimitiveIrType::F64) => "F64".into(),
             Primitive(PrimitiveIrType::Bool) => "Bool".into(),

--- a/ploidy-codegen-rust/src/primitive.rs
+++ b/ploidy-codegen-rust/src/primitive.rs
@@ -19,8 +19,14 @@ impl<'a> ToTokens for CodegenPrimitive<'a> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         tokens.append_all(match self.ty.ty() {
             PrimitiveIrType::String => quote! { ::std::string::String },
+            PrimitiveIrType::I8 => quote! { i8 },
+            PrimitiveIrType::U8 => quote! { u8 },
+            PrimitiveIrType::I16 => quote! { i16 },
+            PrimitiveIrType::U16 => quote! { u16 },
             PrimitiveIrType::I32 => quote! { i32 },
+            PrimitiveIrType::U32 => quote! { u32 },
             PrimitiveIrType::I64 => quote! { i64 },
+            PrimitiveIrType::U64 => quote! { u64 },
             PrimitiveIrType::F32 => quote! { f32 },
             PrimitiveIrType::F64 => quote! { f64 },
             PrimitiveIrType::Bool => quote! { bool },
@@ -101,6 +107,130 @@ mod tests {
     }
 
     #[test]
+    fn test_codegen_primitive_i8() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Test:
+                  type: object
+                  required: [value]
+                  properties:
+                    value:
+                      type: integer
+                      format: int8
+        "})
+        .unwrap();
+        let spec = IrSpec::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(IrGraph::new(&spec));
+        let primitives = graph.primitives().collect_vec();
+        let [ty] = &*primitives else {
+            panic!("expected i8; got `{primitives:?}`");
+        };
+        let p = CodegenPrimitive::new(ty);
+        let actual: syn::Type = parse_quote!(#p);
+        let expected: syn::Type = parse_quote!(i8);
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_codegen_primitive_u8() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Test:
+                  type: object
+                  required: [value]
+                  properties:
+                    value:
+                      type: integer
+                      format: uint8
+        "})
+        .unwrap();
+        let spec = IrSpec::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(IrGraph::new(&spec));
+        let primitives = graph.primitives().collect_vec();
+        let [ty] = &*primitives else {
+            panic!("expected u8; got `{primitives:?}`");
+        };
+        let p = CodegenPrimitive::new(ty);
+        let actual: syn::Type = parse_quote!(#p);
+        let expected: syn::Type = parse_quote!(u8);
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_codegen_primitive_i16() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Test:
+                  type: object
+                  required: [value]
+                  properties:
+                    value:
+                      type: integer
+                      format: int16
+        "})
+        .unwrap();
+        let spec = IrSpec::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(IrGraph::new(&spec));
+        let primitives = graph.primitives().collect_vec();
+        let [ty] = &*primitives else {
+            panic!("expected i16; got `{primitives:?}`");
+        };
+        let p = CodegenPrimitive::new(ty);
+        let actual: syn::Type = parse_quote!(#p);
+        let expected: syn::Type = parse_quote!(i16);
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_codegen_primitive_u16() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Test:
+                  type: object
+                  required: [value]
+                  properties:
+                    value:
+                      type: integer
+                      format: uint16
+        "})
+        .unwrap();
+        let spec = IrSpec::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(IrGraph::new(&spec));
+        let primitives = graph.primitives().collect_vec();
+        let [ty] = &*primitives else {
+            panic!("expected u16; got `{primitives:?}`");
+        };
+        let p = CodegenPrimitive::new(ty);
+        let actual: syn::Type = parse_quote!(#p);
+        let expected: syn::Type = parse_quote!(u16);
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
     fn test_codegen_primitive_i32() {
         let doc = Document::from_yaml(indoc::indoc! {"
             openapi: 3.0.0
@@ -132,6 +262,37 @@ mod tests {
     }
 
     #[test]
+    fn test_codegen_primitive_u32() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Test:
+                  type: object
+                  required: [value]
+                  properties:
+                    value:
+                      type: integer
+                      format: uint32
+        "})
+        .unwrap();
+        let spec = IrSpec::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(IrGraph::new(&spec));
+        let primitives = graph.primitives().collect_vec();
+        let [ty] = &*primitives else {
+            panic!("expected u32; got `{primitives:?}`");
+        };
+        let p = CodegenPrimitive::new(ty);
+        let actual: syn::Type = parse_quote!(#p);
+        let expected: syn::Type = parse_quote!(u32);
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
     fn test_codegen_primitive_i64() {
         let doc = Document::from_yaml(indoc::indoc! {"
             openapi: 3.0.0
@@ -159,6 +320,37 @@ mod tests {
         let p = CodegenPrimitive::new(ty);
         let actual: syn::Type = parse_quote!(#p);
         let expected: syn::Type = parse_quote!(i64);
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_codegen_primitive_u64() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Test:
+                  type: object
+                  required: [value]
+                  properties:
+                    value:
+                      type: integer
+                      format: uint64
+        "})
+        .unwrap();
+        let spec = IrSpec::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(IrGraph::new(&spec));
+        let primitives = graph.primitives().collect_vec();
+        let [ty] = &*primitives else {
+            panic!("expected u64; got `{primitives:?}`");
+        };
+        let p = CodegenPrimitive::new(ty);
+        let actual: syn::Type = parse_quote!(#p);
+        let expected: syn::Type = parse_quote!(u64);
         assert_eq!(actual, expected);
     }
 

--- a/ploidy-core/src/ir/transform.rs
+++ b/ploidy-core/src/ir/transform.rs
@@ -482,13 +482,25 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
                 (Ty::String, Some(Format::Byte)) => PrimitiveIrType::Bytes.into(),
                 (Ty::String, Some(Format::Binary)) => PrimitiveIrType::Binary.into(),
                 (Ty::String, _) => PrimitiveIrType::String.into(),
+
+                (Ty::Integer, Some(Format::Int8)) => PrimitiveIrType::I8.into(),
+                (Ty::Integer, Some(Format::UInt8)) => PrimitiveIrType::U8.into(),
+                (Ty::Integer, Some(Format::Int16)) => PrimitiveIrType::I16.into(),
+                (Ty::Integer, Some(Format::UInt16)) => PrimitiveIrType::U16.into(),
+                (Ty::Integer, Some(Format::Int32)) => PrimitiveIrType::I32.into(),
+                (Ty::Integer, Some(Format::UInt32)) => PrimitiveIrType::U32.into(),
                 (Ty::Integer, Some(Format::Int64)) => PrimitiveIrType::I64.into(),
+                (Ty::Integer, Some(Format::UInt64)) => PrimitiveIrType::U64.into(),
                 (Ty::Integer, Some(Format::UnixTime)) => PrimitiveIrType::UnixTime.into(),
-                (Ty::Integer, Some(Format::Int32) | _) => PrimitiveIrType::I32.into(),
+                (Ty::Integer, _) => PrimitiveIrType::I32.into(),
+
                 (Ty::Number, Some(Format::Float)) => PrimitiveIrType::F32.into(),
+                (Ty::Number, Some(Format::Double)) => PrimitiveIrType::F64.into(),
                 (Ty::Number, Some(Format::UnixTime)) => PrimitiveIrType::UnixTime.into(),
-                (Ty::Number, Some(Format::Double) | _) => PrimitiveIrType::F64.into(),
+                (Ty::Number, _) => PrimitiveIrType::F64.into(),
+
                 (Ty::Boolean, _) => PrimitiveIrType::Bool.into(),
+
                 (Ty::Array, _) => {
                     let items = match &self.schema.items {
                         Some(RefOrSchema::Ref(r)) => IrType::Ref(&r.path),
@@ -511,6 +523,7 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
                     let ty = IrType::Array(items.into());
                     IrUntaggedVariant::Some(IrUntaggedVariantNameHint::Array, ty)
                 }
+
                 (Ty::Object, _) => {
                     let ty = match &self.schema.additional_properties {
                         Some(AdditionalProperties::RefOrSchema(RefOrSchema::Ref(r))) => {
@@ -535,6 +548,7 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
                     };
                     IrUntaggedVariant::Some(IrUntaggedVariantNameHint::Map, ty)
                 }
+
                 (Ty::Null, _) => IrUntaggedVariant::Null,
             })
             .collect_vec();

--- a/ploidy-core/src/ir/types.rs
+++ b/ploidy-core/src/ir/types.rs
@@ -74,8 +74,14 @@ pub enum IrTypeRef<'a> {
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum PrimitiveIrType {
     String,
+    I8,
+    U8,
+    I16,
+    U16,
     I32,
+    U32,
     I64,
+    U64,
     F32,
     F64,
     Bool,

--- a/ploidy-core/src/parse/types.rs
+++ b/ploidy-core/src/parse/types.rs
@@ -292,12 +292,18 @@ pub enum Format {
     Uuid,
     Byte,
     Binary,
+    Int8,
+    UInt8,
+    Int16,
+    UInt16,
     Int32,
+    UInt32,
     Int64,
+    UInt64,
     Float,
     Double,
-    Currency,
-    Decimal,
+    #[serde(other)]
+    Other,
 }
 
 #[derive(Clone, Debug, Deserialize, JsonPointee)]


### PR DESCRIPTION
This PR:

* Adds out-of-the-box support for the [TypeSpec numeric formats](https://typespec.io/docs/language-basics/built-in-types/#numeric-types) and aliases.
* Turns unrecognized formats into `Format::Other`, which fall back to the `type` of the schema, instead of hard-failing.

Closes #14.