### PR TITLE
fix(ir): `format: byte` strings are Base64; `format: binary` are raw bytes.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -739,6 +745,7 @@ dependencies = [
 name = "ploidy-util"
 version = "0.8.0"
 dependencies = [
+ "base64",
  "chrono",
  "itertools",
  "percent-encoding",

--- a/ploidy-codegen-rust/src/cargo.rs
+++ b/ploidy-codegen-rust/src/cargo.rs
@@ -52,12 +52,12 @@ impl<'a> CodegenCargoManifest<'a> {
         };
 
         let dependencies = toml::toml! {
-            bytes = { version = "1", features = ["serde"] }
             chrono = { version = "0.4", features = ["serde"] }
             http = "1"
             ploidy-util = PLOIDY_VERSION
             reqwest = { version = "0.12", default-features = false, features = ["http2", "json", "multipart", "rustls-tls"] }
             serde = { version = "1", features = ["derive"] }
+            serde_bytes = "0.11"
             serde_json = "1"
             serde_path_to_error = "0.1"
             thiserror = "2"

--- a/ploidy-codegen-rust/src/naming.rs
+++ b/ploidy-codegen-rust/src/naming.rs
@@ -213,6 +213,7 @@ impl ToTokens for CodegenUntaggedVariantName {
             Primitive(PrimitiveIrType::Url) => "Url".into(),
             Primitive(PrimitiveIrType::Uuid) => "Uuid".into(),
             Primitive(PrimitiveIrType::Bytes) => "Bytes".into(),
+            Primitive(PrimitiveIrType::Binary) => "Binary".into(),
             Array => "Array".into(),
             Map => "Map".into(),
             Index(index) => Cow::Owned(format!("V{index}")),

--- a/ploidy-core/src/ir/tests/transform.rs
+++ b/ploidy-core/src/ir/tests/transform.rs
@@ -192,6 +192,15 @@ fn test_primitive_string_formats() {
     let result = transform(&doc, IrTypeName::Schema("Data"), &schema);
     assert_matches!(result, IrType::Primitive(PrimitiveIrType::Bytes));
 
+    // `string` with `binary` format.
+    let schema: Schema = serde_yaml::from_str(indoc::indoc! {"
+        type: string
+        format: binary
+    "})
+    .unwrap();
+    let result = transform(&doc, IrTypeName::Schema("RawData"), &schema);
+    assert_matches!(result, IrType::Primitive(PrimitiveIrType::Binary));
+
     // `string` without format.
     let schema: Schema = serde_yaml::from_str(indoc::indoc! {"
         type: string
@@ -1495,26 +1504,6 @@ fn test_unhandled_string_format_falls_back_to_string() {
     let result = transform(&doc, IrTypeName::Schema("CustomType"), &schema);
 
     assert_matches!(result, IrType::Primitive(PrimitiveIrType::String));
-}
-
-#[test]
-fn test_binary_format_maps_to_bytes() {
-    let doc = Document::from_yaml(indoc::indoc! {"
-        openapi: 3.0.0
-        info:
-          title: Test
-          version: 1.0.0
-    "})
-    .unwrap();
-    let schema: Schema = serde_yaml::from_str(indoc::indoc! {"
-        type: string
-        format: binary
-    "})
-    .unwrap();
-
-    let result = transform(&doc, IrTypeName::Schema("Data"), &schema);
-
-    assert_matches!(result, IrType::Primitive(PrimitiveIrType::Bytes));
 }
 
 #[test]

--- a/ploidy-core/src/ir/transform.rs
+++ b/ploidy-core/src/ir/transform.rs
@@ -479,9 +479,8 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
                 (Ty::String, Some(Format::Date)) => PrimitiveIrType::Date.into(),
                 (Ty::String, Some(Format::Uri)) => PrimitiveIrType::Url.into(),
                 (Ty::String, Some(Format::Uuid)) => PrimitiveIrType::Uuid.into(),
-                (Ty::String, Some(Format::Byte) | Some(Format::Binary)) => {
-                    PrimitiveIrType::Bytes.into()
-                }
+                (Ty::String, Some(Format::Byte)) => PrimitiveIrType::Bytes.into(),
+                (Ty::String, Some(Format::Binary)) => PrimitiveIrType::Binary.into(),
                 (Ty::String, _) => PrimitiveIrType::String.into(),
                 (Ty::Integer, Some(Format::Int64)) => PrimitiveIrType::I64.into(),
                 (Ty::Integer, Some(Format::UnixTime)) => PrimitiveIrType::UnixTime.into(),

--- a/ploidy-core/src/ir/types.rs
+++ b/ploidy-core/src/ir/types.rs
@@ -85,6 +85,7 @@ pub enum PrimitiveIrType {
     Url,
     Uuid,
     Bytes,
+    Binary,
 }
 
 /// A named schema type.

--- a/ploidy-util/Cargo.toml
+++ b/ploidy-util/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 keywords.workspace = true
 
 [dependencies]
+base64 = "0.22"
 chrono = "0.4"
 itertools = "0.14"
 percent-encoding = "2.3"

--- a/ploidy-util/src/binary.rs
+++ b/ploidy-util/src/binary.rs
@@ -1,0 +1,124 @@
+use base64::Engine;
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
+
+/// A wrapper around a [`Vec<u8>`] that serializes and deserializes
+/// OpenAPI `byte` strings, which encode binary data as Base64.
+#[derive(Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct Base64(Vec<u8>);
+
+impl Base64 {
+    #[inline]
+    pub fn into_vec(self) -> Vec<u8> {
+        self.0
+    }
+}
+
+impl AsRef<[u8]> for Base64 {
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl AsMut<[u8]> for Base64 {
+    #[inline]
+    fn as_mut(&mut self) -> &mut [u8] {
+        &mut self.0
+    }
+}
+
+impl From<Vec<u8>> for Base64 {
+    #[inline]
+    fn from(value: Vec<u8>) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&[u8]> for Base64 {
+    #[inline]
+    fn from(value: &[u8]) -> Self {
+        Self(value.to_vec())
+    }
+}
+
+impl Serialize for Base64 {
+    #[inline]
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let encoded = base64::engine::general_purpose::STANDARD.encode(&self.0);
+        serializer.serialize_str(&encoded)
+    }
+}
+
+impl<'de> Deserialize<'de> for Base64 {
+    #[inline]
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        use de::Error;
+        let value: &'de str = Deserialize::deserialize(deserializer)?;
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(value)
+            .map_err(|err| D::Error::custom(Base64Error(err)))?;
+        Ok(Base64(decoded))
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("byte string contains invalid Base64: {0}")]
+pub struct Base64Error(#[from] base64::DecodeError);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_serialize_empty() {
+        let byte = Base64::default();
+        let json = serde_json::to_string(&byte).unwrap();
+        assert_eq!(json, r#""""#);
+    }
+
+    #[test]
+    fn test_serialize_text_data() {
+        let byte = Base64::from(b"Hello, World!".as_slice());
+        let json = serde_json::to_string(&byte).unwrap();
+        assert_eq!(json, r#""SGVsbG8sIFdvcmxkIQ==""#);
+    }
+
+    #[test]
+    fn test_serialize_binary_data() {
+        let byte = Base64::from(vec![0x00, 0x01, 0x02, 0xff, 0xfe, 0xfd]);
+        let json = serde_json::to_string(&byte).unwrap();
+        assert_eq!(json, r#""AAEC//79""#);
+    }
+
+    #[test]
+    fn test_deserialize_empty() {
+        let byte: Base64 = serde_json::from_str(r#""""#).unwrap();
+        assert_eq!(byte.as_ref(), b"");
+    }
+
+    #[test]
+    fn test_deserialize_text_data() {
+        let byte: Base64 = serde_json::from_str(r#""SGVsbG8sIFdvcmxkIQ==""#).unwrap();
+        assert_eq!(byte.as_ref(), b"Hello, World!");
+    }
+
+    #[test]
+    fn test_deserialize_binary_data() {
+        let byte: Base64 = serde_json::from_str(r#""AAEC//79""#).unwrap();
+        assert_eq!(byte.as_ref(), &[0x00, 0x01, 0x02, 0xff, 0xfe, 0xfd]);
+    }
+
+    #[test]
+    fn test_deserialize_invalid_base64() {
+        let result: Result<Base64, _> = serde_json::from_str(r#""not valid base64!!!""#);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_roundtrip() {
+        let original = Base64::from(vec![0x00, 0x7f, 0x80, 0xff, 0x42]);
+        let json = serde_json::to_string(&original).unwrap();
+        let restored: Base64 = serde_json::from_str(&json).unwrap();
+        assert_eq!(original, restored);
+    }
+}

--- a/ploidy-util/src/lib.rs
+++ b/ploidy-util/src/lib.rs
@@ -1,8 +1,10 @@
 pub mod absent;
+pub mod binary;
 pub mod date_time;
 pub mod query;
 
 pub use absent::{AbsentError, AbsentOr, FieldAbsentError};
+pub use binary::{Base64, Base64Error};
 pub use date_time::{
     TryFromTimestampError, UnixMicroseconds, UnixMilliseconds, UnixNanoseconds, UnixSeconds,
 };


### PR DESCRIPTION
* Per OpenAPI 3.0, `format: byte` strings are Base64-encoded, so let's (de)serialize them as such. This changes those types to use a new `ploidy_util::Base64` wrapper, similar to how we represent Unix timestamps. (OpenAPI 3.1+ uses `contentEncoding: base64`; we can support that in a follow-up).
* `format: binary` is a ["binary string"](https://swagger.io/docs/specification/v3_0/data-models/data-types/#files). JSON strings are ["WTF-16"](https://wtf-8.codeberg.page/#ill-formed-utf-16), which Serde will [allow and transform into WTF-8 if you're deserializing into a `serde_bytes::ByteBuf`](https://github.com/serde-rs/json/blob/4f6dbfac79647d032b0997b5ab73022340c6dab7/src/de.rs#L1584-L1587)...so this PR does just that.