### PR TITLE
feat(util): Re-export all runtime dependencies from `ploidy-util`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "atomic_refcell"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,6 +143,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
+name = "bytes"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+
+[[package]]
 name = "cargo_toml"
 version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,6 +175,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,6 +189,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -279,6 +298,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,10 +319,95 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
 
 [[package]]
 name = "hashbrown"
@@ -319,6 +429,108 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -468,6 +680,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iri-string"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is_ci"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -539,6 +767,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -584,12 +818,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+]
+
+[[package]]
+name = "mio"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -645,6 +906,18 @@ dependencies = [
  "indexmap",
  "serde",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "ploidy"
@@ -749,12 +1022,17 @@ version = "0.8.1"
 dependencies = [
  "base64",
  "chrono",
+ "http",
  "itertools",
  "percent-encoding",
+ "reqwest",
  "serde",
+ "serde_bytes",
  "serde_json",
+ "serde_path_to_error",
  "thiserror",
  "url",
+ "uuid",
 ]
 
 [[package]]
@@ -764,6 +1042,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
 ]
 
 [[package]]
@@ -796,12 +1083,102 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -822,6 +1199,61 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -850,6 +1282,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -875,6 +1342,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -932,6 +1409,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -951,10 +1440,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "stable_deref_trait"
@@ -967,6 +1472,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "supports-color"
@@ -998,6 +1509,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]
@@ -1062,6 +1582,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "0.9.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1101,6 +1673,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1137,6 +1779,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1146,6 +1794,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -1161,6 +1810,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
+dependencies = [
+ "getrandom 0.3.4",
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1171,6 +1856,19 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1203,6 +1901,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -1266,11 +1993,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -1284,20 +2020,42 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1307,9 +2065,21 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1319,9 +2089,21 @@ checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1331,15 +2113,33 @@ checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1355,6 +2155,12 @@ checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "writeable"
@@ -1392,6 +2198,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerocopy"
+version = "0.8.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7456cf00f0685ad319c5b1693f291a650eaf345e941d082fc4e03df8a03996ac"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1328722bbf2115db7e19d69ebcc15e795719e2d66b60827c6a69a117365e37a0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "zerofrom"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1411,6 +2237,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/ploidy-codegen-rust/src/client.rs
+++ b/ploidy-codegen-rust/src/client.rs
@@ -41,24 +41,24 @@ impl ToTokens for CodegenClientModule<'_> {
             #[doc = #client_doc]
             #[derive(Clone, Debug)]
             pub struct Client {
-                client: ::reqwest::Client,
-                headers: ::http::HeaderMap,
-                base_url: ::url::Url,
+                client: ::ploidy_util::reqwest::Client,
+                headers: ::ploidy_util::http::HeaderMap,
+                base_url: ::ploidy_util::url::Url,
             }
 
             impl Client {
                 /// Create a new client.
                 pub fn new(base_url: impl AsRef<str>) -> Result<Self, crate::error::Error> {
                     Ok(Self::with_reqwest_client(
-                        ::reqwest::Client::new(),
+                        ::ploidy_util::reqwest::Client::new(),
                         base_url.as_ref().parse()?,
                     ))
                 }
 
-                pub fn with_reqwest_client(client: ::reqwest::Client, base_url: ::url::Url) -> Self {
+                pub fn with_reqwest_client(client: ::ploidy_util::reqwest::Client, base_url: ::ploidy_util::url::Url) -> Self {
                     Self {
                         client,
-                        headers: ::http::HeaderMap::new(),
+                        headers: ::ploidy_util::http::HeaderMap::new(),
                         base_url,
                     }
                 }
@@ -66,10 +66,10 @@ impl ToTokens for CodegenClientModule<'_> {
                 /// Adds a header to each request.
                 pub fn with_header<K, V>(mut self, name: K, value: V) -> Result<Self, crate::error::Error>
                 where
-                    K: TryInto<::http::HeaderName>,
-                    V: TryInto<::http::HeaderValue>,
-                    K::Error: Into<::http::Error>,
-                    V::Error: Into<::http::Error>,
+                    K: TryInto<::ploidy_util::http::HeaderName>,
+                    V: TryInto<::ploidy_util::http::HeaderValue>,
+                    K::Error: Into<::ploidy_util::http::Error>,
+                    V::Error: Into<::ploidy_util::http::Error>,
                 {
                     let name = name
                         .try_into()
@@ -99,15 +99,15 @@ impl ToTokens for CodegenClientModule<'_> {
                 /// ```
                 pub fn with_sensitive_header<K, V>(self, name: K, value: V) -> Result<Self, crate::error::Error>
                 where
-                    K: TryInto<::http::HeaderName>,
-                    V: TryInto<::http::HeaderValue>,
-                    K::Error: Into<::http::Error>,
-                    V::Error: Into<::http::Error>,
+                    K: TryInto<::ploidy_util::http::HeaderName>,
+                    V: TryInto<::ploidy_util::http::HeaderValue>,
+                    K::Error: Into<::ploidy_util::http::Error>,
+                    V::Error: Into<::ploidy_util::http::Error>,
                 {
                     let name = name
                         .try_into()
                         .map_err(|err| crate::error::Error::BadHeaderName(err.into()))?;
-                    let mut value: ::http::HeaderValue = value
+                    let mut value: ::ploidy_util::http::HeaderValue = value
                         .try_into()
                         .map_err(|err| crate::error::Error::BadHeaderValue(name.clone(), err.into()))?;
                     value.set_sensitive(true);
@@ -116,10 +116,10 @@ impl ToTokens for CodegenClientModule<'_> {
 
                 pub fn with_user_agent<V>(self, value: V) -> Result<Self, crate::error::Error>
                 where
-                    V: TryInto<::http::HeaderValue>,
-                    V::Error: Into<::http::Error>,
+                    V: TryInto<::ploidy_util::http::HeaderValue>,
+                    V::Error: Into<::ploidy_util::http::Error>,
                 {
-                    self.with_header(::http::header::USER_AGENT, value)
+                    self.with_header(::ploidy_util::http::header::USER_AGENT, value)
                 }
             }
 

--- a/ploidy-codegen-rust/src/enum_.rs
+++ b/ploidy-codegen-rust/src/enum_.rs
@@ -111,19 +111,19 @@ impl ToTokens for CodegenEnum<'_> {
                     }
                 }
 
-                impl<'de> ::serde::Deserialize<'de> for #type_name {
-                    fn deserialize<D: ::serde::Deserializer<'de>>(
+                impl<'de> ::ploidy_util::serde::Deserialize<'de> for #type_name {
+                    fn deserialize<D: ::ploidy_util::serde::Deserializer<'de>>(
                         deserializer: D,
                     ) -> ::std::result::Result<Self, D::Error> {
                         struct Visitor;
-                        impl<'de> ::serde::de::Visitor<'de> for Visitor {
+                        impl<'de> ::ploidy_util::serde::de::Visitor<'de> for Visitor {
                             type Value = #type_name;
 
                             fn expecting(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
                                 f.write_str(#expecting)
                             }
 
-                            fn visit_str<E: ::serde::de::Error>(
+                            fn visit_str<E: ::ploidy_util::serde::de::Error>(
                                 self,
                                 s: &str,
                             ) -> ::std::result::Result<Self::Value, E> {
@@ -131,17 +131,17 @@ impl ToTokens for CodegenEnum<'_> {
                                 Ok(v)
                             }
                         }
-                        ::serde::Deserializer::deserialize_str(deserializer, Visitor)
+                        ::ploidy_util::serde::Deserializer::deserialize_str(deserializer, Visitor)
                     }
                 }
 
-                impl ::serde::Serialize for #type_name {
-                    fn serialize<S: ::serde::Serializer>(
+                impl ::ploidy_util::serde::Serialize for #type_name {
+                    fn serialize<S: ::ploidy_util::serde::Serializer>(
                         &self,
                         serializer: S,
                     ) -> ::std::result::Result<S::Ok, S::Error> {
                         match self {
-                            Self::#other_name => Err(::serde::ser::Error::custom(#other_serialize_error)),
+                            Self::#other_name => Err(::ploidy_util::serde::ser::Error::custom(#other_serialize_error)),
                             v => v.to_string().serialize(serializer),
                         }
                     }
@@ -237,12 +237,12 @@ mod tests {
                     )
                 }
             }
-            impl<'de> ::serde::Deserialize<'de> for Status {
-                fn deserialize<D: ::serde::Deserializer<'de>>(
+            impl<'de> ::ploidy_util::serde::Deserialize<'de> for Status {
+                fn deserialize<D: ::ploidy_util::serde::Deserializer<'de>>(
                     deserializer: D,
                 ) -> ::std::result::Result<Self, D::Error> {
                     struct Visitor;
-                    impl<'de> ::serde::de::Visitor<'de> for Visitor {
+                    impl<'de> ::ploidy_util::serde::de::Visitor<'de> for Visitor {
                         type Value = Status;
                         fn expecting(
                             &self,
@@ -250,7 +250,7 @@ mod tests {
                         ) -> ::std::fmt::Result {
                             f.write_str("a variant of `Status`")
                         }
-                        fn visit_str<E: ::serde::de::Error>(
+                        fn visit_str<E: ::ploidy_util::serde::de::Error>(
                             self,
                             s: &str,
                         ) -> ::std::result::Result<Self::Value, E> {
@@ -258,17 +258,17 @@ mod tests {
                             Ok(v)
                         }
                     }
-                    ::serde::Deserializer::deserialize_str(deserializer, Visitor)
+                    ::ploidy_util::serde::Deserializer::deserialize_str(deserializer, Visitor)
                 }
             }
-            impl ::serde::Serialize for Status {
-                fn serialize<S: ::serde::Serializer>(
+            impl ::ploidy_util::serde::Serialize for Status {
+                fn serialize<S: ::ploidy_util::serde::Serializer>(
                     &self,
                     serializer: S,
                 ) -> ::std::result::Result<S::Ok, S::Error> {
                     match self {
                         Self::OtherStatus => Err(
-                            ::serde::ser::Error::custom(
+                            ::ploidy_util::serde::ser::Error::custom(
                                 "can't serialize variant `Status::OtherStatus`"
                             )
                         ),

--- a/ploidy-codegen-rust/src/inlines.rs
+++ b/ploidy-codegen-rust/src/inlines.rs
@@ -151,7 +151,8 @@ mod tests {
         let expected: syn::File = parse_quote! {
             pub mod types {
                 mod get_items_filter {
-                    #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::serde::Serialize, ::serde::Deserialize)]
+                    #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+                    #[serde(crate = "::ploidy_util::serde")]
                     pub struct GetItemsFilter {
                         #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent",)]
                         pub status: ::ploidy_util::absent::AbsentOr<::std::string::String>,
@@ -263,7 +264,8 @@ mod tests {
         let expected: syn::File = parse_quote! {
             pub mod types {
                 mod get_items_apple {
-                    #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::serde::Serialize, ::serde::Deserialize)]
+                    #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+                    #[serde(crate = "::ploidy_util::serde")]
                     pub struct GetItemsApple {
                         #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent",)]
                         pub value: ::ploidy_util::absent::AbsentOr<::std::string::String>,
@@ -271,7 +273,8 @@ mod tests {
                 }
                 pub use get_items_apple::*;
                 mod get_items_mango {
-                    #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::serde::Serialize, ::serde::Deserialize)]
+                    #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+                    #[serde(crate = "::ploidy_util::serde")]
                     pub struct GetItemsMango {
                         #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent",)]
                         pub value: ::ploidy_util::absent::AbsentOr<::std::string::String>,
@@ -279,7 +282,8 @@ mod tests {
                 }
                 pub use get_items_mango::*;
                 mod get_items_zebra {
-                    #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::serde::Serialize, ::serde::Deserialize)]
+                    #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+                    #[serde(crate = "::ploidy_util::serde")]
                     pub struct GetItemsZebra {
                         #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent",)]
                         pub value: ::ploidy_util::absent::AbsentOr<::std::string::String>,
@@ -362,7 +366,8 @@ mod tests {
         let expected: syn::File = parse_quote! {
             pub mod types {
                 mod get_items_config {
-                    #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::serde::Serialize, ::serde::Deserialize)]
+                    #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+                    #[serde(crate = "::ploidy_util::serde")]
                     pub struct GetItemsConfig {
                         #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent",)]
                         pub enabled: ::ploidy_util::absent::AbsentOr<bool>,
@@ -412,7 +417,8 @@ mod tests {
         let expected: syn::File = parse_quote! {
             pub mod types {
                 mod get_items_filters_item {
-                    #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::serde::Serialize, ::serde::Deserialize)]
+                    #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+                    #[serde(crate = "::ploidy_util::serde")]
                     pub struct GetItemsFiltersItem {
                         #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent",)]
                         pub field: ::ploidy_util::absent::AbsentOr<::std::string::String>,
@@ -462,7 +468,8 @@ mod tests {
         let expected: syn::File = parse_quote! {
             pub mod types {
                 mod get_items_metadata_value {
-                    #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::serde::Serialize, ::serde::Deserialize)]
+                    #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+                    #[serde(crate = "::ploidy_util::serde")]
                     pub struct GetItemsMetadataValue {
                         #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent",)]
                         pub value: ::ploidy_util::absent::AbsentOr<::std::string::String>,

--- a/ploidy-codegen-rust/src/operation.rs
+++ b/ploidy-codegen-rust/src/operation.rs
@@ -177,7 +177,7 @@ impl ToTokens for CodegenOperation<'_> {
                     params.push(quote! { request: impl Into<#param_type> });
                 }
                 IrRequestView::Multipart => {
-                    params.push(quote! { form: reqwest::multipart::Form });
+                    params.push(quote! { form: ::ploidy_util::reqwest::multipart::Form });
                 }
             }
         }
@@ -225,8 +225,8 @@ impl ToTokens for CodegenOperation<'_> {
         let parse_response = if self.op.response().is_some() {
             quote! {
                 let body = response.bytes().await?;
-                let deserializer = &mut serde_json::Deserializer::from_slice(&body);
-                let result = serde_path_to_error::deserialize(deserializer)
+                let deserializer = &mut ::ploidy_util::serde_json::Deserializer::from_slice(&body);
+                let result = ::ploidy_util::serde_path_to_error::deserialize(deserializer)
                     .map_err(crate::error::JsonError::from)?;
                 Ok(result)
             }

--- a/ploidy-codegen-rust/src/primitive.rs
+++ b/ploidy-codegen-rust/src/primitive.rs
@@ -40,7 +40,7 @@ impl<'a> ToTokens for CodegenPrimitive<'a> {
                     .unwrap_or_default();
                 match format {
                     DateTimeFormat::Rfc3339 => {
-                        quote! { ::chrono::DateTime<::chrono::Utc> }
+                        quote! { ::ploidy_util::chrono::DateTime<::ploidy_util::chrono::Utc> }
                     }
                     DateTimeFormat::UnixSeconds => {
                         quote! { ::ploidy_util::date_time::UnixSeconds }
@@ -57,11 +57,11 @@ impl<'a> ToTokens for CodegenPrimitive<'a> {
                 }
             }
             PrimitiveIrType::UnixTime => quote! { ::ploidy_util::date_time::UnixSeconds },
-            PrimitiveIrType::Date => quote! { ::chrono::NaiveDate },
-            PrimitiveIrType::Url => quote! { ::url::Url },
-            PrimitiveIrType::Uuid => quote! { ::uuid::Uuid },
+            PrimitiveIrType::Date => quote! { ::ploidy_util::chrono::NaiveDate },
+            PrimitiveIrType::Url => quote! { ::ploidy_util::url::Url },
+            PrimitiveIrType::Uuid => quote! { ::ploidy_util::uuid::Uuid },
             PrimitiveIrType::Bytes => quote! { ::ploidy_util::binary::Base64 },
-            PrimitiveIrType::Binary => quote! { ::serde_bytes::ByteBuf },
+            PrimitiveIrType::Binary => quote! { ::ploidy_util::serde_bytes::ByteBuf },
         });
     }
 }
@@ -474,7 +474,8 @@ mod tests {
         };
         let p = CodegenPrimitive::new(ty);
         let actual: syn::Type = parse_quote!(#p);
-        let expected: syn::Type = parse_quote!(::chrono::DateTime<::chrono::Utc>);
+        let expected: syn::Type =
+            parse_quote!(::ploidy_util::chrono::DateTime<::ploidy_util::chrono::Utc>);
         assert_eq!(actual, expected);
     }
 
@@ -649,7 +650,7 @@ mod tests {
         };
         let p = CodegenPrimitive::new(ty);
         let actual: syn::Type = parse_quote!(#p);
-        let expected: syn::Type = parse_quote!(::chrono::NaiveDate);
+        let expected: syn::Type = parse_quote!(::ploidy_util::chrono::NaiveDate);
         assert_eq!(actual, expected);
     }
 
@@ -680,7 +681,7 @@ mod tests {
         };
         let p = CodegenPrimitive::new(ty);
         let actual: syn::Type = parse_quote!(#p);
-        let expected: syn::Type = parse_quote!(::url::Url);
+        let expected: syn::Type = parse_quote!(::ploidy_util::url::Url);
         assert_eq!(actual, expected);
     }
 
@@ -711,7 +712,7 @@ mod tests {
         };
         let p = CodegenPrimitive::new(ty);
         let actual: syn::Type = parse_quote!(#p);
-        let expected: syn::Type = parse_quote!(::uuid::Uuid);
+        let expected: syn::Type = parse_quote!(::ploidy_util::uuid::Uuid);
         assert_eq!(actual, expected);
     }
 
@@ -773,7 +774,7 @@ mod tests {
         };
         let p = CodegenPrimitive::new(ty);
         let actual: syn::Type = parse_quote!(#p);
-        let expected: syn::Type = parse_quote!(::serde_bytes::ByteBuf);
+        let expected: syn::Type = parse_quote!(::ploidy_util::serde_bytes::ByteBuf);
         assert_eq!(actual, expected);
     }
 }

--- a/ploidy-codegen-rust/src/ref_.rs
+++ b/ploidy-codegen-rust/src/ref_.rs
@@ -41,7 +41,7 @@ impl ToTokens for CodegenRef<'_> {
                 let ty = CodegenRef::new(&inner);
                 quote! { ::std::option::Option<#ty> }
             }
-            IrTypeView::Any => quote! { ::serde_json::Value },
+            IrTypeView::Any => quote! { ::ploidy_util::serde_json::Value },
             IrTypeView::Inline(ty) => {
                 let path = ty.path();
                 let root: syn::Path = match path.root {
@@ -87,7 +87,7 @@ mod tests {
         let ty = IrTypeView::Any;
         let ref_ = CodegenRef::new(&ty);
         let actual: syn::Type = parse_quote!(#ref_);
-        let expected: syn::Type = parse_quote!(::serde_json::Value);
+        let expected: syn::Type = parse_quote!(::ploidy_util::serde_json::Value);
         assert_eq!(actual, expected);
     }
 

--- a/ploidy-codegen-rust/src/schema.rs
+++ b/ploidy-codegen-rust/src/schema.rs
@@ -112,7 +112,8 @@ mod tests {
         // but the inline types in `mod types` should be sorted alphabetically
         // (`Apple`, `Mango`, `Zebra`).
         let expected: syn::File = parse_quote! {
-            #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::serde::Serialize, ::serde::Deserialize)]
+            #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+            #[serde(crate = "::ploidy_util::serde")]
             pub struct Container {
                 #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent",)]
                 pub zebra: ::ploidy_util::absent::AbsentOr<crate::types::container::types::Zebra>,
@@ -122,17 +123,20 @@ mod tests {
                 pub apple: ::ploidy_util::absent::AbsentOr<crate::types::container::types::Apple>,
             }
             pub mod types {
-                #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::serde::Serialize, ::serde::Deserialize)]
+                #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+                #[serde(crate = "::ploidy_util::serde")]
                 pub struct Apple {
                     #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent",)]
                     pub name: ::ploidy_util::absent::AbsentOr<::std::string::String>,
                 }
-                #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::serde::Serialize, ::serde::Deserialize)]
+                #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+                #[serde(crate = "::ploidy_util::serde")]
                 pub struct Mango {
                     #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent",)]
                     pub name: ::ploidy_util::absent::AbsentOr<::std::string::String>,
                 }
-                #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::serde::Serialize, ::serde::Deserialize)]
+                #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+                #[serde(crate = "::ploidy_util::serde")]
                 pub struct Zebra {
                     #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent",)]
                     pub name: ::ploidy_util::absent::AbsentOr<::std::string::String>,

--- a/ploidy-codegen-rust/src/statics.rs
+++ b/ploidy-codegen-rust/src/statics.rs
@@ -36,47 +36,7 @@ pub struct CodegenErrorModule;
 impl ToTokens for CodegenErrorModule {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         tokens.append_all(quote! {
-            /// Transport-level error types.
-            #[derive(Debug, thiserror::Error)]
-            pub enum Error {
-                /// Network or connection error.
-                #[error("Network error")]
-                Network(#[from] reqwest::Error),
-
-                /// Invalid JSON in request or response.
-                #[error("Malformed JSON")]
-                Json(#[from] JsonError),
-
-                /// Invalid URL.
-                #[error("Malformed URL")]
-                Url(#[from] url::ParseError),
-
-                /// URL can't be used as a base.
-                #[error("Can't use URL as base URL")]
-                UrlCannotBeABase,
-
-                /// Invalid query parameter.
-                #[error("Invalid query parameter")]
-                QueryParam(#[from] ::ploidy_util::QueryParamError),
-
-                /// Invalid HTTP header name.
-                #[error("invalid header name")]
-                BadHeaderName(#[source] http::Error),
-
-                /// Invalid HTTP header value.
-                #[error("invalid value for header `{0}`")]
-                BadHeaderValue(http::HeaderName, #[source] http::Error),
-            }
-
-            /// Invalid or unexpected JSON, with or without a path
-            /// to the unexpected section.
-            #[derive(Debug, thiserror::Error)]
-            pub enum JsonError {
-                #[error(transparent)]
-                Json(#[from] serde_json::Error),
-                #[error(transparent)]
-                JsonWithPath(#[from] serde_path_to_error::Error<serde_json::Error>),
-            }
+            pub use ::ploidy_util::error::*;
         });
     }
 }

--- a/ploidy-codegen-rust/src/struct_.rs
+++ b/ploidy-codegen-rust/src/struct_.rs
@@ -129,7 +129,8 @@ impl ToTokens for CodegenStruct<'_> {
 
         tokens.append_all(quote! {
             #doc_attrs
-            #[derive(Debug, Clone, PartialEq, #(#extra_derives,)* ::serde::Serialize, ::serde::Deserialize)]
+            #[derive(Debug, Clone, PartialEq, #(#extra_derives,)* ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+            #[serde(crate = "::ploidy_util::serde")]
             pub struct #type_name {
                 #(#fields)*
             }
@@ -303,7 +304,8 @@ mod tests {
         // `name` is a required string field, which implements `Default`,
         // so the struct can derive `Default`.
         let expected: syn::ItemStruct = parse_quote! {
-            #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::serde::Serialize, ::serde::Deserialize)]
+            #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+            #[serde(crate = "::ploidy_util::serde")]
             pub struct Pet {
                 pub name: ::std::string::String,
                 #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent",)]
@@ -354,7 +356,8 @@ mod tests {
         // `name` is a required string field, which implements `Default`,
         // so the struct can derive `Default`. The discriminator field is excluded.
         let expected: syn::ItemStruct = parse_quote! {
-            #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::serde::Serialize, ::serde::Deserialize)]
+            #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+            #[serde(crate = "::ploidy_util::serde")]
             pub struct Animal {
                 pub name: ::std::string::String,
             }
@@ -404,10 +407,11 @@ mod tests {
         // and without `#[serde(...)]` attributes. Since both `String` and
         // `Option<T>` implement `Default`, the struct can derive `Default`.
         let expected: syn::ItemStruct = parse_quote! {
-            #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::serde::Serialize, ::serde::Deserialize)]
+            #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+            #[serde(crate = "::ploidy_util::serde")]
             pub struct Record {
                 pub id: ::std::string::String,
-                pub deleted_at: ::std::option::Option<::chrono::DateTime<::chrono::Utc>>,
+                pub deleted_at: ::std::option::Option<::ploidy_util::chrono::DateTime<::ploidy_util::chrono::Utc>>,
             }
         };
         assert_eq!(actual, expected);
@@ -455,10 +459,11 @@ mod tests {
         // Since both `String` and `Option<T>` implement `Default`, the struct can
         // derive `Default`.
         let expected: syn::ItemStruct = parse_quote! {
-            #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::serde::Serialize, ::serde::Deserialize)]
+            #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+            #[serde(crate = "::ploidy_util::serde")]
             pub struct Record {
                 pub id: ::std::string::String,
-                pub deleted_at: ::std::option::Option<::chrono::DateTime<::chrono::Utc>>,
+                pub deleted_at: ::std::option::Option<::ploidy_util::chrono::DateTime<::ploidy_util::chrono::Utc>>,
             }
         };
         assert_eq!(actual, expected);
@@ -504,11 +509,12 @@ mod tests {
         // Optional nullable field uses `AbsentOr<T>` with `#[serde(...)]` attributes.
         // Since `String` implements `Default`, the struct can derive `Default`.
         let expected: syn::ItemStruct = parse_quote! {
-            #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::serde::Serialize, ::serde::Deserialize)]
+            #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+            #[serde(crate = "::ploidy_util::serde")]
             pub struct Record {
                 pub id: ::std::string::String,
                 #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent",)]
-                pub deleted_at: ::ploidy_util::absent::AbsentOr<::chrono::DateTime<::chrono::Utc>>,
+                pub deleted_at: ::ploidy_util::absent::AbsentOr<::ploidy_util::chrono::DateTime<::ploidy_util::chrono::Utc>>,
             }
         };
         assert_eq!(actual, expected);
@@ -554,7 +560,8 @@ mod tests {
         // `id` is a required string field, which implements `Default`,
         // so the struct can derive `Default`.
         let expected: syn::ItemStruct = parse_quote! {
-            #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::serde::Serialize, ::serde::Deserialize)]
+            #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+            #[serde(crate = "::ploidy_util::serde")]
             pub struct User {
                 pub id: ::std::string::String,
                 #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent",)]
@@ -604,7 +611,8 @@ mod tests {
         // `value` and `unit` are required primitive fields. `f64` prevents `Eq`
         // and `Hash`, but both implement `Default`, so the struct can derive it.
         let expected: syn::ItemStruct = parse_quote! {
-            #[derive(Debug, Clone, PartialEq, Default, ::serde::Serialize, ::serde::Deserialize)]
+            #[derive(Debug, Clone, PartialEq, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+            #[serde(crate = "::ploidy_util::serde")]
             pub struct Measurement {
                 pub value: f64,
                 pub unit: ::std::string::String,
@@ -650,7 +658,8 @@ mod tests {
 
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         let expected: syn::ItemStruct = parse_quote! {
-            #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::serde::Serialize, ::serde::Deserialize)]
+            #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+            #[serde(crate = "::ploidy_util::serde")]
             pub struct Options {
                 #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent",)]
                 pub verbose: ::ploidy_util::absent::AbsentOr<bool>,
@@ -700,7 +709,8 @@ mod tests {
         // Both `Outer` and `Inner` have all optional fields,
         // so `Default` should be derived for both.
         let expected: syn::ItemStruct = parse_quote! {
-            #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::serde::Serialize, ::serde::Deserialize)]
+            #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+            #[serde(crate = "::ploidy_util::serde")]
             pub struct Outer {
                 #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent",)]
                 pub inner: ::ploidy_util::absent::AbsentOr<crate::types::Inner>,
@@ -753,7 +763,8 @@ mod tests {
         // but `id` is a string which implements `Default`. Since all reachable
         // required fields are defaultable, `Outer` can derive `Default`.
         let expected: syn::ItemStruct = parse_quote! {
-            #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::serde::Serialize, ::serde::Deserialize)]
+            #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+            #[serde(crate = "::ploidy_util::serde")]
             pub struct Outer {
                 pub inner: crate::types::Inner,
             }
@@ -814,7 +825,8 @@ mod tests {
         // `Pet` is a tagged union, but `Owner.pet` is optional (`AbsentOr<Pet>`),
         // which always implements `Default`.
         let expected: syn::ItemStruct = parse_quote! {
-            #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::serde::Serialize, ::serde::Deserialize)]
+            #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+            #[serde(crate = "::ploidy_util::serde")]
             pub struct Owner {
                 #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent",)]
                 pub pet: ::ploidy_util::absent::AbsentOr<crate::types::Pet>,
@@ -862,7 +874,8 @@ mod tests {
         // `StringOrInt` is an untagged union, but `Container.value` is optional
         // (`AbsentOr<StringOrInt>`), which always implements `Default`.
         let expected: syn::ItemStruct = parse_quote! {
-            #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::serde::Serialize, ::serde::Deserialize)]
+            #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+            #[serde(crate = "::ploidy_util::serde")]
             pub struct Container {
                 #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent",)]
                 pub value: ::ploidy_util::absent::AbsentOr<crate::types::StringOrInt>,
@@ -925,7 +938,8 @@ mod tests {
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         // `Pet` is a required field, so `Owner` can't derive `Default`.
         let expected: syn::ItemStruct = parse_quote! {
-            #[derive(Debug, Clone, PartialEq, Eq, Hash, ::serde::Serialize, ::serde::Deserialize)]
+            #[derive(Debug, Clone, PartialEq, Eq, Hash, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+            #[serde(crate = "::ploidy_util::serde")]
             pub struct Owner {
                 pub pet: crate::types::Pet,
             }
@@ -974,7 +988,8 @@ mod tests {
         // `Outer.inner` is optional, so `Outer` can derive `Default` even though
         // `Inner` has a required field.
         let expected: syn::ItemStruct = parse_quote! {
-            #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::serde::Serialize, ::serde::Deserialize)]
+            #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+            #[serde(crate = "::ploidy_util::serde")]
             pub struct Outer {
                 #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent",)]
                 pub inner: ::ploidy_util::absent::AbsentOr<crate::types::Inner>,
@@ -1018,9 +1033,10 @@ mod tests {
         // `data` is a required `Any` field. Since `serde_json::Value` implements
         // `Default`, the struct can derive `Default`.
         let expected: syn::ItemStruct = parse_quote! {
-            #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::serde::Serialize, ::serde::Deserialize)]
+            #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+            #[serde(crate = "::ploidy_util::serde")]
             pub struct Container {
-                pub data: ::serde_json::Value,
+                pub data: ::ploidy_util::serde_json::Value,
             }
         };
         assert_eq!(actual, expected);
@@ -1069,7 +1085,8 @@ mod tests {
         // Primitives like `String`, `i32`, and `bool` implement `Default`,
         // so the struct can derive `Default`.
         let expected: syn::ItemStruct = parse_quote! {
-            #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::serde::Serialize, ::serde::Deserialize)]
+            #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+            #[serde(crate = "::ploidy_util::serde")]
             pub struct Defaults {
                 pub text: ::std::string::String,
                 pub count: i32,
@@ -1115,9 +1132,10 @@ mod tests {
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         // `Url` doesn't implement `Default`, so the struct can't derive it.
         let expected: syn::ItemStruct = parse_quote! {
-            #[derive(Debug, Clone, PartialEq, Eq, Hash, ::serde::Serialize, ::serde::Deserialize)]
+            #[derive(Debug, Clone, PartialEq, Eq, Hash, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+            #[serde(crate = "::ploidy_util::serde")]
             pub struct Resource {
-                pub link: ::url::Url,
+                pub link: ::ploidy_util::url::Url,
             }
         };
         assert_eq!(actual, expected);
@@ -1164,7 +1182,8 @@ mod tests {
         // `next` is required and recursive, so it should be boxed. `value` is a
         // string which implements `Default`, so the struct can derive `Default`.
         let expected: syn::ItemStruct = parse_quote! {
-            #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::serde::Serialize, ::serde::Deserialize)]
+            #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+            #[serde(crate = "::ploidy_util::serde")]
             pub struct Node {
                 pub value: ::std::string::String,
                 pub next: ::std::boxed::Box<crate::types::Node>,
@@ -1212,7 +1231,8 @@ mod tests {
         // giving `AbsentOr<Box<Node>>`, not `Box<AbsentOr<Node>>`. `value` is a
         // string which implements `Default`, so the struct can derive `Default`.
         let expected: syn::ItemStruct = parse_quote! {
-            #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::serde::Serialize, ::serde::Deserialize)]
+            #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+            #[serde(crate = "::ploidy_util::serde")]
             pub struct Node {
                 pub value: ::std::string::String,
                 #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent",)]
@@ -1264,7 +1284,8 @@ mod tests {
         // provide their own indirection, so no boxing is needed. `value` is a
         // string which implements `Default`, so the struct can derive `Default`.
         let expected: syn::ItemStruct = parse_quote! {
-            #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::serde::Serialize, ::serde::Deserialize)]
+            #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+            #[serde(crate = "::ploidy_util::serde")]
             pub struct Node {
                 pub value: ::std::string::String,
                 pub children: ::std::vec::Vec<crate::types::Node>,
@@ -1315,7 +1336,8 @@ mod tests {
         // being optional (`AbsentOr`). `value` is a string which implements
         // `Default`, so the struct can derive `Default`.
         let expected: syn::ItemStruct = parse_quote! {
-            #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::serde::Serialize, ::serde::Deserialize)]
+            #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+            #[serde(crate = "::ploidy_util::serde")]
             pub struct Node {
                 pub value: ::std::string::String,
                 #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent",)]

--- a/ploidy-codegen-rust/src/tagged.rs
+++ b/ploidy-codegen-rust/src/tagged.rs
@@ -102,8 +102,8 @@ impl ToTokens for CodegenTagged<'_> {
         let type_name = &self.name;
         let main = quote! {
             #doc_attrs
-            #[derive(Debug, Clone, PartialEq, #(#extra_derives,)* ::serde::Serialize, ::serde::Deserialize)]
-            #[serde(tag = #discriminator_field_literal)]
+            #[derive(Debug, Clone, PartialEq, #(#extra_derives,)* ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+            #[serde(crate = "::ploidy_util::serde", tag = #discriminator_field_literal)]
             pub enum #type_name {
                 #(#vs)*
             }
@@ -173,8 +173,8 @@ mod tests {
 
         let actual: syn::File = parse_quote!(#codegen);
         let expected: syn::File = parse_quote! {
-            #[derive(Debug, Clone, PartialEq, Eq, Hash, ::serde::Serialize, ::serde::Deserialize)]
-            #[serde(tag = "petType")]
+            #[derive(Debug, Clone, PartialEq, Eq, Hash, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+            #[serde(crate = "::ploidy_util::serde", tag = "petType")]
             pub enum Pet {
                 #[serde(rename = "dog")]
                 Dog(crate::types::Dog),
@@ -240,8 +240,8 @@ mod tests {
 
         let actual: syn::File = parse_quote!(#codegen);
         let expected: syn::File = parse_quote! {
-            #[derive(Debug, Clone, PartialEq, Eq, Hash, ::serde::Serialize, ::serde::Deserialize)]
-            #[serde(tag = "type")]
+            #[derive(Debug, Clone, PartialEq, Eq, Hash, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+            #[serde(crate = "::ploidy_util::serde", tag = "type")]
             pub enum Pet {
                 #[serde(rename = "canine")]
                 Dog(crate::types::Dog),
@@ -302,8 +302,8 @@ mod tests {
 
         let actual: syn::File = parse_quote!(#codegen);
         let expected: syn::File = parse_quote! {
-            #[derive(Debug, Clone, PartialEq, Eq, Hash, ::serde::Serialize, ::serde::Deserialize)]
-            #[serde(tag = "type")]
+            #[derive(Debug, Clone, PartialEq, Eq, Hash, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+            #[serde(crate = "::ploidy_util::serde", tag = "type")]
             pub enum Pet {
                 #[serde(rename = "dog", alias = "canine", alias = "puppy",)]
                 Dog(crate::types::Dog),
@@ -364,8 +364,8 @@ mod tests {
         let actual: syn::File = parse_quote!(#codegen);
         let expected: syn::File = parse_quote! {
             #[doc = "Represents different types of pets"]
-            #[derive(Debug, Clone, PartialEq, Eq, Hash, ::serde::Serialize, ::serde::Deserialize)]
-            #[serde(tag = "type")]
+            #[derive(Debug, Clone, PartialEq, Eq, Hash, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+            #[serde(crate = "::ploidy_util::serde", tag = "type")]
             pub enum Pet {
                 #[serde(rename = "dog")]
                 Dog(crate::types::Dog),

--- a/ploidy-codegen-rust/src/untagged.rs
+++ b/ploidy-codegen-rust/src/untagged.rs
@@ -62,8 +62,8 @@ impl ToTokens for CodegenUntagged<'_> {
 
         tokens.append_all(quote! {
             #doc_attrs
-            #[derive(Debug, Clone, PartialEq, #(#extra_derives,)* ::serde::Serialize, ::serde::Deserialize)]
-            #[serde(untagged)]
+            #[derive(Debug, Clone, PartialEq, #(#extra_derives,)* ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+            #[serde(crate = "::ploidy_util::serde", untagged)]
             pub enum #type_name_ident {
                 #(#variants),*
             }
@@ -116,8 +116,8 @@ mod tests {
 
         let actual: syn::ItemEnum = parse_quote!(#untagged);
         let expected: syn::ItemEnum = parse_quote! {
-            #[derive(Debug, Clone, PartialEq, Eq, Hash, ::serde::Serialize, ::serde::Deserialize)]
-            #[serde(untagged)]
+            #[derive(Debug, Clone, PartialEq, Eq, Hash, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+            #[serde(crate = "::ploidy_util::serde", untagged)]
             pub enum StringOrInt {
                 String(::std::string::String),
                 I32(i32)
@@ -167,8 +167,8 @@ mod tests {
 
         let actual: syn::ItemEnum = parse_quote!(#untagged);
         let expected: syn::ItemEnum = parse_quote! {
-            #[derive(Debug, Clone, PartialEq, Eq, Hash, ::serde::Serialize, ::serde::Deserialize)]
-            #[serde(untagged)]
+            #[derive(Debug, Clone, PartialEq, Eq, Hash, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+            #[serde(crate = "::ploidy_util::serde", untagged)]
             pub enum Animal {
                 V1(crate::types::Dog),
                 V2(crate::types::Cat)
@@ -211,8 +211,8 @@ mod tests {
         let actual: syn::ItemEnum = parse_quote!(#untagged);
         let expected: syn::ItemEnum = parse_quote! {
             #[doc = "A union that can be either a string or an integer."]
-            #[derive(Debug, Clone, PartialEq, Eq, Hash, ::serde::Serialize, ::serde::Deserialize)]
-            #[serde(untagged)]
+            #[derive(Debug, Clone, PartialEq, Eq, Hash, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+            #[serde(crate = "::ploidy_util::serde", untagged)]
             pub enum StringOrInt {
                 String(::std::string::String),
                 I32(i32)
@@ -253,8 +253,8 @@ mod tests {
 
         let actual: syn::ItemEnum = parse_quote!(#untagged);
         let expected: syn::ItemEnum = parse_quote! {
-            #[derive(Debug, Clone, PartialEq, ::serde::Serialize, ::serde::Deserialize)]
-            #[serde(untagged)]
+            #[derive(Debug, Clone, PartialEq, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+            #[serde(crate = "::ploidy_util::serde", untagged)]
             pub enum StringOrFloat {
                 String(::std::string::String),
                 F32(f32)
@@ -295,8 +295,8 @@ mod tests {
 
         let actual: syn::ItemEnum = parse_quote!(#untagged);
         let expected: syn::ItemEnum = parse_quote! {
-            #[derive(Debug, Clone, PartialEq, ::serde::Serialize, ::serde::Deserialize)]
-            #[serde(untagged)]
+            #[derive(Debug, Clone, PartialEq, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+            #[serde(crate = "::ploidy_util::serde", untagged)]
             pub enum StringOrDouble {
                 String(::std::string::String),
                 F64(f64)

--- a/ploidy-util/Cargo.toml
+++ b/ploidy-util/Cargo.toml
@@ -11,12 +11,15 @@ keywords.workspace = true
 
 [dependencies]
 base64 = "0.22"
-chrono = "0.4"
+chrono = { version = "0.4", features = ["serde"] }
+http = "1"
 itertools = "0.14"
 percent-encoding = "2.3"
+reqwest = { version = "0.12", default-features = false, features = ["http2", "json", "multipart", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
-thiserror = "2"
-url = "2"
-
-[dev-dependencies]
+serde_bytes = "0.11"
 serde_json = "1"
+serde_path_to_error = "0.1"
+thiserror = "2"
+url = { version = "2", features = ["serde"] }
+uuid = { version = "1", features = ["serde", "v4"] }

--- a/ploidy-util/src/error.rs
+++ b/ploidy-util/src/error.rs
@@ -1,0 +1,41 @@
+/// Transport-level error types.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Network or connection error.
+    #[error("Network error")]
+    Network(#[from] reqwest::Error),
+
+    /// Invalid JSON in request or response.
+    #[error("Malformed JSON")]
+    Json(#[from] JsonError),
+
+    /// Invalid URL.
+    #[error("Malformed URL")]
+    Url(#[from] url::ParseError),
+
+    /// URL can't be used as a base.
+    #[error("Can't use URL as base URL")]
+    UrlCannotBeABase,
+
+    /// Invalid query parameter.
+    #[error("Invalid query parameter")]
+    QueryParam(#[from] crate::QueryParamError),
+
+    /// Invalid HTTP header name.
+    #[error("Invalid header name")]
+    BadHeaderName(#[source] http::Error),
+
+    /// Invalid HTTP header value.
+    #[error("Invalid value for header `{0}`")]
+    BadHeaderValue(http::HeaderName, #[source] http::Error),
+}
+
+/// Invalid or unexpected JSON, with or without a path
+/// to the unexpected section.
+#[derive(Debug, thiserror::Error)]
+pub enum JsonError {
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+    #[error(transparent)]
+    JsonWithPath(#[from] serde_path_to_error::Error<serde_json::Error>),
+}

--- a/ploidy-util/src/lib.rs
+++ b/ploidy-util/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod absent;
 pub mod binary;
 pub mod date_time;
+pub mod error;
 pub mod query;
 
 pub use absent::{AbsentError, AbsentOr, FieldAbsentError};
@@ -9,3 +10,13 @@ pub use date_time::{
     TryFromTimestampError, UnixMicroseconds, UnixMilliseconds, UnixNanoseconds, UnixSeconds,
 };
 pub use query::{QueryParamError, QuerySerializer, QueryStyle};
+
+pub use chrono;
+pub use http;
+pub use reqwest;
+pub use serde;
+pub use serde_bytes;
+pub use serde_json;
+pub use serde_path_to_error;
+pub use url;
+pub use uuid;


### PR DESCRIPTION
This is a mostly-mechanical change that:

1. Moves all the generated crate dependencies to `ploidy-util`, and re-exports them.
2. Updates all the generated code to use the reexports.

The global-relative paths definitely make the generated code more verbose, but I don't think it's _too_ bad, and referring to imports this way avoids collisions with generated type names.

This does make `ploidy-util` a little heavier. We can make those dependencies optional, and enable them conditionally (for instance, if you're only building the types, and not the client, we can skip enabling `reqwest`), but I'm not sure it's worth it just yet.