### PR TITLE
Add TypeScript code generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,6 +104,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+
+[[package]]
+name = "ar_archive_writer"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
+dependencies = [
+ "object",
+]
+
+[[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
+name = "ast_node"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb025ef00a6da925cf40870b9c8d008526b6004ece399cb0974209720f0b194"
+dependencies = [
+ "quote",
+ "swc_macros_common",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,6 +184,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "better_scoped_tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd228125315b132eed175bf47619ac79b945b26e56b848ba203ae4ea8603609"
+dependencies = [
+ "scoped-tls",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,6 +203,9 @@ name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "by_address"
@@ -149,6 +220,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "bytes-str"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c60b5ce37e0b883c37eb89f79a1e26fbe9c1081945d024eee93e8d91a7e18b3"
+dependencies = [
+ "bytes",
+ "serde",
+]
+
+[[package]]
 name = "cargo_toml"
 version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,6 +237,15 @@ checksum = "374b7c592d9c00c1f4972ea58390ac6b18cbb6ab79011f3bdc90a0b82ca06b77"
 dependencies = [
  "serde",
  "toml",
+]
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -241,6 +331,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "compact_str"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86b9c4c00838774a6d902ef931eff7470720c51d90c2e32cfe15dc304737b3f"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,6 +365,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "dragonbox_ecma"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd8e701084c37e7ef62d3f9e453b618130cbc0ef3573847785952a3ac3f746bf"
 
 [[package]]
 name = "either"
@@ -336,6 +445,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "from_variant"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ff35a391aef949120a0340d690269b3d9f63460a6106e99bd07b961f345ea9"
+dependencies = [
+ "swc_macros_common",
+ "syn",
 ]
 
 [[package]]
@@ -431,6 +550,16 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -449,6 +578,26 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hstr"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faa57007c3c9dab34df2fa4c1fb52fe9c34ec5a27ed9d8edea53254b50cd7887"
+dependencies = [
+ "hashbrown 0.14.5",
+ "new_debug_unreachable",
+ "once_cell",
+ "rustc-hash",
+ "serde",
+ "triomphe",
+]
 
 [[package]]
 name = "http"
@@ -716,6 +865,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-macro"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57a3e447e24c22647738e4607f1df1e0ec6f72e16182c4cd199f647cdfb0e4"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "is_ci"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,9 +899,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "js-sys"
@@ -874,12 +1035,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -910,6 +1107,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
 
 [[package]]
+name = "par-core"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e96cbd21255b7fb29a5d51ef38a779b517a91abd59e2756c039583f43ef4c90f"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -925,6 +1131,48 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "serde",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher 1.0.2",
 ]
 
 [[package]]
@@ -949,6 +1197,7 @@ dependencies = [
  "miette",
  "mimalloc",
  "ploidy-codegen-rust",
+ "ploidy-codegen-typescript",
  "ploidy-core",
  "semver",
 ]
@@ -974,6 +1223,22 @@ dependencies = [
  "thiserror",
  "toml",
  "unicode-ident",
+]
+
+[[package]]
+name = "ploidy-codegen-typescript"
+version = "0.9.0"
+dependencies = [
+ "heck",
+ "indoc",
+ "itertools",
+ "miette",
+ "ploidy-core",
+ "pretty_assertions",
+ "quasiquodo-ts",
+ "ref-cast",
+ "swc_ecma_codegen",
+ "thiserror",
 ]
 
 [[package]]
@@ -1103,6 +1368,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "psm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3852766467df634d74f0b2d7819bf8dc483a0eb2e3b0f50f756f9cfe8b0d18d8"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
+]
+
+[[package]]
+name = "quasiquodo-ts"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a655c611718e14a98f1b36277969797440c96ebc9591190988ed3a859d7801ef"
+dependencies = [
+ "num-bigint",
+ "quasiquodo-ts-macros",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_utils",
+]
+
+[[package]]
+name = "quasiquodo-ts-core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37da6d1736d4f5a9a99680f47d4ed19c47bdfa4347b405f119aa96e838bf9b05"
+dependencies = [
+ "heck",
+ "num-bigint",
+ "proc-macro2",
+ "quote",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_codegen",
+ "swc_ecma_parser",
+ "swc_ecma_utils",
+ "syn",
+ "thiserror",
+ "winnow",
+]
+
+[[package]]
+name = "quasiquodo-ts-macros"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "844bb893573603f43d33f26aaa58b190708bf41061df899d08e585e26071dc14"
+dependencies = [
+ "quasiquodo-ts-core",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1131,7 +1450,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1174,12 +1493,21 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1189,8 +1517,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rand_core"
@@ -1220,6 +1554,35 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "reqwest"
@@ -1349,10 +1712,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
@@ -1460,6 +1835,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1470,6 +1857,17 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "smartstring"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
+dependencies = [
+ "autocfg",
+ "static_assertions",
+ "version_check",
+]
 
 [[package]]
 name = "socket2"
@@ -1486,6 +1884,37 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stacker"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d74a23609d509411d10e2176dc2a4346e3b4aea2e7b1869f19fdedbc71c013"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "string_enum"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae36a4951ca7bd1cfd991c241584a9824a70f6aff1e7d4f693fb3f2465e4030e"
+dependencies = [
+ "quote",
+ "swc_macros_common",
+ "syn",
+]
 
 [[package]]
 name = "strsim"
@@ -1519,6 +1948,194 @@ name = "supports-unicode"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
+
+[[package]]
+name = "swc_allocator"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d7eefd2c8b228a8c73056482b2ae4b3a1071fbe07638e3b55ceca8570cc48bb"
+dependencies = [
+ "allocator-api2",
+ "bumpalo",
+ "hashbrown 0.14.5",
+ "rustc-hash",
+]
+
+[[package]]
+name = "swc_atoms"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ccbe2ecad10ad7432100f878a107b1d972a8aee83ca53184d00c23a078bb8a"
+dependencies = [
+ "hstr",
+ "once_cell",
+ "serde",
+]
+
+[[package]]
+name = "swc_common"
+version = "18.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1c06698254e9b47daaf9bbb062af489a350bd8d10dfaab0cabbd32d46cec69d"
+dependencies = [
+ "anyhow",
+ "ast_node",
+ "better_scoped_tls",
+ "bytes-str",
+ "either",
+ "from_variant",
+ "num-bigint",
+ "once_cell",
+ "rustc-hash",
+ "serde",
+ "siphasher 0.3.11",
+ "swc_atoms",
+ "swc_eq_ignore_macros",
+ "swc_visit",
+ "tracing",
+ "unicode-width 0.2.2",
+ "url",
+]
+
+[[package]]
+name = "swc_ecma_ast"
+version = "20.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252124d0d786aa2338860701a067c93488747dfadbfedb16ac78f386e16a0ac4"
+dependencies = [
+ "bitflags",
+ "is-macro",
+ "num-bigint",
+ "once_cell",
+ "phf",
+ "rustc-hash",
+ "string_enum",
+ "swc_atoms",
+ "swc_common",
+ "swc_visit",
+ "unicode-id-start",
+]
+
+[[package]]
+name = "swc_ecma_codegen"
+version = "23.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56116de786118dce35e90b612a1f4d952116dd2728ecb197c8064cfccf527baf"
+dependencies = [
+ "ascii",
+ "compact_str",
+ "dragonbox_ecma",
+ "memchr",
+ "num-bigint",
+ "once_cell",
+ "regex",
+ "rustc-hash",
+ "serde",
+ "swc_allocator",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_codegen_macros",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_codegen_macros"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e276dc62c0a2625a560397827989c82a93fd545fcf6f7faec0935a82cc4ddbb8"
+dependencies = [
+ "proc-macro2",
+ "swc_macros_common",
+ "syn",
+]
+
+[[package]]
+name = "swc_ecma_parser"
+version = "33.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d237cf212d1f3ff5c0cf6ab5070f0ed4d624a0ab032ac4f0451675d31890e71"
+dependencies = [
+ "bitflags",
+ "either",
+ "num-bigint",
+ "phf",
+ "rustc-hash",
+ "seq-macro",
+ "serde",
+ "smartstring",
+ "stacker",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_utils"
+version = "26.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3669c1d92ba315caff5a80df76141367acf61b2d846231a1960e25be65a20fbd"
+dependencies = [
+ "dragonbox_ecma",
+ "indexmap",
+ "num_cpus",
+ "once_cell",
+ "par-core",
+ "rustc-hash",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_visit",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_visit"
+version = "20.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e971a258717db3dc8939c38410d8b8cb8126f1b05b9758672daa7cae3e0248c2"
+dependencies = [
+ "new_debug_unreachable",
+ "num-bigint",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_visit",
+ "tracing",
+]
+
+[[package]]
+name = "swc_eq_ignore_macros"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c16ce73424a6316e95e09065ba6a207eba7765496fed113702278b7711d4b632"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "swc_macros_common"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1efbaa74943dc5ad2a2fb16cbd78b77d7e4d63188f3c5b4df2b4dcd2faaae"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "swc_visit"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62fb71484b486c185e34d2172f0eabe7f4722742aad700f426a494bb2de232a2"
+dependencies = [
+ "either",
+ "new_debug_unreachable",
+]
 
 [[package]]
 name = "syn"
@@ -1744,7 +2361,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1754,6 +2383,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "triomphe"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd69c5aa8f924c7519d6372789a74eac5b94fb0f8fcf0d4a97eb0bfc3e785f39"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -1767,6 +2406,12 @@ name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
+name = "unicode-id-start"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81b79ad29b5e19de4260020f8919b443b2ef0277d242ce532ec7b7a2cc8b6007"
 
 [[package]]
 name = "unicode-ident"
@@ -1840,6 +2485,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"
@@ -2016,6 +2667,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "ploidy",
     "ploidy-codegen-rust",
+    "ploidy-codegen-typescript",
     "ploidy-core",
     "ploidy-pointer",
     "ploidy-pointer-derive",
@@ -21,10 +22,18 @@ rust-version = "1.89"
 either = "1"
 indoc = "2"
 ploidy-codegen-rust = { path = "ploidy-codegen-rust", version = "0.9.0" }
+ploidy-codegen-typescript = { path = "ploidy-codegen-typescript", version = "0.9.0" }
 ploidy-core = { path = "ploidy-core", version = "0.9.0" }
 ploidy-pointer = { path = "ploidy-pointer", version = "0.9.0" }
 ploidy-pointer-derive = { path = "ploidy-pointer-derive", version = "0.9.0" }
 pretty_assertions = "1"
+quasiquodo-ts = "0.4"
+swc_atoms = "9"
+swc_common = "18"
+swc_ecma_ast = "20"
+swc_ecma_codegen = "23"
+swc_ecma_parser = { version = "33" }
+swc_ecma_utils = "26"
 ref-cast = "1"
 
 [workspace.lints.rust]

--- a/ploidy-codegen-rust/src/cargo.rs
+++ b/ploidy-codegen-rust/src/cargo.rs
@@ -141,10 +141,7 @@ mod tests {
     use super::*;
 
     use cargo_toml::Package;
-    use ploidy_core::{
-        ir::{IrGraph, IrSpec},
-        parse::Document,
-    };
+    use ploidy_core::{ir::Ir, parse::Document};
 
     use crate::tests::assert_matches;
 
@@ -175,9 +172,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir_graph = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir_graph);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
         let manifest = CodegenCargoManifest::new(&graph, &default_manifest()).to_manifest();
 
         let keys = manifest
@@ -206,9 +202,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir_graph = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir_graph);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
         let manifest = CodegenCargoManifest::new(&graph, &default_manifest()).to_manifest();
 
         let keys = manifest
@@ -236,9 +231,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir_graph = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir_graph);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
         let manifest = CodegenCargoManifest::new(&graph, &default_manifest()).to_manifest();
 
         let keys = manifest
@@ -275,9 +269,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir_graph = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir_graph);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
         let manifest = CodegenCargoManifest::new(&graph, &default_manifest()).to_manifest();
 
         // `Customer` depends on `BillingInfo`, so the `customer` feature
@@ -319,9 +312,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir_graph = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir_graph);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
         let manifest = CodegenCargoManifest::new(&graph, &default_manifest()).to_manifest();
 
         // `Order` → `Customer` → `BillingInfo`, so `order` should
@@ -356,9 +348,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir_graph = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir_graph);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
         let manifest = CodegenCargoManifest::new(&graph, &default_manifest()).to_manifest();
 
         // `Customer` depends on `Address`, which doesn't have a resource.
@@ -391,9 +382,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir_graph = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir_graph);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
         let manifest = CodegenCargoManifest::new(&graph, &default_manifest()).to_manifest();
 
         // Self-referential schemas should not create self-dependencies.
@@ -443,9 +433,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir_graph = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir_graph);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
         let manifest = CodegenCargoManifest::new(&graph, &default_manifest()).to_manifest();
 
         // `listOrders` returns `Order`, which references `Customer`, so
@@ -493,9 +482,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir_graph = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir_graph);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
         let manifest = CodegenCargoManifest::new(&graph, &default_manifest()).to_manifest();
 
         // `listOrders` returns `Customer`, which references `Address`, but
@@ -549,9 +537,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir_graph = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir_graph);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
         let manifest = CodegenCargoManifest::new(&graph, &default_manifest()).to_manifest();
 
         // `a` depends directly on `b`, `c`; transitively on `d` though `b` and `c`.
@@ -616,9 +603,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir_graph = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir_graph);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
         let manifest = CodegenCargoManifest::new(&graph, &default_manifest()).to_manifest();
 
         // A depends on B (unnamed) and C. Since B is unnamed, A only depends on C.
@@ -675,9 +661,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir_graph = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir_graph);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
         let manifest = CodegenCargoManifest::new(&graph, &default_manifest()).to_manifest();
 
         // A transitively depends on B and C.
@@ -743,9 +728,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir_graph = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir_graph);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
         let manifest = CodegenCargoManifest::new(&graph, &default_manifest()).to_manifest();
 
         // The `default` feature should include all other features, but not itself.
@@ -774,9 +758,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir_graph = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir_graph);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
         let manifest = CodegenCargoManifest::new(&graph, &default_manifest()).to_manifest();
 
         // The `default` feature should include all named features.
@@ -805,9 +788,8 @@ mod tests {
             .dependencies
             .insert("serde".to_owned(), Dependency::Simple("1.0".to_owned()));
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir_graph = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir_graph);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
         let manifest = CodegenCargoManifest::new(&graph, &manifest).to_manifest();
 
         let dep_names = manifest

--- a/ploidy-codegen-rust/src/cfg.rs
+++ b/ploidy-codegen-rust/src/cfg.rs
@@ -270,10 +270,7 @@ mod tests {
     use super::*;
 
     use itertools::Itertools;
-    use ploidy_core::{
-        ir::{IrGraph, IrSpec},
-        parse::Document,
-    };
+    use ploidy_core::{ir::Ir, parse::Document};
     use pretty_assertions::assert_eq;
     use syn::parse_quote;
 
@@ -452,9 +449,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir_graph = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir_graph);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let customer = graph.schemas().find(|s| s.name() == "Customer").unwrap();
 
@@ -483,9 +479,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir_graph = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir_graph);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let customer = graph.schemas().find(|s| s.name() == "Customer").unwrap();
         let cfg = CfgFeature::for_schema_type(&customer);
@@ -520,9 +515,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir_graph = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir_graph);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         // `Customer` should be gated.
         let customer = graph.schemas().find(|s| s.name() == "Customer").unwrap();
@@ -570,9 +564,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir_graph = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir_graph);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let customer = graph.schemas().find(|s| s.name() == "Customer").unwrap();
         let cfg = CfgFeature::for_schema_type(&customer);
@@ -626,9 +619,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir_graph = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir_graph);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let address = graph.schemas().find(|s| s.name() == "Address").unwrap();
         let cfg = CfgFeature::for_schema_type(&address);
@@ -671,9 +663,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir_graph = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir_graph);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let customer = graph.schemas().find(|s| s.name() == "Customer").unwrap();
         let cfg = CfgFeature::for_schema_type(&customer);
@@ -725,9 +716,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir_graph = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir_graph);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let customer = graph.schemas().find(|s| s.name() == "Customer").unwrap();
         let cfg = CfgFeature::for_schema_type(&customer);
@@ -777,9 +767,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir_graph = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir_graph);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         // `Customer` keeps its compound feature gate (own + used by).
         let customer = graph.schemas().find(|s| s.name() == "Customer").unwrap();
@@ -825,9 +814,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir_graph = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir_graph);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let simple = graph.schemas().find(|s| s.name() == "Simple").unwrap();
         let cfg = CfgFeature::for_schema_type(&simple);
@@ -871,9 +859,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir_graph = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir_graph);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         // In a cycle involving B, all types become ungated, because
         // B depends on C, which depends on A, which depends on B.
@@ -923,9 +910,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir_graph = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir_graph);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         // Each type uses just its own feature; Cargo feature dependencies
         // handle the transitive requirements.
@@ -976,9 +962,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir_graph = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir_graph);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let ops = graph.operations().collect_vec();
         let inlines = ops.iter().flat_map(|op| op.inlines()).collect_vec();
@@ -1054,9 +1039,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir_graph = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir_graph);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let op = graph.operations().find(|o| o.id() == "getThings").unwrap();
         let cfg = CfgFeature::for_operation(&op);
@@ -1110,9 +1094,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir_graph = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir_graph);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let op = graph.operations().find(|o| o.id() == "getThings").unwrap();
         let cfg = CfgFeature::for_operation(&op);
@@ -1165,9 +1148,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir_graph = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir_graph);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let op = graph.operations().find(|o| o.id() == "getThings").unwrap();
         let cfg = CfgFeature::for_operation(&op);
@@ -1225,9 +1207,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir_graph = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir_graph);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let op = graph.operations().find(|o| o.id() == "getThings").unwrap();
         let cfg = CfgFeature::for_operation(&op);
@@ -1288,9 +1269,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir_graph = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir_graph);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let op = graph.operations().find(|o| o.id() == "getThings").unwrap();
         let cfg = CfgFeature::for_operation(&op);
@@ -1319,9 +1299,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir_graph = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir_graph);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let op = graph
             .operations()
@@ -1379,9 +1358,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir_graph = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir_graph);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let ops = graph.operations().collect_vec();
         let inlines = ops.iter().flat_map(|op| op.inlines()).collect_vec();

--- a/ploidy-codegen-rust/src/enum_.rs
+++ b/ploidy-codegen-rust/src/enum_.rs
@@ -156,7 +156,7 @@ mod tests {
     use super::*;
 
     use ploidy_core::{
-        ir::{IrGraph, IrSpec, SchemaIrTypeView},
+        ir::{Ir, SchemaIrTypeView},
         parse::Document,
     };
     use pretty_assertions::assert_eq;
@@ -185,9 +185,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "Status");
         let Some(schema @ SchemaIrTypeView::Enum(_, enum_view)) = &schema else {
@@ -301,9 +300,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "Priority");
         let Some(schema @ SchemaIrTypeView::Enum(_, view)) = &schema else {

--- a/ploidy-codegen-rust/src/inlines.rs
+++ b/ploidy-codegen-rust/src/inlines.rs
@@ -113,10 +113,7 @@ mod tests {
     use super::*;
 
     use itertools::Itertools;
-    use ploidy_core::{
-        ir::{IrGraph, IrSpec},
-        parse::Document,
-    };
+    use ploidy_core::{ir::Ir, parse::Document};
     use pretty_assertions::assert_eq;
     use syn::parse_quote;
 
@@ -147,9 +144,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let ops = graph.operations().collect_vec();
         let inlines = CodegenInlines::Resource(&ops);
@@ -205,9 +201,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let ops = graph.operations().collect_vec();
         let inlines = CodegenInlines::Resource(&ops);
@@ -259,9 +254,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let ops = graph.operations().collect_vec();
         let inlines = CodegenInlines::Resource(&ops);
@@ -324,9 +318,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let ops = graph.operations().collect_vec();
         let inlines = CodegenInlines::Resource(&ops);
@@ -362,9 +355,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let ops = graph.operations().collect_vec();
         let inlines = CodegenInlines::Resource(&ops);
@@ -413,9 +405,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let ops = graph.operations().collect_vec();
         let inlines = CodegenInlines::Resource(&ops);
@@ -464,9 +455,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let ops = graph.operations().collect_vec();
         let inlines = CodegenInlines::Resource(&ops);

--- a/ploidy-codegen-rust/src/naming.rs
+++ b/ploidy-codegen-rust/src/naming.rs
@@ -434,6 +434,7 @@ impl<'a> CodegenTypePathSegment<'a> {
                     ArrayItem => f.write_str("Item"),
                     Variant(index) => write!(f, "V{index}"),
                     Parent(index) => write!(f, "P{index}"),
+                    TaggedVariant(name) => write!(f, "{}", AsPascalCase(clean(name))),
                 }
             }
         }

--- a/ploidy-codegen-rust/src/primitive.rs
+++ b/ploidy-codegen-rust/src/primitive.rs
@@ -71,10 +71,7 @@ mod tests {
     use super::*;
 
     use itertools::Itertools;
-    use ploidy_core::{
-        ir::{IrGraph, IrSpec},
-        parse::Document,
-    };
+    use ploidy_core::{ir::Ir, parse::Document};
     use pretty_assertions::assert_eq;
     use syn::parse_quote;
 
@@ -94,8 +91,8 @@ mod tests {
                   type: string
         "})
         .unwrap();
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let graph = CodegenGraph::new(IrGraph::new(&spec));
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
         let primitives = graph.primitives().collect_vec();
         let [ty] = &*primitives else {
             panic!("expected string; got `{primitives:?}`");
@@ -125,8 +122,8 @@ mod tests {
                       format: int8
         "})
         .unwrap();
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let graph = CodegenGraph::new(IrGraph::new(&spec));
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
         let primitives = graph.primitives().collect_vec();
         let [ty] = &*primitives else {
             panic!("expected i8; got `{primitives:?}`");
@@ -156,8 +153,8 @@ mod tests {
                       format: uint8
         "})
         .unwrap();
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let graph = CodegenGraph::new(IrGraph::new(&spec));
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
         let primitives = graph.primitives().collect_vec();
         let [ty] = &*primitives else {
             panic!("expected u8; got `{primitives:?}`");
@@ -187,8 +184,8 @@ mod tests {
                       format: int16
         "})
         .unwrap();
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let graph = CodegenGraph::new(IrGraph::new(&spec));
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
         let primitives = graph.primitives().collect_vec();
         let [ty] = &*primitives else {
             panic!("expected i16; got `{primitives:?}`");
@@ -218,8 +215,8 @@ mod tests {
                       format: uint16
         "})
         .unwrap();
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let graph = CodegenGraph::new(IrGraph::new(&spec));
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
         let primitives = graph.primitives().collect_vec();
         let [ty] = &*primitives else {
             panic!("expected u16; got `{primitives:?}`");
@@ -249,8 +246,8 @@ mod tests {
                       format: int32
         "})
         .unwrap();
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let graph = CodegenGraph::new(IrGraph::new(&spec));
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
         let primitives = graph.primitives().collect_vec();
         let [ty] = &*primitives else {
             panic!("expected string; got `{primitives:?}`");
@@ -280,8 +277,8 @@ mod tests {
                       format: uint32
         "})
         .unwrap();
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let graph = CodegenGraph::new(IrGraph::new(&spec));
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
         let primitives = graph.primitives().collect_vec();
         let [ty] = &*primitives else {
             panic!("expected u32; got `{primitives:?}`");
@@ -311,8 +308,8 @@ mod tests {
                       format: int64
         "})
         .unwrap();
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let graph = CodegenGraph::new(IrGraph::new(&spec));
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
         let primitives = graph.primitives().collect_vec();
         let [ty] = &*primitives else {
             panic!("expected i64; got `{primitives:?}`");
@@ -342,8 +339,8 @@ mod tests {
                       format: uint64
         "})
         .unwrap();
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let graph = CodegenGraph::new(IrGraph::new(&spec));
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
         let primitives = graph.primitives().collect_vec();
         let [ty] = &*primitives else {
             panic!("expected u64; got `{primitives:?}`");
@@ -373,8 +370,8 @@ mod tests {
                       format: float
         "})
         .unwrap();
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let graph = CodegenGraph::new(IrGraph::new(&spec));
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
         let primitives = graph.primitives().collect_vec();
         let [ty] = &*primitives else {
             panic!("expected f32; got `{primitives:?}`");
@@ -404,8 +401,8 @@ mod tests {
                       format: double
         "})
         .unwrap();
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let graph = CodegenGraph::new(IrGraph::new(&spec));
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
         let primitives = graph.primitives().collect_vec();
         let [ty] = &*primitives else {
             panic!("expected f64; got `{primitives:?}`");
@@ -434,8 +431,8 @@ mod tests {
                       type: boolean
         "})
         .unwrap();
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let graph = CodegenGraph::new(IrGraph::new(&spec));
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
         let primitives = graph.primitives().collect_vec();
         let [ty] = &*primitives else {
             panic!("expected bool; got `{primitives:?}`");
@@ -465,9 +462,8 @@ mod tests {
                       format: date-time
         "})
         .unwrap();
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        // Default config uses RFC 3339.
-        let graph = CodegenGraph::new(IrGraph::new(&spec));
+        let ir = Ir::from_doc(&doc).unwrap(); // Default config uses RFC 3339.
+        let graph = CodegenGraph::new(ir.graph().finalize());
         let primitives = graph.primitives().collect_vec();
         let [ty] = &*primitives else {
             panic!("expected datetime; got `{primitives:?}`");
@@ -498,9 +494,9 @@ mod tests {
                       format: date-time
         "})
         .unwrap();
-        let spec = IrSpec::from_doc(&doc).unwrap();
+        let ir = Ir::from_doc(&doc).unwrap();
         let graph = CodegenGraph::with_config(
-            IrGraph::new(&spec),
+            ir.graph().finalize(),
             &CodegenConfig {
                 date_time_format: DateTimeFormat::UnixMilliseconds,
             },
@@ -534,9 +530,9 @@ mod tests {
                       format: date-time
         "})
         .unwrap();
-        let spec = IrSpec::from_doc(&doc).unwrap();
+        let ir = Ir::from_doc(&doc).unwrap();
         let graph = CodegenGraph::with_config(
-            IrGraph::new(&spec),
+            ir.graph().finalize(),
             &CodegenConfig {
                 date_time_format: DateTimeFormat::UnixSeconds,
             },
@@ -570,9 +566,9 @@ mod tests {
                       format: date-time
         "})
         .unwrap();
-        let spec = IrSpec::from_doc(&doc).unwrap();
+        let ir = Ir::from_doc(&doc).unwrap();
         let graph = CodegenGraph::with_config(
-            IrGraph::new(&spec),
+            ir.graph().finalize(),
             &CodegenConfig {
                 date_time_format: DateTimeFormat::UnixMicroseconds,
             },
@@ -606,9 +602,9 @@ mod tests {
                       format: date-time
         "})
         .unwrap();
-        let spec = IrSpec::from_doc(&doc).unwrap();
+        let ir = Ir::from_doc(&doc).unwrap();
         let graph = CodegenGraph::with_config(
-            IrGraph::new(&spec),
+            ir.graph().finalize(),
             &CodegenConfig {
                 date_time_format: DateTimeFormat::UnixNanoseconds,
             },
@@ -642,8 +638,8 @@ mod tests {
                       format: date
         "})
         .unwrap();
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let graph = CodegenGraph::new(IrGraph::new(&spec));
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
         let primitives = graph.primitives().collect_vec();
         let [ty] = &*primitives else {
             panic!("expected date; got `{primitives:?}`");
@@ -673,8 +669,8 @@ mod tests {
                       format: uri
         "})
         .unwrap();
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let graph = CodegenGraph::new(IrGraph::new(&spec));
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
         let primitives = graph.primitives().collect_vec();
         let [ty] = &*primitives else {
             panic!("expected url; got `{primitives:?}`");
@@ -704,8 +700,8 @@ mod tests {
                       format: uuid
         "})
         .unwrap();
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let graph = CodegenGraph::new(IrGraph::new(&spec));
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
         let primitives = graph.primitives().collect_vec();
         let [ty] = &*primitives else {
             panic!("expected uuid; got `{primitives:?}`");
@@ -735,8 +731,8 @@ mod tests {
                       format: byte
         "})
         .unwrap();
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let graph = CodegenGraph::new(IrGraph::new(&spec));
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
         let primitives = graph.primitives().collect_vec();
         let [ty] = &*primitives else {
             panic!("expected bytes; got `{primitives:?}`");
@@ -766,8 +762,8 @@ mod tests {
                       format: binary
         "})
         .unwrap();
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let graph = CodegenGraph::new(IrGraph::new(&spec));
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
         let primitives = graph.primitives().collect_vec();
         let [ty] = &*primitives else {
             panic!("expected binary; got `{primitives:?}`");

--- a/ploidy-codegen-rust/src/ref_.rs
+++ b/ploidy-codegen-rust/src/ref_.rs
@@ -82,8 +82,7 @@ mod tests {
 
     use ploidy_core::{
         ir::{
-            ContainerView, InlineIrTypeView, IrGraph, IrSpec, IrStructFieldName, IrTypeView,
-            SchemaIrTypeView,
+            ContainerView, InlineIrTypeView, Ir, IrStructFieldName, IrTypeView, SchemaIrTypeView,
         },
         parse::Document,
     };
@@ -111,9 +110,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "Container");
         let Some(SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
@@ -156,9 +154,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "Container");
         let Some(SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
@@ -198,9 +195,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "Container");
         let Some(SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
@@ -239,9 +235,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "Container");
         let Some(SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
@@ -283,9 +278,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "Container");
         let Some(SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
@@ -323,9 +317,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "Container");
         let Some(SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
@@ -367,9 +360,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "Container");
         let Some(SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
@@ -417,9 +409,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "Container");
         let Some(SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
@@ -460,9 +451,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "Container");
         let Some(SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
@@ -509,9 +499,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "Container");
         let Some(SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
@@ -551,9 +540,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph
             .schemas()
@@ -592,9 +580,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "Container");
         let Some(SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
@@ -634,9 +621,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph
             .schemas()
@@ -674,9 +660,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "Container");
         let Some(SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
@@ -722,9 +707,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let op = graph
             .operations()
@@ -770,9 +754,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let op = graph
             .operations()

--- a/ploidy-codegen-rust/src/ref_.rs
+++ b/ploidy-codegen-rust/src/ref_.rs
@@ -310,6 +310,8 @@ mod tests {
               schemas:
                 Container:
                   type: object
+                  required:
+                    - value
                   properties:
                     value:
                       type: string
@@ -352,6 +354,8 @@ mod tests {
               schemas:
                 Container:
                   type: object
+                  required:
+                    - count
                   properties:
                     count:
                       type: integer
@@ -442,6 +446,8 @@ mod tests {
               schemas:
                 Container:
                   type: object
+                  required:
+                    - items
                   properties:
                     items:
                       type: array

--- a/ploidy-codegen-rust/src/resource.rs
+++ b/ploidy-codegen-rust/src/resource.rs
@@ -62,10 +62,7 @@ mod tests {
     use super::*;
 
     use itertools::Itertools;
-    use ploidy_core::{
-        ir::{IrGraph, IrSpec},
-        parse::Document,
-    };
+    use ploidy_core::{ir::Ir, parse::Document};
     use pretty_assertions::assert_eq;
 
     use syn::parse_quote;
@@ -108,9 +105,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let ops = graph.operations().collect_vec();
         let feature = CargoFeature::from_name("customer");
@@ -184,9 +180,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let ops = graph.operations().collect_vec();
         let feature = CargoFeature::from_name("orders");

--- a/ploidy-codegen-rust/src/schema.rs
+++ b/ploidy-codegen-rust/src/schema.rs
@@ -95,7 +95,7 @@ mod tests {
     use super::*;
 
     use ploidy_core::{
-        ir::{IrGraph, IrSpec, SchemaIrTypeView},
+        ir::{Ir, SchemaIrTypeView},
         parse::Document,
     };
     use pretty_assertions::assert_eq;
@@ -136,9 +136,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "Container");
         let Some(schema @ SchemaIrTypeView::Struct(_, _)) = &schema else {
@@ -213,9 +212,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "InvalidParameters");
         let Some(schema @ SchemaIrTypeView::Container(_, _)) = &schema else {
@@ -257,9 +255,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "Tags");
         let Some(schema @ SchemaIrTypeView::Container(_, _)) = &schema else {
@@ -292,9 +289,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "Metadata");
         let Some(schema @ SchemaIrTypeView::Container(_, _)) = &schema else {
@@ -340,9 +336,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         // `type: ["string", "null"]` becomes `Option<String>`.
         let schema = graph.schemas().find(|s| s.name() == "NullableString");
@@ -421,9 +416,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "Tags");
         let Some(schema @ SchemaIrTypeView::Container(_, _)) = &schema else {

--- a/ploidy-codegen-rust/src/struct_.rs
+++ b/ploidy-codegen-rust/src/struct_.rs
@@ -306,7 +306,7 @@ mod tests {
     use super::*;
 
     use ploidy_core::{
-        ir::{IrGraph, IrSpec, SchemaIrTypeView},
+        ir::{Ir, SchemaIrTypeView},
         parse::Document,
     };
     use pretty_assertions::assert_eq;
@@ -337,9 +337,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "Pet");
         let Some(schema @ SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
@@ -366,6 +365,8 @@ mod tests {
 
     #[test]
     fn test_struct_excludes_discriminator_fields() {
+        // `Animal` is only used inside the `Pet` tagged union, so it's
+        // non-standalone and the discriminator field (`type`) is excluded.
         let doc = Document::from_yaml(indoc::indoc! {"
             openapi: 3.0.0
             info:
@@ -384,14 +385,18 @@ mod tests {
                   required:
                     - type
                     - name
+                Pet:
+                  oneOf:
+                    - $ref: '#/components/schemas/Animal'
                   discriminator:
                     propertyName: type
+                    mapping:
+                      animal: '#/components/schemas/Animal'
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "Animal");
         let Some(schema @ SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
@@ -439,9 +444,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "Record");
         let Some(schema @ SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
@@ -490,9 +494,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "Record");
         let Some(schema @ SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
@@ -542,9 +545,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "Record");
         let Some(schema @ SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
@@ -595,9 +597,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "Record");
         let Some(schema @ SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
@@ -645,9 +646,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "User");
         let Some(schema @ SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
@@ -696,9 +696,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "Measurement");
         let Some(schema @ SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
@@ -745,9 +744,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "Options");
         let Some(schema @ SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
@@ -794,9 +792,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "Outer");
         let Some(schema @ SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
@@ -847,9 +844,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "Outer");
         let Some(schema @ SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
@@ -910,9 +906,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "Owner");
         let Some(schema @ SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
@@ -959,9 +954,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "Container");
         let Some(schema @ SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
@@ -1024,9 +1018,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "Owner");
         let Some(schema @ SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
@@ -1073,9 +1066,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "Outer");
         let Some(schema @ SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
@@ -1118,9 +1110,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "Container");
         let Some(schema @ SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
@@ -1170,9 +1161,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "Defaults");
         let Some(schema @ SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
@@ -1218,9 +1208,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "Resource");
         let Some(schema @ SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
@@ -1268,9 +1257,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "Container");
         let Some(schema @ SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
@@ -1337,9 +1325,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "Corgi");
         let Some(schema @ SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
@@ -1390,9 +1377,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "Node");
         let Some(schema @ SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
@@ -1438,9 +1424,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "Node");
         let Some(schema @ SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
@@ -1491,9 +1476,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "Node");
         let Some(schema @ SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
@@ -1542,9 +1526,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "Node");
         let Some(schema @ SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
@@ -1606,9 +1589,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "Person");
         let Some(schema @ SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
@@ -1657,9 +1639,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "Config");
         let Some(schema @ SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
@@ -1677,6 +1658,74 @@ mod tests {
                 pub name: ::std::string::String,
                 #[serde(flatten,)]
                 pub additional_properties: ::std::collections::BTreeMap<::std::string::String, ::std::string::String>,
+            }
+        };
+        assert_eq!(actual, expected);
+    }
+
+    // MARK: Standalone discriminator
+
+    #[test]
+    fn test_standalone_struct_includes_discriminator() {
+        // `Dog` is both a variant of `Pet` tagged union AND referenced by
+        // `Owner.dog`, making it standalone. The discriminator field `kind`
+        // should be included as a regular field on the struct.
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Dog:
+                  type: object
+                  properties:
+                    kind:
+                      type: string
+                    bark:
+                      type: string
+                  required:
+                    - kind
+                    - bark
+                Pet:
+                  oneOf:
+                    - $ref: '#/components/schemas/Dog'
+                  discriminator:
+                    propertyName: kind
+                    mapping:
+                      dog: '#/components/schemas/Dog'
+                Owner:
+                  type: object
+                  properties:
+                    dog:
+                      $ref: '#/components/schemas/Dog'
+        "})
+        .unwrap();
+
+        let ir = Ir::from_doc(&doc).unwrap();
+        let mut raw = ir.graph();
+        raw.lower_tagged_variants();
+        let graph = CodegenGraph::new(raw.finalize());
+
+        let schema = graph.schemas().find(|s| s.name() == "Dog");
+        let Some(schema @ SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
+            panic!("expected struct `Dog`; got `{schema:?}`");
+        };
+
+        let name = CodegenTypeName::Schema(schema);
+        let codegen = CodegenStruct::new(name, struct_view);
+
+        let actual: syn::ItemStruct = parse_quote!(#codegen);
+        // Both `kind` and `bark` should be present. After lowering, the
+        // tagged union no longer references `Dog` directly, so `kind`
+        // is not treated as a discriminator.
+        let expected: syn::ItemStruct = parse_quote! {
+            #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+            #[serde(crate = "::ploidy_util::serde")]
+            pub struct Dog {
+                pub kind: ::std::string::String,
+                pub bark: ::std::string::String,
             }
         };
         assert_eq!(actual, expected);

--- a/ploidy-codegen-rust/src/untagged.rs
+++ b/ploidy-codegen-rust/src/untagged.rs
@@ -77,7 +77,7 @@ mod tests {
     use super::*;
 
     use ploidy_core::{
-        ir::{IrGraph, IrSpec, SchemaIrTypeView},
+        ir::{Ir, SchemaIrTypeView},
         parse::Document,
     };
     use pretty_assertions::assert_eq;
@@ -103,9 +103,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "StringOrInt");
         let Some(schema @ SchemaIrTypeView::Untagged(_, untagged_view)) = &schema else {
@@ -154,9 +153,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "Animal");
         let Some(schema @ SchemaIrTypeView::Untagged(_, untagged_view)) = &schema else {
@@ -197,9 +195,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "StringOrInt");
         let Some(schema @ SchemaIrTypeView::Untagged(_, untagged_view)) = &schema else {
@@ -240,9 +237,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "StringOrFloat");
         let Some(schema @ SchemaIrTypeView::Untagged(_, untagged_view)) = &schema else {
@@ -282,9 +278,8 @@ mod tests {
         "})
         .unwrap();
 
-        let spec = IrSpec::from_doc(&doc).unwrap();
-        let ir = IrGraph::new(&spec);
-        let graph = CodegenGraph::new(ir);
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
 
         let schema = graph.schemas().find(|s| s.name() == "StringOrDouble");
         let Some(schema @ SchemaIrTypeView::Untagged(_, untagged_view)) = &schema else {

--- a/ploidy-codegen-typescript/Cargo.toml
+++ b/ploidy-codegen-typescript/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "ploidy-codegen-typescript"
+description = "A Ploidy generator that emits TypeScript type declarations"
+readme = "README.md"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
+keywords.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+heck = "0.5"
+itertools = "0.14"
+miette = "7"
+ploidy-core = { workspace = true }
+quasiquodo-ts = { workspace = true }
+ref-cast = { workspace = true }
+swc_ecma_codegen = { workspace = true }
+thiserror = "2"
+
+[dev-dependencies]
+indoc = { workspace = true }
+pretty_assertions = { workspace = true }
+
+[lints]
+workspace = true

--- a/ploidy-codegen-typescript/src/client.rs
+++ b/ploidy-codegen-typescript/src/client.rs
@@ -1,0 +1,249 @@
+use std::collections::BTreeMap;
+
+use ploidy_core::ir::{ExtendableView, IrTypeView, View};
+use quasiquodo_ts::{
+    Comments,
+    swc::ecma_ast::{ClassMember, Module},
+    ts_quote,
+};
+
+use super::{
+    TsSource,
+    graph::CodegenGraph,
+    naming::{CodegenIdent, CodegenIdentUsage},
+    operation::CodegenOperation,
+};
+
+/// Generates a `client.ts` file with a `Client` class containing
+/// async methods for each OpenAPI operation.
+pub struct CodegenClient<'a> {
+    graph: &'a CodegenGraph<'a>,
+}
+
+impl<'a> CodegenClient<'a> {
+    pub fn new(graph: &'a CodegenGraph<'a>) -> Self {
+        Self { graph }
+    }
+
+    /// Generates the full `client.ts` content and returns it as a
+    /// [`TsSource`].
+    pub fn into_code(self) -> TsSource<Module> {
+        let comments = Comments::new();
+
+        // `type_name -> file_name` -- `BTreeMap` for sorted, deduplicated output.
+        let mut all_imports: BTreeMap<String, String> = BTreeMap::new();
+
+        // Build class members.
+        let mut class_members: Vec<ClassMember> = Vec::new();
+
+        class_members.push(ts_quote!("private baseUrl: string" as ClassMember));
+        class_members.push(ts_quote!(
+            "private headers: Record<string, string>" as ClassMember
+        ));
+        class_members.push(ts_quote!(
+            r#"constructor(baseUrl: string, headers?: Record<string, string>) {
+                this.baseUrl = baseUrl;
+                this.headers = headers ?? {};
+            }"# as ClassMember
+        ));
+
+        // Operation methods.
+        for op in self.graph.operations() {
+            // Collect imports by walking IR type dependencies.
+            let views = op.dependencies().filter_map(|view| match view {
+                IrTypeView::Schema(ty) => Some(ty),
+                IrTypeView::Inline(_) => None,
+            });
+            for view in views {
+                let ext = view.extensions();
+                let ident = ext.get::<CodegenIdent>().unwrap();
+                let type_name = CodegenIdentUsage::Type(&ident).display().to_string();
+                let file_name = CodegenIdentUsage::Module(&ident).display().to_string();
+                all_imports.entry(type_name).or_insert(file_name);
+            }
+
+            let codegen = CodegenOperation::new(&op);
+            class_members.push(codegen.emit(&comments));
+        }
+
+        // Build class + export via `Vec<ClassMember>` splice.
+        let class_stmt = ts_quote!(
+            "export class Client { #{members}; }" as ModuleItem,
+            members: Vec<ClassMember> = class_members
+        );
+
+        // Build import statements.
+        let mut module = Module::default();
+        for (type_name, file_name) in &all_imports {
+            let spec = format!("./types/{file_name}");
+            module.body.push(ts_quote!(
+                r#"import type { #{name} } from #{spec}"# as ModuleItem,
+                name: Ident = type_name,
+                spec: &str = &spec,
+            ));
+        }
+        module.body.push(class_stmt);
+
+        TsSource::new("client.ts".to_owned(), comments, module)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use ploidy_core::{codegen::Code, ir::Ir, parse::Document};
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn test_full_client_class() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Pet Store
+              version: 1.0.0
+            paths:
+              /pets:
+                get:
+                  operationId: listPets
+                  parameters:
+                    - name: limit
+                      in: query
+                      schema:
+                        type: string
+                  responses:
+                    '200':
+                      description: ok
+                      content:
+                        application/json:
+                          schema:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Pet'
+                post:
+                  operationId: createPet
+                  requestBody:
+                    required: true
+                    content:
+                      application/json:
+                        schema:
+                          $ref: '#/components/schemas/CreatePetRequest'
+                  responses:
+                    '201':
+                      description: created
+                      content:
+                        application/json:
+                          schema:
+                            $ref: '#/components/schemas/Pet'
+              /pets/{petId}:
+                get:
+                  operationId: getPet
+                  parameters:
+                    - name: petId
+                      in: path
+                      required: true
+                      schema:
+                        type: string
+                  responses:
+                    '200':
+                      description: ok
+                      content:
+                        application/json:
+                          schema:
+                            $ref: '#/components/schemas/Pet'
+                delete:
+                  operationId: deletePet
+                  parameters:
+                    - name: petId
+                      in: path
+                      required: true
+                      schema:
+                        type: string
+                  responses:
+                    '204':
+                      description: deleted
+            components:
+              schemas:
+                Pet:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                CreatePetRequest:
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    name:
+                      type: string
+        "})
+        .unwrap();
+
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
+        let code = CodegenClient::new(&graph).into_code();
+
+        assert_eq!(code.path(), "client.ts");
+        assert_eq!(
+            code.into_string().unwrap(),
+            indoc::indoc! {r#"
+                import type { CreatePetRequest } from "./types/create-pet-request";
+                import type { Pet } from "./types/pet";
+                export class Client {
+                  private baseUrl: string;
+                  private headers: Record<string, string>;
+                  constructor(baseUrl: string, headers?: Record<string, string>){
+                    this.baseUrl = baseUrl;
+                    this.headers = headers ?? {};
+                  }
+                  async listPets(query?: {
+                    limit?: string;
+                  }): Promise<Pet[]> {
+                    let url = new URL(this.baseUrl);
+                    url.pathname = (url.pathname.endsWith("/") ? url.pathname.slice(0, -1) : url.pathname) + "/pets";
+                    if (query?.limit !== undefined) url.searchParams.set("limit", query.limit);
+                    const response = await fetch(url, {
+                      method: "GET",
+                      headers: this.headers
+                    });
+                    if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);
+                    return await response.json();
+                  }
+                  async createPet(request: CreatePetRequest): Promise<Pet> {
+                    let url = new URL(this.baseUrl);
+                    url.pathname = (url.pathname.endsWith("/") ? url.pathname.slice(0, -1) : url.pathname) + "/pets";
+                    const response = await fetch(url, {
+                      method: "POST",
+                      headers: {
+                        ...this.headers,
+                        "Content-Type": "application/json"
+                      },
+                      body: JSON.stringify(request)
+                    });
+                    if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);
+                    return await response.json();
+                  }
+                  async getPet(petId: string): Promise<Pet> {
+                    let url = new URL(this.baseUrl);
+                    url.pathname = (url.pathname.endsWith("/") ? url.pathname.slice(0, -1) : url.pathname) + "/pets/" + encodeURIComponent(petId);
+                    const response = await fetch(url, {
+                      method: "GET",
+                      headers: this.headers
+                    });
+                    if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);
+                    return await response.json();
+                  }
+                  async deletePet(petId: string): Promise<void> {
+                    let url = new URL(this.baseUrl);
+                    url.pathname = (url.pathname.endsWith("/") ? url.pathname.slice(0, -1) : url.pathname) + "/pets/" + encodeURIComponent(petId);
+                    const response = await fetch(url, {
+                      method: "DELETE",
+                      headers: this.headers
+                    });
+                    if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);
+                  }
+                }
+            "#}
+        );
+    }
+}

--- a/ploidy-codegen-typescript/src/enum_.rs
+++ b/ploidy-codegen-typescript/src/enum_.rs
@@ -1,0 +1,191 @@
+use itertools::Itertools;
+use ploidy_core::ir::{IrEnumVariant, IrEnumView};
+use quasiquodo_ts::{swc::ecma_ast::TsType, ts_quote};
+
+/// Resolves an enum to a TypeScript type expression (a union of
+/// literals, or `string` for unrepresentable variants).
+pub fn ts_enum_type(ty: &IrEnumView<'_>) -> TsType {
+    let mut types = ty.variants().iter().map(|variant| match variant {
+        IrEnumVariant::String(s) => ts_quote!("#{s}" as TsType, s: &str = s),
+        IrEnumVariant::Number(n) => {
+            ts_quote!("#{n}" as TsType, n: f64 = n.as_f64().unwrap_or(0.0))
+        }
+        IrEnumVariant::Bool(true) => ts_quote!("true" as TsType),
+        IrEnumVariant::Bool(false) => ts_quote!("false" as TsType),
+    });
+    let Some(first) = types.next() else {
+        return ts_quote!("never" as TsType);
+    };
+    ts_quote!(
+        "#{first} | #{rest}" as TsType,
+        first: TsType = first,
+        rest: Vec<Box<TsType>> = types.map(Box::new).collect_vec(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use ploidy_core::{
+        codegen::Code,
+        ir::{Ir, SchemaIrTypeView},
+        parse::Document,
+    };
+    use pretty_assertions::assert_eq;
+    use quasiquodo_ts::{Comments, swc::ecma_ast::Module, ts_quote};
+
+    use crate::{CodegenGraph, TsSource, naming::CodegenTypeName};
+
+    #[test]
+    fn test_enum_string_variants() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Status:
+                  type: string
+                  enum:
+                    - active
+                    - inactive
+                    - pending
+        "})
+        .unwrap();
+
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
+
+        let schema = graph.schemas().find(|s| s.name() == "Status");
+        let Some(schema @ SchemaIrTypeView::Enum(_, enum_view)) = &schema else {
+            panic!("expected enum `Status`; got `{schema:?}`");
+        };
+
+        let name = CodegenTypeName::Schema(schema).display().to_string();
+        let comments = Comments::new();
+        let ty = ts_enum_type(enum_view);
+        let items = vec![ts_quote!(
+            "export type #{n} = #{t}" as ModuleItem,
+            n: Ident = name,
+            t: TsType = ty
+        )];
+        assert_eq!(
+            TsSource::new(
+                String::new(),
+                comments,
+                Module {
+                    body: items,
+                    ..Module::default()
+                }
+            )
+            .into_string()
+            .unwrap(),
+            "export type Status = \"active\" | \"inactive\" | \"pending\";\n"
+        );
+    }
+
+    #[test]
+    fn test_enum_with_description() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Status:
+                  description: The status of a resource.
+                  type: string
+                  enum:
+                    - active
+                    - inactive
+        "})
+        .unwrap();
+
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
+
+        let schema = graph.schemas().find(|s| s.name() == "Status");
+        let Some(schema @ SchemaIrTypeView::Enum(_, enum_view)) = &schema else {
+            panic!("expected enum `Status`; got `{schema:?}`");
+        };
+
+        let name = CodegenTypeName::Schema(schema).display().to_string();
+
+        // Description is handled by the caller (schema.rs) via Comments.
+        let comments = Comments::new();
+        let ty = ts_enum_type(enum_view);
+        let items = vec![ts_quote!(
+            "export type #{n} = #{t}" as ModuleItem,
+            n: Ident = name,
+            t: TsType = ty
+        )];
+        assert_eq!(
+            TsSource::new(
+                String::new(),
+                comments,
+                Module {
+                    body: items,
+                    ..Module::default()
+                }
+            )
+            .into_string()
+            .unwrap(),
+            "export type Status = \"active\" | \"inactive\";\n"
+        );
+    }
+
+    #[test]
+    fn test_enum_unrepresentable_becomes_string() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Priority:
+                  type: integer
+                  enum:
+                    - 1
+                    - 2
+                    - 3
+        "})
+        .unwrap();
+
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
+
+        let schema = graph.schemas().find(|s| s.name() == "Priority");
+        let Some(schema @ SchemaIrTypeView::Enum(_, enum_view)) = &schema else {
+            panic!("expected enum `Priority`; got `{schema:?}`");
+        };
+
+        let name = CodegenTypeName::Schema(schema).display().to_string();
+        let comments = Comments::new();
+        let ty = ts_enum_type(enum_view);
+        let items = vec![ts_quote!(
+            "export type #{n} = #{t}" as ModuleItem,
+            n: Ident = name,
+            t: TsType = ty
+        )];
+        assert_eq!(
+            TsSource::new(
+                String::new(),
+                comments,
+                Module {
+                    body: items,
+                    ..Module::default()
+                }
+            )
+            .into_string()
+            .unwrap(),
+            "export type Priority = 1 | 2 | 3;\n"
+        );
+    }
+}

--- a/ploidy-codegen-typescript/src/graph.rs
+++ b/ploidy-codegen-typescript/src/graph.rs
@@ -1,0 +1,33 @@
+use std::ops::Deref;
+
+use ploidy_core::{
+    codegen::UniqueNames,
+    ir::{ExtendableView, IrGraph},
+};
+
+use super::naming::CodegenIdentScope;
+
+/// Decorates an [`IrGraph`] with TypeScript-specific information.
+#[derive(Debug)]
+pub struct CodegenGraph<'a>(IrGraph<'a>);
+
+impl<'a> CodegenGraph<'a> {
+    /// Wraps a type graph and decorates schemas with unique TypeScript names.
+    pub fn new(graph: IrGraph<'a>) -> Self {
+        let unique = UniqueNames::new();
+        let mut scope = CodegenIdentScope::new(&unique);
+        for mut view in graph.schemas() {
+            let ident = scope.uniquify(view.name());
+            view.extensions_mut().insert(ident);
+        }
+        Self(graph)
+    }
+}
+
+impl<'a> Deref for CodegenGraph<'a> {
+    type Target = IrGraph<'a>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}

--- a/ploidy-codegen-typescript/src/lib.rs
+++ b/ploidy-codegen-typescript/src/lib.rs
@@ -1,0 +1,92 @@
+use std::path::Path;
+
+use ploidy_core::codegen::{Code, write_to_disk};
+use quasiquodo_ts::{
+    Comments,
+    swc::common::{SourceMap, sync::Lrc},
+};
+use swc_ecma_codegen::{Node, text_writer::JsWriter};
+
+mod client;
+mod enum_;
+mod graph;
+mod naming;
+mod operation;
+mod primitive;
+mod ref_;
+mod schema;
+mod struct_;
+mod tagged;
+mod types;
+mod untagged;
+
+#[cfg(test)]
+mod tests;
+
+pub use client::*;
+pub use graph::*;
+pub use naming::*;
+pub use schema::*;
+pub use types::*;
+
+/// Writes TypeScript type declarations to disk.
+///
+/// Generates one `.ts` file per schema type under `types/`, plus a
+/// barrel `types/index.ts` that re-exports all types.
+pub fn write_types_to_disk(output: &Path, graph: &CodegenGraph<'_>) -> miette::Result<()> {
+    for view in graph.schemas() {
+        let code = CodegenSchemaType::new(&view).into_code();
+        write_to_disk(output, code)?;
+    }
+
+    write_to_disk(output, CodegenTypesModule::new(graph).into_code())?;
+
+    Ok(())
+}
+
+/// Writes a TypeScript HTTP client to disk.
+///
+/// Generates a `client.ts` file with a `Client` class containing
+/// async methods for each OpenAPI operation.
+pub fn write_client_to_disk(output: &Path, graph: &CodegenGraph<'_>) -> miette::Result<()> {
+    let code = CodegenClient::new(graph).into_code();
+    write_to_disk(output, code)?;
+    Ok(())
+}
+
+pub struct TsSource<T> {
+    path: String,
+    comments: Comments,
+    body: T,
+}
+
+impl<T> TsSource<T> {
+    pub fn new(path: String, comments: Comments, body: T) -> Self {
+        Self {
+            path,
+            comments,
+            body,
+        }
+    }
+}
+
+impl<T: Node> Code for TsSource<T> {
+    fn path(&self) -> &str {
+        &self.path
+    }
+
+    fn into_string(self) -> miette::Result<String> {
+        let mut buf = Vec::new();
+        let cm = Lrc::new(SourceMap::default());
+        let mut wr = JsWriter::new(cm.clone(), "\n", &mut buf, None);
+        wr.set_indent_str("  ");
+        let mut emitter = swc_ecma_codegen::Emitter {
+            cfg: swc_ecma_codegen::Config::default(),
+            cm,
+            comments: Some(&*self.comments),
+            wr: Box::new(wr),
+        };
+        self.body.emit_with(&mut emitter).unwrap();
+        Ok(String::from_utf8(buf).unwrap())
+    }
+}

--- a/ploidy-codegen-typescript/src/naming.rs
+++ b/ploidy-codegen-typescript/src/naming.rs
@@ -1,0 +1,525 @@
+use std::{cmp::Ordering, fmt::Display, ops::Deref};
+
+use heck::{AsKebabCase, AsLowerCamelCase, AsPascalCase};
+use itertools::Itertools;
+use ploidy_core::{
+    codegen::{
+        UniqueNames,
+        unique::{UniqueNamesScope, WordSegments},
+    },
+    ir::{
+        ExtendableView, InlineIrTypePathSegment, InlineIrTypeView, IrStructFieldName,
+        IrStructFieldNameHint, IrUntaggedVariantNameHint, PrimitiveIrType, SchemaIrTypeView,
+    },
+};
+use quasiquodo_ts::swc::ecma_ast::Ident;
+use ref_cast::{RefCastCustom, ref_cast_custom};
+
+/// TypeScript reserved words that can't be used as identifiers.
+const KEYWORDS: &[&str] = &[
+    "break",
+    "case",
+    "catch",
+    "class",
+    "const",
+    "continue",
+    "debugger",
+    "default",
+    "delete",
+    "do",
+    "else",
+    "enum",
+    "export",
+    "extends",
+    "false",
+    "finally",
+    "for",
+    "function",
+    "if",
+    "import",
+    "in",
+    "instanceof",
+    "new",
+    "null",
+    "return",
+    "super",
+    "switch",
+    "this",
+    "throw",
+    "true",
+    "try",
+    "typeof",
+    "var",
+    "void",
+    "while",
+    "with",
+    // Strict mode reserved words.
+    "implements",
+    "interface",
+    "let",
+    "package",
+    "private",
+    "protected",
+    "public",
+    "static",
+    "yield",
+];
+
+/// A name for a schema or an inline type, used in generated TypeScript code.
+///
+/// [`CodegenTypeName`] produces PascalCase type names (e.g., `Pet`,
+/// `GetItemsFilter`). Use [`display`](Self::display) for the type name
+/// string, [`into_module_name`](Self::into_module_name) for the corresponding
+/// module name (kebab-case), and [`into_sort_key`](Self::into_sort_key) for
+/// deterministic sorting.
+#[derive(Clone, Copy, Debug)]
+pub enum CodegenTypeName<'a> {
+    Schema(&'a SchemaIrTypeView<'a>),
+    Inline(&'a InlineIrTypeView<'a>),
+}
+
+impl<'a> CodegenTypeName<'a> {
+    /// Returns a formattable representation of this type name.
+    ///
+    /// [`CodegenTypeName`] doesn't implement [`Display`] directly, to
+    /// help catch context mismatches: using `.display()` in a
+    /// [`ts_quote`] macro, or `.to_string()` in a [`format`] string,
+    /// stands out during review.
+    pub fn display(&self) -> impl Display {
+        struct DisplayTypeName<'a>(CodegenTypeName<'a>);
+        impl Display for DisplayTypeName<'_> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                match self.0 {
+                    CodegenTypeName::Schema(view) => {
+                        let ident = view.extensions().get::<CodegenIdent>().unwrap();
+                        write!(f, "{}", CodegenIdentUsage::Type(&ident).display())
+                    }
+                    CodegenTypeName::Inline(view) => {
+                        let ident = CodegenIdent::from_segments(&view.path().segments);
+                        write!(f, "{}", CodegenIdentUsage::Type(&ident).display())
+                    }
+                }
+            }
+        }
+        DisplayTypeName(*self)
+    }
+
+    #[inline]
+    pub fn into_module_name(self) -> CodegenModuleName<'a> {
+        CodegenModuleName(self)
+    }
+
+    #[inline]
+    pub fn into_sort_key(self) -> CodegenTypeNameSortKey<'a> {
+        CodegenTypeNameSortKey(self)
+    }
+}
+
+/// A module name derived from a [`CodegenTypeName`].
+///
+/// Produces kebab-case file names (e.g., `create-pet-request`).
+/// For string interpolation (e.g., file paths), use
+/// [`display`](Self::display), which returns an `impl Display` that
+/// can be used with `format!`.
+#[derive(Clone, Copy, Debug)]
+pub struct CodegenModuleName<'a>(CodegenTypeName<'a>);
+
+impl<'a> CodegenModuleName<'a> {
+    #[inline]
+    pub fn into_type_name(self) -> CodegenTypeName<'a> {
+        self.0
+    }
+
+    /// Returns a formattable representation of this module name.
+    pub fn display(&self) -> impl Display {
+        struct DisplayModuleName<'a>(CodegenTypeName<'a>);
+        impl Display for DisplayModuleName<'_> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                match self.0 {
+                    CodegenTypeName::Schema(view) => {
+                        let ident = view.extensions().get::<CodegenIdent>().unwrap();
+                        write!(f, "{}", CodegenIdentUsage::Module(&ident).display())
+                    }
+                    CodegenTypeName::Inline(view) => {
+                        let ident = CodegenIdent::from_segments(&view.path().segments);
+                        write!(f, "{}", CodegenIdentUsage::Module(&ident).display())
+                    }
+                }
+            }
+        }
+        DisplayModuleName(self.0)
+    }
+}
+
+/// A sort key for deterministic ordering of [`CodegenTypeName`]s.
+///
+/// Sorts schema types before inline types, then lexicographically by name.
+#[derive(Clone, Copy, Debug)]
+pub struct CodegenTypeNameSortKey<'a>(CodegenTypeName<'a>);
+
+impl<'a> CodegenTypeNameSortKey<'a> {
+    #[inline]
+    pub fn for_schema(view: &'a SchemaIrTypeView<'a>) -> Self {
+        Self(CodegenTypeName::Schema(view))
+    }
+
+    #[inline]
+    pub fn for_inline(view: &'a InlineIrTypeView<'a>) -> Self {
+        Self(CodegenTypeName::Inline(view))
+    }
+
+    #[inline]
+    pub fn into_name(self) -> CodegenTypeName<'a> {
+        self.0
+    }
+}
+
+impl Eq for CodegenTypeNameSortKey<'_> {}
+
+impl Ord for CodegenTypeNameSortKey<'_> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match (&self.0, &other.0) {
+            (CodegenTypeName::Schema(a), CodegenTypeName::Schema(b)) => a.name().cmp(b.name()),
+            (CodegenTypeName::Inline(a), CodegenTypeName::Inline(b)) => a.path().cmp(b.path()),
+            (CodegenTypeName::Schema(_), CodegenTypeName::Inline(_)) => Ordering::Less,
+            (CodegenTypeName::Inline(_), CodegenTypeName::Schema(_)) => Ordering::Greater,
+        }
+    }
+}
+
+impl PartialEq for CodegenTypeNameSortKey<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other).is_eq()
+    }
+}
+
+impl PartialOrd for CodegenTypeNameSortKey<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// A cleaned string that's valid for any TypeScript identifier usage.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct CodegenIdent(String);
+
+impl CodegenIdent {
+    /// Creates an identifier for any usage.
+    pub fn new(s: &str) -> Self {
+        let s = clean(s);
+        if KEYWORDS.contains(&s.as_str()) {
+            Self(format!("_{s}"))
+        } else {
+            Self(s)
+        }
+    }
+
+    /// Creates an identifier from an inline type path.
+    pub fn from_segments(segments: &[InlineIrTypePathSegment<'_>]) -> Self {
+        Self(
+            segments
+                .iter()
+                .map(CodegenTypePathSegment)
+                .format_with("", |segment, f| f(&segment.display()))
+                .to_string(),
+        )
+    }
+}
+
+impl AsRef<CodegenIdentRef> for CodegenIdent {
+    fn as_ref(&self) -> &CodegenIdentRef {
+        self
+    }
+}
+
+impl Deref for CodegenIdent {
+    type Target = CodegenIdentRef;
+
+    fn deref(&self) -> &Self::Target {
+        CodegenIdentRef::new(&self.0)
+    }
+}
+
+/// A string slice that's guaranteed to be valid for any
+/// [`CodegenIdentUsage`].
+#[derive(Debug, Eq, Ord, PartialEq, PartialOrd, RefCastCustom)]
+#[repr(transparent)]
+pub struct CodegenIdentRef(str);
+
+impl CodegenIdentRef {
+    #[ref_cast_custom]
+    fn new(s: &str) -> &Self;
+}
+
+/// A context-aware wrapper for emitting a [`CodegenIdentRef`] as a
+/// TypeScript identifier.
+///
+/// [`CodegenIdentUsage`] is a lower-level building block for generating
+/// identifiers. For schema and inline types, prefer [`CodegenTypeName`]
+/// instead.
+///
+/// Each [`CodegenIdentUsage`] variant determines the case
+/// transformation applied to the identifier: module names become
+/// kebab-case; type and variant names become PascalCase; field,
+/// parameter, and method names become camelCase.
+///
+/// [`CodegenIdentUsage`] doesn't implement [`Display`] directly, to
+/// help catch context mismatches. Use [`display`](Self::display).
+#[derive(Clone, Copy, Debug)]
+pub enum CodegenIdentUsage<'a> {
+    Module(&'a CodegenIdentRef),
+    Type(&'a CodegenIdentRef),
+    Field(&'a CodegenIdentRef),
+    Variant(&'a CodegenIdentRef),
+    Param(&'a CodegenIdentRef),
+    Method(&'a CodegenIdentRef),
+}
+
+impl CodegenIdentUsage<'_> {
+    /// Returns a formattable representation of this identifier.
+    pub fn display(self) -> impl Display {
+        struct DisplayUsage<'a>(CodegenIdentUsage<'a>);
+        impl Display for DisplayUsage<'_> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                use CodegenIdentUsage::*;
+                match self.0 {
+                    Module(name) => {
+                        if name.0.starts_with(Ident::is_valid_start) {
+                            write!(f, "{}", AsKebabCase(&name.0))
+                        } else {
+                            write!(f, "_{}", AsKebabCase(&name.0))
+                        }
+                    }
+                    Field(name) | Param(name) | Method(name) => {
+                        if name.0.starts_with(Ident::is_valid_start) {
+                            write!(f, "{}", AsLowerCamelCase(&name.0))
+                        } else {
+                            write!(f, "_{}", AsLowerCamelCase(&name.0))
+                        }
+                    }
+                    Type(name) | Variant(name) => {
+                        if name.0.starts_with(Ident::is_valid_start) {
+                            write!(f, "{}", AsPascalCase(&name.0))
+                        } else {
+                            write!(f, "_{}", AsPascalCase(&name.0))
+                        }
+                    }
+                }
+            }
+        }
+        DisplayUsage(self)
+    }
+}
+
+/// A scope for generating unique, valid TypeScript identifiers.
+#[derive(Debug)]
+pub struct CodegenIdentScope<'a>(UniqueNamesScope<'a>);
+
+impl<'a> CodegenIdentScope<'a> {
+    /// Creates a new identifier scope backed by the given arena.
+    pub fn new(arena: &'a UniqueNames) -> Self {
+        Self(arena.scope_with_reserved(itertools::chain!(
+            KEYWORDS.iter().copied(),
+            std::iter::once("")
+        )))
+    }
+
+    /// Cleans the input string and returns a name that's unique
+    /// within this scope.
+    pub fn uniquify(&mut self, name: &str) -> CodegenIdent {
+        CodegenIdent(self.0.uniquify(&clean(name)).into_owned())
+    }
+}
+
+/// A field name derived from an [`IrStructFieldNameHint`].
+#[derive(Clone, Copy, Debug)]
+pub struct CodegenStructFieldName(pub IrStructFieldNameHint);
+
+impl CodegenStructFieldName {
+    /// Returns a formattable representation of this field name.
+    pub fn display(self) -> impl Display {
+        struct DisplayFieldName(IrStructFieldNameHint);
+        impl Display for DisplayFieldName {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                match self.0 {
+                    IrStructFieldNameHint::Index(index) => write!(f, "variant{index}"),
+                    IrStructFieldNameHint::AdditionalProperties => {
+                        f.write_str("additionalProperties")
+                    }
+                }
+            }
+        }
+        DisplayFieldName(self.0)
+    }
+}
+
+/// A variant name for an untagged union member.
+#[derive(Clone, Copy, Debug)]
+pub struct CodegenUntaggedVariantName(pub IrUntaggedVariantNameHint);
+
+impl CodegenUntaggedVariantName {
+    /// Returns a formattable representation of this variant name.
+    pub fn display(self) -> impl Display {
+        struct DisplayVariantName(IrUntaggedVariantNameHint);
+        impl Display for DisplayVariantName {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                use IrUntaggedVariantNameHint::*;
+                match self.0 {
+                    Primitive(PrimitiveIrType::String) => f.write_str("String"),
+                    Primitive(PrimitiveIrType::I8) => f.write_str("I8"),
+                    Primitive(PrimitiveIrType::U8) => f.write_str("U8"),
+                    Primitive(PrimitiveIrType::I16) => f.write_str("I16"),
+                    Primitive(PrimitiveIrType::U16) => f.write_str("U16"),
+                    Primitive(PrimitiveIrType::I32) => f.write_str("I32"),
+                    Primitive(PrimitiveIrType::U32) => f.write_str("U32"),
+                    Primitive(PrimitiveIrType::I64) => f.write_str("I64"),
+                    Primitive(PrimitiveIrType::U64) => f.write_str("U64"),
+                    Primitive(PrimitiveIrType::F32) => f.write_str("F32"),
+                    Primitive(PrimitiveIrType::F64) => f.write_str("F64"),
+                    Primitive(PrimitiveIrType::Bool) => f.write_str("Bool"),
+                    Primitive(PrimitiveIrType::DateTime) => f.write_str("DateTime"),
+                    Primitive(PrimitiveIrType::UnixTime) => f.write_str("UnixTime"),
+                    Primitive(PrimitiveIrType::Date) => f.write_str("Date"),
+                    Primitive(PrimitiveIrType::Url) => f.write_str("Url"),
+                    Primitive(PrimitiveIrType::Uuid) => f.write_str("Uuid"),
+                    Primitive(PrimitiveIrType::Bytes) => f.write_str("Bytes"),
+                    Primitive(PrimitiveIrType::Binary) => f.write_str("Binary"),
+                    Array => f.write_str("Array"),
+                    Map => f.write_str("Map"),
+                    Index(index) => write!(f, "V{index}"),
+                }
+            }
+        }
+        DisplayVariantName(self.0)
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct CodegenTypePathSegment<'a>(&'a InlineIrTypePathSegment<'a>);
+
+impl<'a> CodegenTypePathSegment<'a> {
+    fn display(&self) -> impl Display + '_ {
+        struct DisplaySegment<'a>(&'a InlineIrTypePathSegment<'a>);
+        impl Display for DisplaySegment<'_> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                use InlineIrTypePathSegment::*;
+                match self.0 {
+                    Operation(name) => write!(f, "{}", AsPascalCase(clean(name))),
+                    Parameter(name) => write!(f, "{}", AsPascalCase(clean(name))),
+                    Request => f.write_str("Request"),
+                    Response => f.write_str("Response"),
+                    Field(IrStructFieldName::Name(name)) => {
+                        write!(f, "{}", AsPascalCase(clean(name)))
+                    }
+                    Field(IrStructFieldName::Hint(IrStructFieldNameHint::Index(index))) => {
+                        write!(f, "Variant{index}")
+                    }
+                    Field(IrStructFieldName::Hint(IrStructFieldNameHint::AdditionalProperties)) => {
+                        f.write_str("AdditionalProperties")
+                    }
+                    MapValue => f.write_str("Value"),
+                    ArrayItem => f.write_str("Item"),
+                    Variant(index) => write!(f, "V{index}"),
+                    Parent(index) => write!(f, "P{index}"),
+                    TaggedVariant(name) => write!(f, "{}", AsPascalCase(clean(name))),
+                }
+            }
+        }
+        DisplaySegment(self.0)
+    }
+}
+
+/// Makes a string suitable for inclusion within a TypeScript identifier.
+fn clean(s: &str) -> String {
+    WordSegments::new(s)
+        .flat_map(|s| s.split(|c| !Ident::is_valid_continue(c)))
+        .join("_")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use pretty_assertions::assert_eq;
+
+    // MARK: `clean()`
+
+    #[test]
+    fn test_clean() {
+        assert_eq!(clean("foo-bar"), "foo_bar");
+        assert_eq!(clean("foo.bar"), "foo_bar");
+        assert_eq!(clean("FooBar"), "Foo_Bar");
+        assert_eq!(clean("123foo"), "123_foo");
+    }
+
+    // MARK: Usages
+
+    #[test]
+    fn test_codegen_ident_type() {
+        let ident = CodegenIdent::new("pet_store");
+        let usage = CodegenIdentUsage::Type(&ident);
+        assert_eq!(usage.display().to_string(), "PetStore");
+    }
+
+    #[test]
+    fn test_codegen_ident_field() {
+        let ident = CodegenIdent::new("pet_store");
+        let usage = CodegenIdentUsage::Field(&ident);
+        assert_eq!(usage.display().to_string(), "petStore");
+    }
+
+    #[test]
+    fn test_codegen_ident_module() {
+        let ident = CodegenIdent::new("MyModule");
+        let usage = CodegenIdentUsage::Module(&ident);
+        assert_eq!(usage.display().to_string(), "my-module");
+    }
+
+    #[test]
+    fn test_codegen_ident_variant() {
+        let ident = CodegenIdent::new("http_error");
+        let usage = CodegenIdentUsage::Variant(&ident);
+        assert_eq!(usage.display().to_string(), "HttpError");
+    }
+
+    #[test]
+    fn test_codegen_ident_param() {
+        let ident = CodegenIdent::new("userId");
+        let usage = CodegenIdentUsage::Param(&ident);
+        assert_eq!(usage.display().to_string(), "userId");
+    }
+
+    #[test]
+    fn test_codegen_ident_method() {
+        let ident = CodegenIdent::new("getUserById");
+        let usage = CodegenIdentUsage::Method(&ident);
+        assert_eq!(usage.display().to_string(), "getUserById");
+    }
+
+    // MARK: Special characters
+
+    #[test]
+    fn test_codegen_ident_keyword_escaped() {
+        let ident = CodegenIdent::new("class");
+        let usage = CodegenIdentUsage::Type(&ident);
+        assert_eq!(usage.display().to_string(), "Class");
+    }
+
+    #[test]
+    fn test_codegen_ident_number_prefix() {
+        let ident = CodegenIdent::new("1099KStatus");
+
+        let type_usage = CodegenIdentUsage::Type(&ident);
+        assert_eq!(type_usage.display().to_string(), "_1099KStatus");
+
+        let field_usage = CodegenIdentUsage::Field(&ident);
+        assert_eq!(field_usage.display().to_string(), "_1099KStatus");
+    }
+
+    #[test]
+    fn test_codegen_ident_special_chars() {
+        let ident = CodegenIdent::new("foo-bar-baz");
+        let usage = CodegenIdentUsage::Field(&ident);
+        assert_eq!(usage.display().to_string(), "fooBarBaz");
+    }
+}

--- a/ploidy-codegen-typescript/src/operation.rs
+++ b/ploidy-codegen-typescript/src/operation.rs
@@ -1,0 +1,1169 @@
+use ploidy_core::{
+    ir::{
+        ContainerView, InlineIrTypeView, IrOperationView, IrParameterStyle, IrParameterView,
+        IrQueryParameter, IrRequestView, IrResponseView, IrTypeView, PrimitiveIrType,
+    },
+    parse::{Method, path::PathFragment},
+};
+use quasiquodo_ts::{
+    Comments, JsDoc,
+    swc::ecma_ast::{ClassMember, Expr, Param, Stmt, TsType, TsTypeElement},
+    ts_quote,
+};
+
+use super::{
+    naming::{CodegenIdent, CodegenIdentUsage},
+    ref_::ts_type_ref,
+};
+
+// MARK: CodegenOperation
+
+/// Generates a single `async` instance method for the `Client` class.
+pub struct CodegenOperation<'a> {
+    op: &'a IrOperationView<'a>,
+}
+
+impl<'a> CodegenOperation<'a> {
+    pub fn new(op: &'a IrOperationView<'a>) -> Self {
+        Self { op }
+    }
+
+    /// Returns the camelCase method name derived from `operationId`.
+    fn method_name(&self) -> String {
+        CodegenIdentUsage::Method(&CodegenIdent::new(self.op.id()))
+            .display()
+            .to_string()
+    }
+
+    /// Generates the method as a [`ClassMember::Method`].
+    pub fn emit(&self, comments: &Comments) -> ClassMember {
+        let method_name = self.method_name();
+
+        // Build formal parameters.
+        let params = self.build_params(comments);
+
+        // Build return type annotation: `Promise<T>` or `Promise<void>`.
+        let return_type = self.build_return_type(comments);
+
+        // Build body statements.
+        let mut stmts: Vec<Stmt> = Vec::new();
+        self.emit_url(&mut stmts);
+        self.emit_query_params(&mut stmts);
+        self.emit_fetch(&mut stmts);
+
+        ts_quote!(
+            comments,
+            "#{doc} async #{name}(#{params}): #{ret} { #{body}; }" as ClassMember,
+            doc: Option<JsDoc> = self.op.description().map(JsDoc::new),
+            name: Ident = &*method_name,
+            params: Vec<Param> = params,
+            ret: TsType = return_type,
+            body: Vec<Stmt> = stmts
+        )
+    }
+
+    /// Builds formal parameters for the method signature.
+    fn build_params(&self, comments: &Comments) -> Vec<Param> {
+        let mut items: Vec<Param> = Vec::new();
+
+        // Path parameters, in order.
+        for param in self.op.path().params() {
+            let name = CodegenIdentUsage::Param(&CodegenIdent::new(param.name()))
+                .display()
+                .to_string();
+            items.push(ts_quote!(
+                "#{name}: string" as Param,
+                name: Ident = &*name
+            ));
+        }
+
+        // Collect query parameters and check if any are required.
+        let mut query_params: Vec<_> = self.op.query().collect();
+        query_params.sort_by_key(|p| !p.required());
+        let query_required = query_params.iter().any(|p| p.required());
+        let has_query = !query_params.is_empty();
+
+        // Helper to build query param.
+        let build_query_param = |comments: &Comments| {
+            let members: Vec<TsTypeElement> = query_params
+                .iter()
+                .map(|p| {
+                    let name = p.name();
+                    let ty = ts_type_ref(&p.ty(), comments);
+                    if p.required() {
+                        ts_quote!("#{name}: #{ty}" as TsTypeElement, name: &str = name, ty: TsType = ty)
+                    } else {
+                        ts_quote!("#{name}?: #{ty}" as TsTypeElement, name: &str = name, ty: TsType = ty)
+                    }
+                })
+                .collect();
+
+            let obj_type = ts_quote!(
+                "{ #{members}; }" as TsType,
+                members: Vec<TsTypeElement> = members
+            );
+
+            if query_required {
+                ts_quote!(
+                    "query: #{ty}" as Param,
+                    ty: TsType = obj_type
+                )
+            } else {
+                ts_quote!(
+                    "query?: #{ty}" as Param,
+                    ty: TsType = obj_type
+                )
+            }
+        };
+
+        // If query is required, add it now (before request body).
+        if has_query && query_required {
+            items.push(build_query_param(comments));
+        }
+
+        // Request body.
+        match self.op.request() {
+            Some(IrRequestView::Json(ty)) => {
+                let ts_ty = ts_type_ref(&ty, comments);
+                items.push(ts_quote!(
+                    "request: #{ty}" as Param,
+                    ty: TsType = ts_ty
+                ));
+            }
+            Some(IrRequestView::Multipart) => {
+                items.push(ts_quote!("request: FormData" as Param));
+            }
+            None => {}
+        }
+
+        // If query is optional, add it last (after request body).
+        if has_query && !query_required {
+            items.push(build_query_param(comments));
+        }
+
+        items
+    }
+
+    /// Builds the return type (`Promise<T>` or `Promise<void>`).
+    fn build_return_type(&self, comments: &Comments) -> TsType {
+        let inner = match self.op.response() {
+            Some(IrResponseView::Json(ty)) => ts_type_ref(&ty, comments),
+            None => ts_quote!("void" as TsType),
+        };
+        ts_quote!("Promise<#{t}>" as TsType, t: TsType = inner)
+    }
+
+    /// Emits URL construction that correctly appends the operation path
+    /// to the base URL's existing pathname:
+    ///
+    /// ```js
+    /// let url = new URL(this.baseUrl);
+    /// url.pathname = prefix + "/pets/" + encodeURIComponent(petId);
+    /// ```
+    fn emit_url(&self, stmts: &mut Vec<Stmt>) {
+        let segments: Vec<_> = self.op.path().segments().collect();
+
+        // Statement 1: `let url = new URL(this.baseUrl);`
+        stmts.push(ts_quote!("let url = new URL(this.baseUrl);" as Stmt));
+
+        // Statement 2: `url.pathname = <prefix> + "/seg" + encodeURIComponent(p);`
+        let mut parts: Vec<Expr> = vec![self.emit_pathname_prefix()];
+
+        // Accumulator for adjacent literal fragments (merged into one
+        // string to avoid redundant `"/" + "pets"` chains).
+        let mut lit_acc = String::new();
+
+        for segment in &segments {
+            lit_acc.push('/');
+            for fragment in segment.fragments() {
+                match fragment {
+                    PathFragment::Literal(text) => lit_acc.push_str(text),
+                    PathFragment::Param(name) => {
+                        // Flush accumulated literal before the expression.
+                        if !lit_acc.is_empty() {
+                            let s = std::mem::take(&mut lit_acc);
+                            parts.push(ts_quote!("#{s}" as Expr, s: &str = &*s));
+                        }
+                        let normalized_name = CodegenIdentUsage::Param(&CodegenIdent::new(name))
+                            .display()
+                            .to_string();
+                        parts.push(ts_quote!(
+                            "encodeURIComponent(#{n})" as Expr,
+                            n: Ident = &*normalized_name
+                        ));
+                    }
+                }
+            }
+        }
+
+        // Flush any remaining literal.
+        if !lit_acc.is_empty() {
+            parts.push(ts_quote!("#{s}" as Expr, s: &str = &*lit_acc));
+        }
+
+        let path = parts
+            .into_iter()
+            .reduce(|a, b| ts_quote!("#{a} + #{b}" as Expr, a: Expr = a, b: Expr = b))
+            .unwrap();
+
+        stmts.push(ts_quote!(
+            "url.pathname = #{path};" as Stmt,
+            path: Expr = path
+        ));
+    }
+
+    /// Builds `(url.pathname.endsWith('/') ? url.pathname.slice(0, -1) : url.pathname)`.
+    ///
+    /// Wrapped in parens because the ternary is used as the left
+    /// operand of `+`, which binds tighter.
+    fn emit_pathname_prefix(&self) -> Expr {
+        ts_quote!(
+            r#"(url.pathname.endsWith("/") ? url.pathname.slice(0, -1) : url.pathname)"# as Expr
+        )
+    }
+
+    /// Emits query parameter serialization statements.
+    ///
+    /// Generates `searchParams.set` or `searchParams.append` calls
+    /// depending on the parameter's resolved IR type and style.
+    fn emit_query_params(&self, stmts: &mut Vec<Stmt>) {
+        for param in self.op.query() {
+            let body = emit_query_param_body(&param);
+
+            if param.required() {
+                stmts.push(body);
+            } else {
+                let name = param.name();
+                let test = ts_quote!(
+                    "query?.[#{name}] !== undefined" as Expr,
+                    name: &str = name
+                );
+
+                stmts.push(ts_quote!(
+                    "if (#{test}) #{body}" as Stmt,
+                    test: Expr = test,
+                    body: Stmt = body
+                ));
+            }
+        }
+    }
+
+    /// Emits the `fetch` call, error check, and response parsing.
+    fn emit_fetch(&self, stmts: &mut Vec<Stmt>) {
+        let method = match self.op.method() {
+            Method::Get => "GET",
+            Method::Post => "POST",
+            Method::Put => "PUT",
+            Method::Delete => "DELETE",
+            Method::Patch => "PATCH",
+        };
+        let has_response = self.op.response().is_some();
+
+        // `const response = await fetch(url, { ... })` with appropriate
+        // options depending on whether the request has a body.
+        match self.op.request() {
+            Some(IrRequestView::Json(_)) => {
+                stmts.push(ts_quote!(
+                    r#"
+                        const response = await fetch(url, {
+                            method: #{method},
+                            headers: {
+                                ...this.headers,
+                                "Content-Type": "application/json",
+                            },
+                            body: JSON.stringify(request),
+                        });
+                    "# as Stmt,
+                    method: &str = method
+                ));
+            }
+            Some(IrRequestView::Multipart) => {
+                stmts.push(ts_quote!(
+                    r#"
+                        const response = await fetch(url, {
+                            method: #{method},
+                            headers: this.headers,
+                            body: request,
+                        });
+                    "# as Stmt,
+                    method: &str = method
+                ));
+            }
+            None => {
+                stmts.push(ts_quote!(
+                    r#"
+                        const response = await fetch(url, {
+                            method: #{method},
+                            headers: this.headers,
+                        });
+                    "# as Stmt,
+                    method: &str = method
+                ));
+            }
+        }
+
+        // `if (!response.ok) throw new Error(...)`
+        stmts.push(ts_quote!(
+            r#"if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);"#
+                as Stmt
+        ));
+
+        // `return await response.json()`
+        if has_response {
+            stmts.push(ts_quote!("return await response.json();" as Stmt));
+        }
+    }
+}
+
+/// Returns `true` if the primitive maps to a TS `string` type.
+fn is_string_primitive(ty: PrimitiveIrType) -> bool {
+    matches!(
+        ty,
+        PrimitiveIrType::String
+            | PrimitiveIrType::DateTime
+            | PrimitiveIrType::UnixTime
+            | PrimitiveIrType::Date
+            | PrimitiveIrType::Url
+            | PrimitiveIrType::Uuid
+            | PrimitiveIrType::Bytes
+            | PrimitiveIrType::Binary
+    )
+}
+
+/// Wraps `expr` in `String(expr)` if the inner type is not
+/// string-like.
+fn maybe_stringify(expr: Expr, ty: &IrTypeView<'_>) -> Expr {
+    if is_string_type(ty) {
+        expr
+    } else {
+        ts_quote!("String(#{e})" as Expr, e: Expr = expr)
+    }
+}
+
+/// Returns `true` if the type resolves to a TS `string`.
+fn is_string_type(ty: &IrTypeView<'_>) -> bool {
+    match ty {
+        IrTypeView::Inline(InlineIrTypeView::Primitive(_, view)) => is_string_primitive(view.ty()),
+        IrTypeView::Inline(InlineIrTypeView::Container(_, ContainerView::Optional(inner))) => {
+            is_string_type(&inner.ty())
+        }
+        _ => false,
+    }
+}
+
+/// Returns the inner element type of an array, unwrapping optionals.
+fn array_inner_type<'a>(ty: &IrTypeView<'a>) -> Option<IrTypeView<'a>> {
+    match ty {
+        IrTypeView::Inline(InlineIrTypeView::Container(_, ContainerView::Array(inner))) => {
+            Some(inner.ty())
+        }
+        IrTypeView::Inline(InlineIrTypeView::Container(_, ContainerView::Optional(inner))) => {
+            array_inner_type(&inner.ty())
+        }
+        _ => None,
+    }
+}
+
+/// Emits the body statement for a single query parameter.
+fn emit_query_param_body(param: &IrParameterView<'_, IrQueryParameter>) -> Stmt {
+    let name = param.name();
+    let ty = param.ty();
+
+    // Check if the parameter type is an array (possibly wrapped in Optional).
+    if let Some(inner_ty) = array_inner_type(&ty) {
+        return emit_array_query_param(name, param.style(), &inner_ty);
+    }
+
+    // Scalar: `url.searchParams.set("name", value)` with optional
+    // `String()` wrapping for non-string types.
+    let query_field = ts_quote!("query[#{name}]" as Expr, name: &str = name);
+    let value = maybe_stringify(query_field, &ty);
+    ts_quote!(
+        "url.searchParams.set(#{name}, #{value});" as Stmt,
+        name: &str = name,
+        value: Expr = value
+    )
+}
+
+/// Emits serialization for an array query parameter.
+fn emit_array_query_param(
+    name: &str,
+    style: Option<IrParameterStyle>,
+    inner_ty: &IrTypeView<'_>,
+) -> Stmt {
+    match style {
+        // Non-exploded form: `url.searchParams.set("k", query.k.join(","))`
+        Some(IrParameterStyle::Form { exploded: false }) => {
+            let joined = ts_quote!(
+                r#"query[#{name}].join(",")"# as Expr,
+                name: &str = name
+            );
+            ts_quote!(
+                "url.searchParams.set(#{name}, #{joined});" as Stmt,
+                name: &str = name,
+                joined: Expr = joined
+            )
+        }
+
+        // Pipe-delimited: `url.searchParams.set("k", query.k.join("|"))`
+        Some(IrParameterStyle::PipeDelimited) => {
+            let joined = ts_quote!(
+                r#"query[#{name}].join("|")"# as Expr,
+                name: &str = name
+            );
+            ts_quote!(
+                "url.searchParams.set(#{name}, #{joined});" as Stmt,
+                name: &str = name,
+                joined: Expr = joined
+            )
+        }
+
+        // Space-delimited: `url.searchParams.set("k", query.k.join(" "))`
+        Some(IrParameterStyle::SpaceDelimited) => {
+            let joined = ts_quote!(
+                r#"query[#{name}].join(" ")"# as Expr,
+                name: &str = name
+            );
+            ts_quote!(
+                "url.searchParams.set(#{name}, #{joined});" as Stmt,
+                name: &str = name,
+                joined: Expr = joined
+            )
+        }
+
+        // Exploded form (default): `for (const v of query.k)
+        // url.searchParams.append("k", v)` (or `String(v)` for
+        // non-string inner types).
+        Some(IrParameterStyle::Form { exploded: true })
+        | Some(IrParameterStyle::DeepObject)
+        | None => {
+            let value = maybe_stringify(ts_quote!("v" as Expr), inner_ty);
+            ts_quote!(
+                "for (const v of query[#{name}]) url.searchParams.append(#{name}, #{value});" as Stmt,
+                name: &str = name,
+                value: Expr = value
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use ploidy_core::{codegen::Code, ir::Ir, parse::Document};
+    use pretty_assertions::assert_eq;
+
+    use quasiquodo_ts::Comments;
+
+    use crate::{CodegenGraph, TsSource};
+
+    /// Helper to find an operation by ID, emit its method as a
+    /// `ClassMember`, wrap it in a minimal class, render through
+    /// `TsSource`, and extract the method text.
+    fn emit_operation(doc: &Document, operation_id: &str) -> String {
+        let ir = Ir::from_doc(doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
+        let op = graph
+            .operations()
+            .find(|op| op.id() == operation_id)
+            .unwrap();
+
+        let comments = Comments::new();
+        let member = CodegenOperation::new(&op).emit(&comments);
+        TsSource::new(String::new(), comments, member)
+            .into_string()
+            .unwrap()
+    }
+
+    // MARK: Basic operations
+
+    #[test]
+    fn test_get_no_params() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths:
+              /pets:
+                get:
+                  operationId: listPets
+                  responses:
+                    '200':
+                      description: ok
+                      content:
+                        application/json:
+                          schema:
+                            type: array
+                            items:
+                              type: string
+            components:
+              schemas: {}
+        "})
+        .unwrap();
+
+        assert_eq!(
+            emit_operation(&doc, "listPets"),
+            indoc::indoc! {r#"
+                async listPets(): Promise<string[]> {
+                  let url = new URL(this.baseUrl);
+                  url.pathname = (url.pathname.endsWith("/") ? url.pathname.slice(0, -1) : url.pathname) + "/pets";
+                  const response = await fetch(url, {
+                    method: "GET",
+                    headers: this.headers
+                  });
+                  if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);
+                  return await response.json();
+                }"#
+            },
+        );
+    }
+
+    #[test]
+    fn test_get_with_path_params() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths:
+              /pets/{petId}:
+                get:
+                  operationId: getPet
+                  parameters:
+                    - name: petId
+                      in: path
+                      required: true
+                      schema:
+                        type: string
+                  responses:
+                    '200':
+                      description: ok
+                      content:
+                        application/json:
+                          schema:
+                            $ref: '#/components/schemas/Pet'
+            components:
+              schemas:
+                Pet:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+        "})
+        .unwrap();
+
+        assert_eq!(
+            emit_operation(&doc, "getPet"),
+            indoc::indoc! {r#"
+                async getPet(petId: string): Promise<Pet> {
+                  let url = new URL(this.baseUrl);
+                  url.pathname = (url.pathname.endsWith("/") ? url.pathname.slice(0, -1) : url.pathname) + "/pets/" + encodeURIComponent(petId);
+                  const response = await fetch(url, {
+                    method: "GET",
+                    headers: this.headers
+                  });
+                  if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);
+                  return await response.json();
+                }"#
+            },
+        );
+    }
+
+    #[test]
+    fn test_get_with_query_params() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths:
+              /pets:
+                get:
+                  operationId: listPets
+                  parameters:
+                    - name: limit
+                      in: query
+                      schema:
+                        type: string
+                    - name: offset
+                      in: query
+                      schema:
+                        type: string
+                  responses:
+                    '200':
+                      description: ok
+                      content:
+                        application/json:
+                          schema:
+                            type: array
+                            items:
+                              type: string
+            components:
+              schemas: {}
+        "})
+        .unwrap();
+
+        assert_eq!(
+            emit_operation(&doc, "listPets"),
+            indoc::indoc! {r#"
+                async listPets(query?: {
+                  limit?: string;
+                  offset?: string;
+                }): Promise<string[]> {
+                  let url = new URL(this.baseUrl);
+                  url.pathname = (url.pathname.endsWith("/") ? url.pathname.slice(0, -1) : url.pathname) + "/pets";
+                  if (query?.limit !== undefined) url.searchParams.set("limit", query.limit);
+                  if (query?.offset !== undefined) url.searchParams.set("offset", query.offset);
+                  const response = await fetch(url, {
+                    method: "GET",
+                    headers: this.headers
+                  });
+                  if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);
+                  return await response.json();
+                }"#
+            },
+        );
+    }
+
+    #[test]
+    fn test_post_with_json_body() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths:
+              /pets:
+                post:
+                  operationId: createPet
+                  requestBody:
+                    required: true
+                    content:
+                      application/json:
+                        schema:
+                          $ref: '#/components/schemas/CreatePetRequest'
+                  responses:
+                    '201':
+                      description: created
+                      content:
+                        application/json:
+                          schema:
+                            $ref: '#/components/schemas/Pet'
+            components:
+              schemas:
+                CreatePetRequest:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                Pet:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+        "})
+        .unwrap();
+
+        assert_eq!(
+            emit_operation(&doc, "createPet"),
+            indoc::indoc! {r#"
+                async createPet(request: CreatePetRequest): Promise<Pet> {
+                  let url = new URL(this.baseUrl);
+                  url.pathname = (url.pathname.endsWith("/") ? url.pathname.slice(0, -1) : url.pathname) + "/pets";
+                  const response = await fetch(url, {
+                    method: "POST",
+                    headers: {
+                      ...this.headers,
+                      "Content-Type": "application/json"
+                    },
+                    body: JSON.stringify(request)
+                  });
+                  if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);
+                  return await response.json();
+                }"#
+            },
+        );
+    }
+
+    #[test]
+    fn test_delete_no_response() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths:
+              /pets/{petId}:
+                delete:
+                  operationId: deletePet
+                  parameters:
+                    - name: petId
+                      in: path
+                      required: true
+                      schema:
+                        type: string
+                  responses:
+                    '204':
+                      description: deleted
+            components:
+              schemas: {}
+        "})
+        .unwrap();
+
+        assert_eq!(
+            emit_operation(&doc, "deletePet"),
+            indoc::indoc! {r#"
+                async deletePet(petId: string): Promise<void> {
+                  let url = new URL(this.baseUrl);
+                  url.pathname = (url.pathname.endsWith("/") ? url.pathname.slice(0, -1) : url.pathname) + "/pets/" + encodeURIComponent(petId);
+                  const response = await fetch(url, {
+                    method: "DELETE",
+                    headers: this.headers
+                  });
+                  if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);
+                }"#
+            },
+        );
+    }
+
+    #[test]
+    fn test_mixed_path_and_query_params() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths:
+              /users/{userId}/posts:
+                get:
+                  operationId: listUserPosts
+                  parameters:
+                    - name: userId
+                      in: path
+                      required: true
+                      schema:
+                        type: string
+                    - name: limit
+                      in: query
+                      schema:
+                        type: string
+                  responses:
+                    '200':
+                      description: ok
+                      content:
+                        application/json:
+                          schema:
+                            type: array
+                            items:
+                              type: string
+            components:
+              schemas: {}
+        "})
+        .unwrap();
+
+        assert_eq!(
+            emit_operation(&doc, "listUserPosts"),
+            indoc::indoc! {r#"
+                async listUserPosts(userId: string, query?: {
+                  limit?: string;
+                }): Promise<string[]> {
+                  let url = new URL(this.baseUrl);
+                  url.pathname = (url.pathname.endsWith("/") ? url.pathname.slice(0, -1) : url.pathname) + "/users/" + encodeURIComponent(userId) + "/posts";
+                  if (query?.limit !== undefined) url.searchParams.set("limit", query.limit);
+                  const response = await fetch(url, {
+                    method: "GET",
+                    headers: this.headers
+                  });
+                  if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);
+                  return await response.json();
+                }"#
+            },
+        );
+    }
+
+    // MARK: Typed query parameters
+
+    #[test]
+    fn test_query_param_number() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths:
+              /pets:
+                get:
+                  operationId: listPets
+                  parameters:
+                    - name: limit
+                      in: query
+                      required: true
+                      schema:
+                        type: integer
+                    - name: offset
+                      in: query
+                      schema:
+                        type: integer
+                  responses:
+                    '200':
+                      description: ok
+                      content:
+                        application/json:
+                          schema:
+                            type: array
+                            items:
+                              type: string
+            components:
+              schemas: {}
+        "})
+        .unwrap();
+
+        assert_eq!(
+            emit_operation(&doc, "listPets"),
+            indoc::indoc! {r#"
+                async listPets(query: {
+                  limit: number;
+                  offset?: number;
+                }): Promise<string[]> {
+                  let url = new URL(this.baseUrl);
+                  url.pathname = (url.pathname.endsWith("/") ? url.pathname.slice(0, -1) : url.pathname) + "/pets";
+                  url.searchParams.set("limit", String(query.limit));
+                  if (query?.offset !== undefined) url.searchParams.set("offset", String(query.offset));
+                  const response = await fetch(url, {
+                    method: "GET",
+                    headers: this.headers
+                  });
+                  if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);
+                  return await response.json();
+                }"#
+            },
+        );
+    }
+
+    #[test]
+    fn test_query_param_boolean() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths:
+              /pets:
+                get:
+                  operationId: listPets
+                  parameters:
+                    - name: active
+                      in: query
+                      schema:
+                        type: boolean
+                  responses:
+                    '200':
+                      description: ok
+                      content:
+                        application/json:
+                          schema:
+                            type: array
+                            items:
+                              type: string
+            components:
+              schemas: {}
+        "})
+        .unwrap();
+
+        assert_eq!(
+            emit_operation(&doc, "listPets"),
+            indoc::indoc! {r#"
+                async listPets(query?: {
+                  active?: boolean;
+                }): Promise<string[]> {
+                  let url = new URL(this.baseUrl);
+                  url.pathname = (url.pathname.endsWith("/") ? url.pathname.slice(0, -1) : url.pathname) + "/pets";
+                  if (query?.active !== undefined) url.searchParams.set("active", String(query.active));
+                  const response = await fetch(url, {
+                    method: "GET",
+                    headers: this.headers
+                  });
+                  if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);
+                  return await response.json();
+                }"#
+            },
+        );
+    }
+
+    #[test]
+    fn test_query_param_array_exploded() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths:
+              /pets:
+                get:
+                  operationId: listPets
+                  parameters:
+                    - name: tags
+                      in: query
+                      schema:
+                        type: array
+                        items:
+                          type: string
+                  responses:
+                    '200':
+                      description: ok
+            components:
+              schemas: {}
+        "})
+        .unwrap();
+
+        assert_eq!(
+            emit_operation(&doc, "listPets"),
+            indoc::indoc! {r#"
+                async listPets(query?: {
+                  tags?: string[];
+                }): Promise<void> {
+                  let url = new URL(this.baseUrl);
+                  url.pathname = (url.pathname.endsWith("/") ? url.pathname.slice(0, -1) : url.pathname) + "/pets";
+                  if (query?.tags !== undefined) for (const v of query.tags)url.searchParams.append("tags", v);
+                  const response = await fetch(url, {
+                    method: "GET",
+                    headers: this.headers
+                  });
+                  if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);
+                }"#
+            },
+        );
+    }
+
+    #[test]
+    fn test_query_param_array_exploded_numbers() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths:
+              /pets:
+                get:
+                  operationId: listPets
+                  parameters:
+                    - name: ids
+                      in: query
+                      required: true
+                      schema:
+                        type: array
+                        items:
+                          type: integer
+                  responses:
+                    '200':
+                      description: ok
+            components:
+              schemas: {}
+        "})
+        .unwrap();
+
+        assert_eq!(
+            emit_operation(&doc, "listPets"),
+            indoc::indoc! {r#"
+                async listPets(query: {
+                  ids: number[];
+                }): Promise<void> {
+                  let url = new URL(this.baseUrl);
+                  url.pathname = (url.pathname.endsWith("/") ? url.pathname.slice(0, -1) : url.pathname) + "/pets";
+                  for (const v of query.ids)url.searchParams.append("ids", String(v));
+                  const response = await fetch(url, {
+                    method: "GET",
+                    headers: this.headers
+                  });
+                  if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);
+                }"#
+            },
+        );
+    }
+
+    #[test]
+    fn test_query_param_array_form_non_exploded() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths:
+              /pets:
+                get:
+                  operationId: listPets
+                  parameters:
+                    - name: tags
+                      in: query
+                      style: form
+                      explode: false
+                      schema:
+                        type: array
+                        items:
+                          type: string
+                  responses:
+                    '200':
+                      description: ok
+            components:
+              schemas: {}
+        "})
+        .unwrap();
+
+        assert_eq!(
+            emit_operation(&doc, "listPets"),
+            indoc::indoc! {r#"
+                async listPets(query?: {
+                  tags?: string[];
+                }): Promise<void> {
+                  let url = new URL(this.baseUrl);
+                  url.pathname = (url.pathname.endsWith("/") ? url.pathname.slice(0, -1) : url.pathname) + "/pets";
+                  if (query?.tags !== undefined) url.searchParams.set("tags", query.tags.join(","));
+                  const response = await fetch(url, {
+                    method: "GET",
+                    headers: this.headers
+                  });
+                  if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);
+                }"#
+            },
+        );
+    }
+
+    #[test]
+    fn test_query_param_array_pipe_delimited() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths:
+              /pets:
+                get:
+                  operationId: listPets
+                  parameters:
+                    - name: filters
+                      in: query
+                      style: pipeDelimited
+                      schema:
+                        type: array
+                        items:
+                          type: string
+                  responses:
+                    '200':
+                      description: ok
+            components:
+              schemas: {}
+        "})
+        .unwrap();
+
+        assert_eq!(
+            emit_operation(&doc, "listPets"),
+            indoc::indoc! {r#"
+                async listPets(query?: {
+                  filters?: string[];
+                }): Promise<void> {
+                  let url = new URL(this.baseUrl);
+                  url.pathname = (url.pathname.endsWith("/") ? url.pathname.slice(0, -1) : url.pathname) + "/pets";
+                  if (query?.filters !== undefined) url.searchParams.set("filters", query.filters.join("|"));
+                  const response = await fetch(url, {
+                    method: "GET",
+                    headers: this.headers
+                  });
+                  if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);
+                }"#
+            },
+        );
+    }
+
+    #[test]
+    fn test_query_param_array_space_delimited() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths:
+              /pets:
+                get:
+                  operationId: listPets
+                  parameters:
+                    - name: keywords
+                      in: query
+                      style: spaceDelimited
+                      schema:
+                        type: array
+                        items:
+                          type: string
+                  responses:
+                    '200':
+                      description: ok
+            components:
+              schemas: {}
+        "})
+        .unwrap();
+
+        assert_eq!(
+            emit_operation(&doc, "listPets"),
+            indoc::indoc! {r#"
+                async listPets(query?: {
+                  keywords?: string[];
+                }): Promise<void> {
+                  let url = new URL(this.baseUrl);
+                  url.pathname = (url.pathname.endsWith("/") ? url.pathname.slice(0, -1) : url.pathname) + "/pets";
+                  if (query?.keywords !== undefined) url.searchParams.set("keywords", query.keywords.join(" "));
+                  const response = await fetch(url, {
+                    method: "GET",
+                    headers: this.headers
+                  });
+                  if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);
+                }"#
+            },
+        );
+    }
+
+    // MARK: Descriptions
+
+    #[test]
+    fn test_operation_with_description() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths:
+              /pets:
+                get:
+                  operationId: listPets
+                  description: Lists all pets in the store.
+                  responses:
+                    '200':
+                      description: ok
+                      content:
+                        application/json:
+                          schema:
+                            type: array
+                            items:
+                              type: string
+            components:
+              schemas: {}
+        "})
+        .unwrap();
+
+        assert_eq!(
+            emit_operation(&doc, "listPets"),
+            indoc::indoc! {r#"
+                /** Lists all pets in the store. */ async listPets(): Promise<string[]> {
+                  let url = new URL(this.baseUrl);
+                  url.pathname = (url.pathname.endsWith("/") ? url.pathname.slice(0, -1) : url.pathname) + "/pets";
+                  const response = await fetch(url, {
+                    method: "GET",
+                    headers: this.headers
+                  });
+                  if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);
+                  return await response.json();
+                }"#
+            },
+        );
+    }
+}

--- a/ploidy-codegen-typescript/src/primitive.rs
+++ b/ploidy-codegen-typescript/src/primitive.rs
@@ -1,0 +1,107 @@
+use ploidy_core::ir::PrimitiveIrType;
+use quasiquodo_ts::{swc::ecma_ast::TsType, ts_quote};
+
+/// Maps a primitive IR type to a TypeScript type.
+pub fn ts_primitive(ty: PrimitiveIrType) -> TsType {
+    match ty {
+        PrimitiveIrType::String
+        | PrimitiveIrType::DateTime
+        | PrimitiveIrType::UnixTime
+        | PrimitiveIrType::Date
+        | PrimitiveIrType::Url
+        | PrimitiveIrType::Uuid
+        | PrimitiveIrType::Bytes
+        | PrimitiveIrType::Binary => ts_quote!("string" as TsType),
+
+        PrimitiveIrType::I8
+        | PrimitiveIrType::U8
+        | PrimitiveIrType::I16
+        | PrimitiveIrType::U16
+        | PrimitiveIrType::I32
+        | PrimitiveIrType::U32
+        | PrimitiveIrType::I64
+        | PrimitiveIrType::U64
+        | PrimitiveIrType::F32
+        | PrimitiveIrType::F64 => ts_quote!("number" as TsType),
+
+        PrimitiveIrType::Bool => ts_quote!("boolean" as TsType),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use ploidy_core::codegen::Code;
+    use pretty_assertions::assert_eq;
+    use quasiquodo_ts::{Comments, swc::ecma_ast::Module};
+
+    use crate::TsSource;
+
+    /// Emits a primitive as `export type T = <prim>;` and returns the
+    /// output string.
+    fn emit_prim(ty: PrimitiveIrType) -> String {
+        let comments = Comments::new();
+        let items = vec![ts_quote!(
+            "export type T = #{t}" as ModuleItem,
+            t: TsType = ts_primitive(ty)
+        )];
+        TsSource::new(
+            String::new(),
+            comments,
+            Module {
+                body: items,
+                ..Module::default()
+            },
+        )
+        .into_string()
+        .unwrap()
+    }
+
+    #[test]
+    fn test_string_primitives() {
+        assert_eq!(
+            emit_prim(PrimitiveIrType::String),
+            "export type T = string;\n"
+        );
+        assert_eq!(
+            emit_prim(PrimitiveIrType::DateTime),
+            "export type T = string;\n"
+        );
+        assert_eq!(
+            emit_prim(PrimitiveIrType::Date),
+            "export type T = string;\n"
+        );
+        assert_eq!(emit_prim(PrimitiveIrType::Url), "export type T = string;\n");
+        assert_eq!(
+            emit_prim(PrimitiveIrType::Uuid),
+            "export type T = string;\n"
+        );
+        assert_eq!(
+            emit_prim(PrimitiveIrType::Bytes),
+            "export type T = string;\n"
+        );
+        assert_eq!(
+            emit_prim(PrimitiveIrType::Binary),
+            "export type T = string;\n"
+        );
+    }
+
+    #[test]
+    fn test_number_primitives() {
+        assert_eq!(emit_prim(PrimitiveIrType::I32), "export type T = number;\n");
+        assert_eq!(emit_prim(PrimitiveIrType::U32), "export type T = number;\n");
+        assert_eq!(emit_prim(PrimitiveIrType::I64), "export type T = number;\n");
+        assert_eq!(emit_prim(PrimitiveIrType::U64), "export type T = number;\n");
+        assert_eq!(emit_prim(PrimitiveIrType::F32), "export type T = number;\n");
+        assert_eq!(emit_prim(PrimitiveIrType::F64), "export type T = number;\n");
+    }
+
+    #[test]
+    fn test_bool_primitive() {
+        assert_eq!(
+            emit_prim(PrimitiveIrType::Bool),
+            "export type T = boolean;\n"
+        );
+    }
+}

--- a/ploidy-codegen-typescript/src/ref_.rs
+++ b/ploidy-codegen-typescript/src/ref_.rs
@@ -1,0 +1,322 @@
+use ploidy_core::ir::{ContainerView, ExtendableView, InlineIrTypeView, IrTypeView};
+use quasiquodo_ts::{Comments, swc::ecma_ast::TsType, ts_quote};
+
+use super::{
+    enum_::ts_enum_type,
+    naming::{CodegenIdent, CodegenIdentUsage},
+    primitive::ts_primitive,
+    struct_::ts_struct_type,
+    tagged::ts_tagged_type,
+    untagged::ts_untagged_type,
+};
+
+/// Resolves an [`IrTypeView`] to a TypeScript type expression.
+pub fn ts_type_ref(ty: &IrTypeView<'_>, comments: &Comments) -> TsType {
+    match ty {
+        // Inline containers are emitted directly.
+        IrTypeView::Inline(InlineIrTypeView::Container(_, ContainerView::Array(inner))) => {
+            let inner_ty = inner.ty();
+            let elem = ts_type_ref(&inner_ty, comments);
+            match elem {
+                TsType::TsUnionOrIntersectionType(_) => {
+                    ts_quote!("(#{ty})[]" as TsType, ty: TsType = elem)
+                }
+                _ => ts_quote!("#{ty}[]" as TsType, ty: TsType = elem),
+            }
+        }
+        IrTypeView::Inline(InlineIrTypeView::Container(_, ContainerView::Map(inner))) => {
+            let inner_ty = inner.ty();
+            let v = ts_type_ref(&inner_ty, comments);
+            ts_quote!("Record<string, #{v}>" as TsType, v: TsType = v)
+        }
+        IrTypeView::Inline(InlineIrTypeView::Container(_, ContainerView::Optional(inner))) => {
+            let inner_ty = inner.ty();
+            let t = ts_type_ref(&inner_ty, comments);
+            ts_quote!("#{t} | null" as TsType, t: TsType = t)
+        }
+
+        // Inline primitives are emitted directly.
+        IrTypeView::Inline(InlineIrTypeView::Primitive(_, view)) => ts_primitive(view.ty()),
+
+        // Inline `Any` becomes `unknown`.
+        IrTypeView::Inline(InlineIrTypeView::Any(_, _)) => ts_quote!("unknown" as TsType),
+
+        // Inline structured types are expanded in place.
+        IrTypeView::Inline(InlineIrTypeView::Struct(_, view)) => ts_struct_type(view, comments),
+        IrTypeView::Inline(InlineIrTypeView::Enum(_, view)) => ts_enum_type(view),
+        IrTypeView::Inline(InlineIrTypeView::Tagged(_, view)) => ts_tagged_type(view, comments),
+        IrTypeView::Inline(InlineIrTypeView::Untagged(_, view)) => ts_untagged_type(view, comments),
+
+        // Schema types are bare references.
+        IrTypeView::Schema(ty) => {
+            let ext = ty.extensions();
+            let ident = ext.get::<CodegenIdent>().unwrap();
+            let type_name = CodegenIdentUsage::Type(&ident).display().to_string();
+            ts_quote!("#{name}" as TsType, name: Ident = type_name)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use ploidy_core::{
+        codegen::Code,
+        ir::{Ir, IrStructFieldName, SchemaIrTypeView},
+        parse::Document,
+    };
+    use pretty_assertions::assert_eq;
+    use quasiquodo_ts::{Comments, swc::ecma_ast::Module};
+
+    use crate::{CodegenGraph, TsSource};
+
+    /// Emits a type as `export type T = <ty>;` and returns the output string.
+    fn emit_ty(ty_fn: impl FnOnce(&Comments) -> TsType) -> String {
+        let comments = Comments::new();
+        let ty = ty_fn(&comments);
+        let items = vec![quasiquodo_ts::ts_quote!(
+            "export type T = #{t}" as ModuleItem,
+            t: TsType = ty
+        )];
+        TsSource::new(
+            String::new(),
+            comments,
+            Module {
+                body: items,
+                ..Module::default()
+            },
+        )
+        .into_string()
+        .unwrap()
+    }
+
+    #[test]
+    fn test_ref_schema_type() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Pet:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+        "})
+        .unwrap();
+
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
+
+        let schema = graph
+            .schemas()
+            .find(|s| s.name() == "Pet")
+            .expect("expected schema `Pet`");
+        let ty = IrTypeView::Schema(schema);
+        assert_eq!(
+            emit_ty(|comments| ts_type_ref(&ty, comments)),
+            "export type T = Pet;\n"
+        );
+    }
+
+    #[test]
+    fn test_ref_inline_array_of_strings() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Container:
+                  type: object
+                  required:
+                    - items
+                  properties:
+                    items:
+                      type: array
+                      items:
+                        type: string
+        "})
+        .unwrap();
+
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
+
+        let schema = graph.schemas().find(|s| s.name() == "Container");
+        let Some(SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
+            panic!("expected struct `Container`; got `{schema:?}`");
+        };
+        let field = struct_view
+            .fields()
+            .find(|f| matches!(f.name(), IrStructFieldName::Name("items")))
+            .unwrap();
+        let ty = field.ty();
+        assert_eq!(
+            emit_ty(|comments| ts_type_ref(&ty, comments)),
+            "export type T = string[];\n"
+        );
+    }
+
+    #[test]
+    fn test_ref_inline_map_of_strings() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Container:
+                  type: object
+                  required:
+                    - metadata
+                  properties:
+                    metadata:
+                      type: object
+                      additionalProperties:
+                        type: string
+        "})
+        .unwrap();
+
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
+
+        let schema = graph.schemas().find(|s| s.name() == "Container");
+        let Some(SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
+            panic!("expected struct `Container`; got `{schema:?}`");
+        };
+        let field = struct_view
+            .fields()
+            .find(|f| matches!(f.name(), IrStructFieldName::Name("metadata")))
+            .unwrap();
+        let ty = field.ty();
+        assert_eq!(
+            emit_ty(|comments| ts_type_ref(&ty, comments)),
+            "export type T = Record<string, string>;\n"
+        );
+    }
+
+    #[test]
+    fn test_ref_nullable_string() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Container:
+                  type: object
+                  required:
+                    - value
+                  properties:
+                    value:
+                      type: string
+                      nullable: true
+        "})
+        .unwrap();
+
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
+
+        let schema = graph.schemas().find(|s| s.name() == "Container");
+        let Some(SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
+            panic!("expected struct `Container`; got `{schema:?}`");
+        };
+        let field = struct_view
+            .fields()
+            .find(|f| matches!(f.name(), IrStructFieldName::Name("value")))
+            .unwrap();
+        let ty = field.ty();
+        assert_eq!(
+            emit_ty(|comments| ts_type_ref(&ty, comments)),
+            "export type T = string | null;\n"
+        );
+    }
+
+    #[test]
+    fn test_ref_any_type() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Container:
+                  type: object
+                  required:
+                    - data
+                  properties:
+                    data: {}
+        "})
+        .unwrap();
+
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
+
+        let schema = graph.schemas().find(|s| s.name() == "Container");
+        let Some(SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
+            panic!("expected struct `Container`; got `{schema:?}`");
+        };
+        let field = struct_view
+            .fields()
+            .find(|f| matches!(f.name(), IrStructFieldName::Name("data")))
+            .unwrap();
+        let ty = field.ty();
+        assert_eq!(
+            emit_ty(|comments| ts_type_ref(&ty, comments)),
+            "export type T = unknown;\n"
+        );
+    }
+
+    #[test]
+    fn test_ref_inline_struct() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Container:
+                  type: object
+                  required:
+                    - nested
+                  properties:
+                    nested:
+                      type: object
+                      properties:
+                        value:
+                          type: string
+        "})
+        .unwrap();
+
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
+
+        let schema = graph.schemas().find(|s| s.name() == "Container");
+        let Some(SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
+            panic!("expected struct `Container`; got `{schema:?}`");
+        };
+        let field = struct_view
+            .fields()
+            .find(|f| matches!(f.name(), IrStructFieldName::Name("nested")))
+            .unwrap();
+        let ty = field.ty();
+        assert_eq!(
+            emit_ty(|comments| ts_type_ref(&ty, comments)),
+            "export type T = {\n  value?: string;\n};\n"
+        );
+    }
+}

--- a/ploidy-codegen-typescript/src/schema.rs
+++ b/ploidy-codegen-typescript/src/schema.rs
@@ -1,0 +1,424 @@
+use std::collections::BTreeMap;
+
+use ploidy_core::ir::{ContainerView, ExtendableView, IrTypeView, SchemaIrTypeView, View};
+use quasiquodo_ts::{
+    Comments, JsDoc,
+    swc::ecma_ast::{Module, ModuleItem, TsType},
+    ts_quote,
+};
+
+use super::{
+    TsSource,
+    enum_::ts_enum_type,
+    naming::{CodegenIdent, CodegenIdentUsage, CodegenTypeName},
+    primitive::ts_primitive,
+    ref_::ts_type_ref,
+    struct_::ts_struct,
+    tagged::ts_tagged_type,
+    untagged::ts_untagged_type,
+};
+
+/// Generates a TypeScript module for a named schema type.
+pub struct CodegenSchemaType<'a> {
+    ty: &'a SchemaIrTypeView<'a>,
+}
+
+impl<'a> CodegenSchemaType<'a> {
+    pub fn new(ty: &'a SchemaIrTypeView<'a>) -> Self {
+        Self { ty }
+    }
+
+    /// Generates the TypeScript module and returns it as a
+    /// [`TsSource`].
+    pub fn into_code(self) -> TsSource<Module> {
+        let name = CodegenTypeName::Schema(self.ty);
+        let type_name = name.display().to_string();
+        let comments = Comments::new();
+
+        // Build module items: imports then main decl (with JSDoc).
+        let mut module = Module::default();
+
+        // Collect imports.
+        for import in collect_imports(self.ty) {
+            module.body.push(import);
+        }
+
+        // Build the main type item.
+        let main_item = match self.ty {
+            SchemaIrTypeView::Struct(_, view) => {
+                ts_struct(&type_name, view, &comments, view.description())
+            }
+            SchemaIrTypeView::Enum(_, view) => ts_quote!(
+                comments,
+                "#{doc} export type #{n} = #{t}" as ModuleItem,
+                doc: Option<JsDoc> = view.description().map(JsDoc::new),
+                n: Ident = &type_name,
+                t: TsType = ts_enum_type(view)
+            ),
+            SchemaIrTypeView::Tagged(_, view) => ts_quote!(
+                comments,
+                "#{doc} export type #{n} = #{t}" as ModuleItem,
+                doc: Option<JsDoc> = view.description().map(JsDoc::new),
+                n: Ident = &type_name,
+                t: TsType = ts_tagged_type(view, &comments)
+            ),
+            SchemaIrTypeView::Untagged(_, view) => ts_quote!(
+                comments,
+                "#{doc} export type #{n} = #{t}" as ModuleItem,
+                doc: Option<JsDoc> = view.description().map(JsDoc::new),
+                n: Ident = &type_name,
+                t: TsType = ts_untagged_type(view, &comments)
+            ),
+            SchemaIrTypeView::Container(_, ContainerView::Array(inner)) => {
+                let inner_ty = inner.ty();
+                let elem = ts_type_ref(&inner_ty, &comments);
+                let arr_ty = match elem {
+                    TsType::TsUnionOrIntersectionType(ty) => {
+                        ts_quote!("(#{ty})[]" as TsType, ty: TsType = ty)
+                    }
+                    ty => ts_quote!("#{ty}[]" as TsType, ty: TsType = ty),
+                };
+                ts_quote!(
+                    comments,
+                    "#{doc} export type #{n} = #{t}" as ModuleItem,
+                    doc: Option<JsDoc> = inner.description().map(JsDoc::new),
+                    n: Ident = &type_name,
+                    t: TsType = arr_ty
+                )
+            }
+            SchemaIrTypeView::Container(_, ContainerView::Map(inner)) => {
+                let inner_ty = inner.ty();
+                let v = ts_type_ref(&inner_ty, &comments);
+                ts_quote!(
+                    comments,
+                    "#{doc} export type #{n} = #{t}" as ModuleItem,
+                    doc: Option<JsDoc> = inner.description().map(JsDoc::new),
+                    n: Ident = &type_name,
+                    t: TsType = ts_quote!("Record<string, #{v}>" as TsType, v: TsType = v)
+                )
+            }
+            SchemaIrTypeView::Container(_, ContainerView::Optional(inner)) => {
+                let inner_ty = inner.ty();
+                let t = ts_type_ref(&inner_ty, &comments);
+                ts_quote!(
+                    comments,
+                    "#{doc} export type #{n} = #{t}" as ModuleItem,
+                    doc: Option<JsDoc> = inner.description().map(JsDoc::new),
+                    n: Ident = &type_name,
+                    t: TsType = ts_quote!("#{t} | null" as TsType, t: TsType = t)
+                )
+            }
+            SchemaIrTypeView::Primitive(_, view) => ts_quote!(
+                comments,
+                "export type #{n} = #{t}" as ModuleItem,
+                n: Ident = &type_name,
+                t: TsType = ts_primitive(view.ty())
+            ),
+            SchemaIrTypeView::Any(_, _) => ts_quote!(
+                comments,
+                "export type #{n} = unknown" as ModuleItem,
+                n: Ident = &type_name,
+            ),
+        };
+
+        module.body.push(main_item);
+
+        let module_name = name.into_module_name();
+        let file_name = module_name.display();
+
+        TsSource::new(format!("types/{file_name}.ts"), comments, module)
+    }
+}
+
+/// Collects `import type` declarations needed for a schema's file.
+fn collect_imports(schema: &SchemaIrTypeView<'_>) -> Vec<ModuleItem> {
+    let mut imported_schemas: BTreeMap<String, CodegenIdent> = BTreeMap::new();
+
+    // Walk all type dependencies to find referenced schemas.
+    // `dependencies()` already excludes self (see `IrGraph::new`).
+    for dep in schema.dependencies() {
+        if let IrTypeView::Schema(view) = &dep {
+            let ext = view.extensions();
+            let ident = ext.get::<CodegenIdent>().unwrap().clone();
+            let type_name = CodegenIdentUsage::Type(&ident).display().to_string();
+            imported_schemas.entry(type_name).or_insert(ident);
+        }
+    }
+
+    imported_schemas
+        .into_iter()
+        .map(|(type_name, ident)| {
+            let file_name = CodegenIdentUsage::Module(&ident).display().to_string();
+            let spec = format!("./{file_name}");
+            ts_quote!(
+                r#"import type { #{n} } from #{spec}"# as ModuleItem,
+                n: Ident = type_name,
+                spec: &str = &spec,
+            )
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use ploidy_core::{codegen::Code, ir::Ir, parse::Document};
+    use pretty_assertions::assert_eq;
+
+    use crate::CodegenGraph;
+
+    #[test]
+    fn test_schema_struct() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Pet:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                  required:
+                    - name
+        "})
+        .unwrap();
+
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
+
+        let schema = graph
+            .schemas()
+            .find(|s| s.name() == "Pet")
+            .expect("expected schema `Pet`");
+        let code = CodegenSchemaType::new(&schema).into_code();
+        assert_eq!(code.path(), "types/pet.ts");
+        assert_eq!(
+            code.into_string().unwrap(),
+            indoc::indoc! {"
+                export interface Pet {
+                  name: string;
+                }
+            "}
+        );
+    }
+
+    #[test]
+    fn test_schema_enum() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Status:
+                  type: string
+                  enum:
+                    - active
+                    - inactive
+        "})
+        .unwrap();
+
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
+
+        let schema = graph
+            .schemas()
+            .find(|s| s.name() == "Status")
+            .expect("expected schema `Status`");
+        let code = CodegenSchemaType::new(&schema).into_code();
+        assert_eq!(code.path(), "types/status.ts");
+        assert_eq!(
+            code.into_string().unwrap(),
+            "export type Status = \"active\" | \"inactive\";\n"
+        );
+    }
+
+    #[test]
+    fn test_schema_with_imports() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Dog:
+                  type: object
+                  properties:
+                    bark:
+                      type: string
+                Cat:
+                  type: object
+                  properties:
+                    meow:
+                      type: string
+                Animal:
+                  oneOf:
+                    - $ref: '#/components/schemas/Dog'
+                    - $ref: '#/components/schemas/Cat'
+        "})
+        .unwrap();
+
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
+
+        let schema = graph
+            .schemas()
+            .find(|s| s.name() == "Animal")
+            .expect("expected schema `Animal`");
+        let code = CodegenSchemaType::new(&schema).into_code();
+        assert_eq!(code.path(), "types/animal.ts");
+        assert_eq!(
+            code.into_string().unwrap(),
+            indoc::indoc! {r#"
+                import type { Cat } from "./cat";
+                import type { Dog } from "./dog";
+                export type Animal = Dog | Cat;
+            "#}
+        );
+    }
+
+    #[test]
+    fn test_schema_container_array() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Tags:
+                  type: array
+                  items:
+                    type: string
+        "})
+        .unwrap();
+
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
+
+        let schema = graph
+            .schemas()
+            .find(|s| s.name() == "Tags")
+            .expect("expected schema `Tags`");
+        let code = CodegenSchemaType::new(&schema).into_code();
+        assert_eq!(code.path(), "types/tags.ts");
+        assert_eq!(
+            code.into_string().unwrap(),
+            "export type Tags = string[];\n"
+        );
+    }
+
+    #[test]
+    fn test_schema_container_map() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Metadata:
+                  type: object
+                  additionalProperties:
+                    type: string
+        "})
+        .unwrap();
+
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
+
+        let schema = graph
+            .schemas()
+            .find(|s| s.name() == "Metadata")
+            .expect("expected schema `Metadata`");
+        let code = CodegenSchemaType::new(&schema).into_code();
+        assert_eq!(code.path(), "types/metadata.ts");
+        assert_eq!(
+            code.into_string().unwrap(),
+            "export type Metadata = Record<string, string>;\n"
+        );
+    }
+
+    #[test]
+    fn test_schema_any() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Anything:
+                  {}
+        "})
+        .unwrap();
+
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
+
+        let schema = graph
+            .schemas()
+            .find(|s| s.name() == "Anything")
+            .expect("expected schema `Anything`");
+        let code = CodegenSchemaType::new(&schema).into_code();
+        assert_eq!(code.path(), "types/anything.ts");
+        assert_eq!(
+            code.into_string().unwrap(),
+            "export type Anything = unknown;\n"
+        );
+    }
+
+    #[test]
+    fn test_schema_with_inline_types() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Container:
+                  type: object
+                  properties:
+                    nested:
+                      type: object
+                      properties:
+                        value:
+                          type: string
+        "})
+        .unwrap();
+
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
+
+        let schema = graph
+            .schemas()
+            .find(|s| s.name() == "Container")
+            .expect("expected schema `Container`");
+        let code = CodegenSchemaType::new(&schema).into_code();
+        assert_eq!(code.path(), "types/container.ts");
+        assert_eq!(
+            code.into_string().unwrap(),
+            indoc::indoc! {"
+                export interface Container {
+                  nested?: {
+                    value?: string;
+                  };
+                }
+            "}
+        );
+    }
+}

--- a/ploidy-codegen-typescript/src/struct_.rs
+++ b/ploidy-codegen-typescript/src/struct_.rs
@@ -1,0 +1,739 @@
+use itertools::Itertools;
+use ploidy_core::ir::{
+    ContainerView, InlineIrTypeView, IrStructFieldName, IrStructFieldView, IrStructView,
+    IrTypeView, SchemaIrTypeView,
+};
+use quasiquodo_ts::{
+    Comments, JsDoc,
+    swc::ecma_ast::{ModuleItem, TsType, TsTypeElement},
+    ts_quote,
+};
+
+use super::{
+    naming::{CodegenIdent, CodegenIdentUsage, CodegenStructFieldName},
+    ref_::ts_type_ref,
+};
+
+/// Resolves a struct to a TypeScript type expression (an object
+/// literal type or an intersection of parent refs and own members).
+pub fn ts_struct_type(ty: &IrStructView<'_>, comments: &Comments) -> TsType {
+    let parents: Vec<_> = ty.parents().collect();
+    let has_flattened = ty.own_fields().any(|f| f.flattened());
+
+    let schema_parents: Vec<_> = parents
+        .iter()
+        .filter(|p| matches!(p, IrTypeView::Schema(_)))
+        .collect();
+    let all_parents_are_inline = schema_parents.is_empty();
+
+    if all_parents_are_inline && !has_flattened {
+        // No named schema parents; all fields (including inherited)
+        // are emitted in a single object literal.
+        let members: Vec<TsTypeElement> = ty
+            .fields()
+            .map(|field| ts_property_for_field(&field, comments))
+            .collect();
+        ts_quote!(
+            "{ #{m}; }" as TsType,
+            m: Vec<TsTypeElement> = members
+        )
+    } else {
+        // Intersection: parent refs + own non-flattened fields +
+        // flattened fields.
+        ts_struct_intersection_type(ty, &parents, comments)
+    }
+}
+
+/// Generates a TypeScript interface or intersection type from a struct,
+/// returning a complete `export` module item.
+///
+/// Decision tree:
+/// 1. No named schema parents, no flattened fields ->
+///    `export interface Foo { ... }` (includes linearized inline parents)
+/// 2. All parents are named schema structs, no flattened ->
+///    `export interface Foo extends Bar { ... }` (own fields only)
+/// 3. Flattened fields or mixed parents ->
+///    `export type Foo = Bar & Baz & { ... }`
+pub fn ts_struct(
+    name: &str,
+    ty: &IrStructView<'_>,
+    comments: &Comments,
+    desc: Option<&str>,
+) -> ModuleItem {
+    let parents: Vec<_> = ty.parents().collect();
+    let has_flattened = ty.own_fields().any(|f| f.flattened());
+
+    let schema_parents: Vec<_> = parents
+        .iter()
+        .filter(|p| matches!(p, IrTypeView::Schema(_)))
+        .collect();
+    let all_parents_are_inline = schema_parents.is_empty();
+    let all_parents_are_schema_structs = !parents.is_empty()
+        && parents
+            .iter()
+            .all(|p| matches!(p, IrTypeView::Schema(SchemaIrTypeView::Struct(_, _))));
+
+    let doc = desc.map(JsDoc::new);
+
+    if all_parents_are_inline && !has_flattened {
+        // Case 1: No named schema parents. Inline parents are
+        // linearized into `fields()`, so emit a simple interface.
+        let members: Vec<TsTypeElement> = ty
+            .fields()
+            .map(|field| ts_property_for_field(&field, comments))
+            .collect();
+        ts_quote!(
+            comments,
+            "#{doc} export interface #{n} { #{m}; }" as ModuleItem,
+            doc: Option<JsDoc> = doc,
+            n: Ident = name,
+            m: Vec<TsTypeElement> = members
+        )
+    } else if all_parents_are_schema_structs && !has_flattened {
+        // Case 2: Interface with extends.
+        let extends_idents: Vec<_> = parents
+            .iter()
+            .filter_map(|p| {
+                if let IrTypeView::Schema(view) = p {
+                    let type_name = super::naming::CodegenTypeName::Schema(view)
+                        .display()
+                        .to_string();
+                    Some(ts_quote!("#{n}" as Ident, n: Ident = type_name))
+                } else {
+                    None
+                }
+            })
+            .collect();
+        let members: Vec<TsTypeElement> = ty
+            .own_fields()
+            .map(|field| ts_property_for_field(&field, comments))
+            .collect();
+        ts_quote!(
+            comments,
+            "#{doc} export interface #{n} extends #{parents} { #{m}; }" as ModuleItem,
+            doc: Option<JsDoc> = doc,
+            n: Ident = name,
+            parents: Vec<Ident> = extends_idents,
+            m: Vec<TsTypeElement> = members
+        )
+    } else {
+        // Case 3: Intersection type.
+        let intersection_ty = ts_struct_intersection_type(ty, &parents, comments);
+        ts_quote!(
+            comments,
+            "#{doc} export type #{n} = #{t}" as ModuleItem,
+            doc: Option<JsDoc> = doc,
+            n: Ident = name,
+            t: TsType = intersection_ty
+        )
+    }
+}
+
+/// Builds an intersection type from parents and own fields,
+/// returning the raw `TsType`.
+fn ts_struct_intersection_type(
+    ty: &IrStructView<'_>,
+    parents: &[IrTypeView<'_>],
+    comments: &Comments,
+) -> TsType {
+    let mut parts: Vec<TsType> = Vec::new();
+
+    for parent in parents {
+        parts.push(ts_type_ref(parent, comments));
+    }
+
+    let own_members: Vec<TsTypeElement> = ty
+        .own_fields()
+        .filter(|f| !f.flattened())
+        .map(|field| ts_property_for_field(&field, comments))
+        .collect();
+
+    for field in ty.own_fields().filter(|f| f.flattened()) {
+        let ty = field.ty();
+        parts.push(ts_type_ref(&ty, comments));
+    }
+
+    if !own_members.is_empty() {
+        parts.push(ts_quote!(
+            "{ #{m}; }" as TsType,
+            m: Vec<TsTypeElement> = own_members
+        ));
+    }
+
+    if parts.len() == 1 {
+        parts.into_iter().next().unwrap()
+    } else {
+        let mut iter = parts.into_iter();
+        let first = iter.next().unwrap();
+        ts_quote!(
+            "#{first} & #{rest}" as TsType,
+            first: TsType = first,
+            rest: Vec<Box<TsType>> = iter.map(Box::new).collect_vec(),
+        )
+    }
+}
+
+/// Converts a struct field to a TypeScript property signature.
+fn ts_property_for_field(field: &IrStructFieldView<'_, '_>, comments: &Comments) -> TsTypeElement {
+    let name = match field.name() {
+        IrStructFieldName::Name(n) => CodegenIdentUsage::Field(&CodegenIdent::new(n))
+            .display()
+            .to_string(),
+        IrStructFieldName::Hint(hint) => CodegenStructFieldName(hint).display().to_string(),
+    };
+
+    // Peel away optional layers to get the inner type and nullability.
+    //
+    // The IR wraps non-required fields in `Optional(T)`. For required
+    // nullable fields, it uses `Optional(T)` too. For non-required
+    // nullable fields, it double-wraps: `Optional(Optional(T))`.
+    //
+    // For TypeScript, `?:` handles the "not present" semantics from
+    // the outer Optional. Only additional Optional layers indicate
+    // the value can be `null`.
+    let field_ty = field.ty();
+    let (inner_ty, depth) = peel_optional(field_ty);
+
+    let ts_ty = ts_type_ref(&inner_ty, comments);
+
+    // Determine optionality and nullability:
+    // - Required field with depth >= 1: `prop: T | null`
+    // - Optional field with depth >= 2: `prop?: T | null`
+    //   (depth 1 = the "not present" Optional consumed by `?:`,
+    //   depth 2 = an additional nullable layer from the schema)
+    // - Optional field with depth <= 1: `prop?: T`
+    // - Required field with depth == 0: `prop: T`
+    //
+    let nullable = |ty: TsType| ts_quote!("#{t} | null" as TsType, t: TsType = ty);
+    let (optional, final_ty) = if field.required() {
+        if depth >= 1 {
+            (false, nullable(ts_ty))
+        } else {
+            (false, ts_ty)
+        }
+    } else {
+        // Non-required fields always get `?:`. The outer Optional
+        // (depth=1) is consumed by `?:`. Any remaining layers
+        // (depth >= 2) indicate nullability.
+        if depth >= 2 {
+            (true, nullable(ts_ty))
+        } else {
+            (true, ts_ty)
+        }
+    };
+
+    let doc = field.description().map(JsDoc::new);
+    if optional {
+        ts_quote!(
+            comments,
+            "#{doc} #{name}?: #{ty}" as TsTypeElement,
+            doc: Option<JsDoc> = doc,
+            name: &str = &name,
+            ty: TsType = final_ty,
+        )
+    } else {
+        ts_quote!(
+            comments,
+            "#{doc} #{name}: #{ty}" as TsTypeElement,
+            doc: Option<JsDoc> = doc,
+            name: &str = &name,
+            ty: TsType = final_ty,
+        )
+    }
+}
+
+/// Peels away `Optional` container layers, returning the inner type
+/// and the number of layers peeled.
+fn peel_optional(ty: IrTypeView<'_>) -> (IrTypeView<'_>, usize) {
+    let mut current = ty;
+    let mut depth = 0;
+    loop {
+        match current {
+            IrTypeView::Schema(SchemaIrTypeView::Container(_, ContainerView::Optional(inner)))
+            | IrTypeView::Inline(InlineIrTypeView::Container(_, ContainerView::Optional(inner))) => {
+                current = inner.ty();
+                depth += 1;
+            }
+            _ => return (current, depth),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use ploidy_core::{
+        codegen::Code,
+        ir::{Ir, SchemaIrTypeView},
+        parse::Document,
+    };
+    use pretty_assertions::assert_eq;
+    use quasiquodo_ts::{Comments, swc::ecma_ast::Module};
+
+    use crate::{CodegenGraph, TsSource, naming::CodegenTypeName};
+
+    #[test]
+    fn test_struct_simple_interface() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Pet:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    age:
+                      type: integer
+                      format: int32
+                  required:
+                    - name
+        "})
+        .unwrap();
+
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
+
+        let schema = graph.schemas().find(|s| s.name() == "Pet");
+        let Some(schema @ SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
+            panic!("expected struct `Pet`; got `{schema:?}`");
+        };
+
+        let name = CodegenTypeName::Schema(schema).display().to_string();
+        let comments = Comments::new();
+        let items = vec![ts_struct(&name, struct_view, &comments, None)];
+        assert_eq!(
+            TsSource::new(
+                String::new(),
+                comments,
+                Module {
+                    body: items,
+                    ..Module::default()
+                }
+            )
+            .into_string()
+            .unwrap(),
+            indoc::indoc! {"
+                export interface Pet {
+                  name: string;
+                  age?: number;
+                }
+            "}
+        );
+    }
+
+    #[test]
+    fn test_struct_required_nullable_field() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Record:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                    deleted_at:
+                      type: string
+                      format: date-time
+                      nullable: true
+                  required:
+                    - id
+                    - deleted_at
+        "})
+        .unwrap();
+
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
+
+        let schema = graph.schemas().find(|s| s.name() == "Record");
+        let Some(schema @ SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
+            panic!("expected struct `Record`; got `{schema:?}`");
+        };
+
+        let name = CodegenTypeName::Schema(schema).display().to_string();
+        let comments = Comments::new();
+        let items = vec![ts_struct(&name, struct_view, &comments, None)];
+        assert_eq!(
+            TsSource::new(
+                String::new(),
+                comments,
+                Module {
+                    body: items,
+                    ..Module::default()
+                }
+            )
+            .into_string()
+            .unwrap(),
+            indoc::indoc! {"
+                export interface Record {
+                  id: string;
+                  deletedAt: string | null;
+                }
+            "}
+        );
+    }
+
+    #[test]
+    fn test_struct_optional_nullable_field() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Record:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                    deleted_at:
+                      type: string
+                      format: date-time
+                      nullable: true
+                  required:
+                    - id
+        "})
+        .unwrap();
+
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
+
+        let schema = graph.schemas().find(|s| s.name() == "Record");
+        let Some(schema @ SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
+            panic!("expected struct `Record`; got `{schema:?}`");
+        };
+
+        let name = CodegenTypeName::Schema(schema).display().to_string();
+        let comments = Comments::new();
+        let items = vec![ts_struct(&name, struct_view, &comments, None)];
+        assert_eq!(
+            TsSource::new(
+                String::new(),
+                comments,
+                Module {
+                    body: items,
+                    ..Module::default()
+                }
+            )
+            .into_string()
+            .unwrap(),
+            indoc::indoc! {"
+                export interface Record {
+                  id: string;
+                  deletedAt?: string | null;
+                }
+            "}
+        );
+    }
+
+    #[test]
+    fn test_struct_with_description() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Pet:
+                  description: A pet in the store.
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                  required:
+                    - name
+        "})
+        .unwrap();
+
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
+
+        let schema = graph.schemas().find(|s| s.name() == "Pet");
+        let Some(schema @ SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
+            panic!("expected struct `Pet`; got `{schema:?}`");
+        };
+
+        let name = CodegenTypeName::Schema(schema).display().to_string();
+        let comments = Comments::new();
+
+        // Description is handled by the caller (schema.rs) via Comments.
+        // Here we just verify the decl itself produces correct output.
+        let items = vec![ts_struct(&name, struct_view, &comments, None)];
+        assert_eq!(
+            TsSource::new(
+                String::new(),
+                comments,
+                Module {
+                    body: items,
+                    ..Module::default()
+                }
+            )
+            .into_string()
+            .unwrap(),
+            indoc::indoc! {"
+                export interface Pet {
+                  name: string;
+                }
+            "}
+        );
+    }
+
+    #[test]
+    fn test_struct_field_descriptions() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Pet:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                      description: The pet's name.
+                    age:
+                      type: integer
+                      format: int32
+                      description: Age in years.
+                  required:
+                    - name
+        "})
+        .unwrap();
+
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
+
+        let schema = graph.schemas().find(|s| s.name() == "Pet");
+        let Some(schema @ SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
+            panic!("expected struct `Pet`; got `{schema:?}`");
+        };
+
+        let name = CodegenTypeName::Schema(schema).display().to_string();
+        let comments = Comments::new();
+        let items = vec![ts_struct(&name, struct_view, &comments, None)];
+        assert_eq!(
+            TsSource::new(
+                String::new(),
+                comments,
+                Module {
+                    body: items,
+                    ..Module::default()
+                }
+            )
+            .into_string()
+            .unwrap(),
+            indoc::indoc! {"
+                export interface Pet {
+                  /** The pet's name. */ name: string;
+                  /** Age in years. */ age?: number;
+                }
+            "}
+        );
+    }
+
+    #[test]
+    fn test_struct_linearizes_inline_all_of_parent_fields() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Person:
+                  allOf:
+                    - type: object
+                      properties:
+                        name:
+                          type: string
+                      required:
+                        - name
+                    - type: object
+                      properties:
+                        age:
+                          type: integer
+                          format: int32
+                      required:
+                        - age
+                  properties:
+                    email:
+                      type: string
+                  required:
+                    - email
+        "})
+        .unwrap();
+
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
+
+        let schema = graph.schemas().find(|s| s.name() == "Person");
+        let Some(schema @ SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
+            panic!("expected struct `Person`; got `{schema:?}`");
+        };
+
+        let name = CodegenTypeName::Schema(schema).display().to_string();
+        let comments = Comments::new();
+        let items = vec![ts_struct(&name, struct_view, &comments, None)];
+        assert_eq!(
+            TsSource::new(
+                String::new(),
+                comments,
+                Module {
+                    body: items,
+                    ..Module::default()
+                }
+            )
+            .into_string()
+            .unwrap(),
+            indoc::indoc! {"
+                export interface Person {
+                  name: string;
+                  age: number;
+                  email: string;
+                }
+            "}
+        );
+    }
+
+    #[test]
+    fn test_struct_extends_named_schema_parent() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Animal:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                  required:
+                    - name
+                Employee:
+                  allOf:
+                    - $ref: '#/components/schemas/Animal'
+                  properties:
+                    role:
+                      type: string
+                  required:
+                    - role
+        "})
+        .unwrap();
+
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
+
+        let schema = graph.schemas().find(|s| s.name() == "Employee");
+        let Some(schema @ SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
+            panic!("expected struct `Employee`; got `{schema:?}`");
+        };
+
+        let name = CodegenTypeName::Schema(schema).display().to_string();
+        let comments = Comments::new();
+        let items = vec![ts_struct(&name, struct_view, &comments, None)];
+        assert_eq!(
+            TsSource::new(
+                String::new(),
+                comments,
+                Module {
+                    body: items,
+                    ..Module::default()
+                }
+            )
+            .into_string()
+            .unwrap(),
+            indoc::indoc! {"
+                export interface Employee extends Animal {
+                  role: string;
+                }
+            "}
+        );
+    }
+
+    #[test]
+    fn test_struct_intersection_type_with_flattened_any_of() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Dog:
+                  type: object
+                  properties:
+                    bark:
+                      type: string
+                Cat:
+                  type: object
+                  properties:
+                    meow:
+                      type: string
+                Pet:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                  required:
+                    - name
+                  anyOf:
+                    - $ref: '#/components/schemas/Dog'
+                    - $ref: '#/components/schemas/Cat'
+        "})
+        .unwrap();
+
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
+
+        let schema = graph.schemas().find(|s| s.name() == "Pet");
+        let Some(schema @ SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
+            panic!("expected struct `Pet`; got `{schema:?}`");
+        };
+
+        let name = CodegenTypeName::Schema(schema).display().to_string();
+        let comments = Comments::new();
+        let items = vec![ts_struct(&name, struct_view, &comments, None)];
+        let output = TsSource::new(
+            String::new(),
+            comments,
+            Module {
+                body: items,
+                ..Module::default()
+            },
+        )
+        .into_string()
+        .unwrap();
+
+        // The anyOf variants become flattened optional fields, producing
+        // an intersection type: `Dog & Cat & { name: string; }`.
+        assert!(output.contains("Dog"), "expected `Dog` in output: {output}");
+        assert!(output.contains("Cat"), "expected `Cat` in output: {output}");
+        assert!(output.contains("&"), "expected `&` in output: {output}");
+        assert!(
+            output.contains("name: string"),
+            "expected own field `name: string` in output: {output}"
+        );
+    }
+}

--- a/ploidy-codegen-typescript/src/tagged.rs
+++ b/ploidy-codegen-typescript/src/tagged.rs
@@ -1,0 +1,259 @@
+use itertools::Itertools;
+use ploidy_core::ir::IrTaggedView;
+use quasiquodo_ts::{Comments, swc::ecma_ast::TsType, ts_quote};
+
+use super::ref_::ts_type_ref;
+
+/// Resolves a tagged union to a TypeScript type expression (a union
+/// of `{ tag: 'value' } & VariantRef` intersections).
+pub fn ts_tagged_type(ty: &IrTaggedView<'_>, comments: &Comments) -> TsType {
+    let tag = ty.tag();
+    let mut types = ty.variants().map(|variant| {
+        let view = variant.ty();
+        let variant_ref = ts_type_ref(&view, comments);
+
+        let discriminator_value = variant.aliases().first().copied().unwrap_or(variant.name());
+
+        let tag_object = ts_quote!(
+            "{ #{tag}: #{v}; }" as TsType,
+            tag: &str = tag,
+            v: &str = discriminator_value
+        );
+
+        ts_quote!(
+            "#{a} & #{b}" as TsType,
+            a: TsType = tag_object,
+            b: TsType = variant_ref,
+        )
+    });
+    let Some(first) = types.next() else {
+        return ts_quote!("never" as TsType);
+    };
+    ts_quote!(
+        "#{first} | #{rest}" as TsType,
+        first: TsType = first,
+        rest: Vec<Box<TsType>> = types.map(Box::new).collect_vec(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use ploidy_core::{
+        codegen::Code,
+        ir::{Ir, SchemaIrTypeView},
+        parse::Document,
+    };
+    use pretty_assertions::assert_eq;
+    use quasiquodo_ts::{Comments, swc::ecma_ast::Module};
+
+    use crate::{CodegenGraph, TsSource, naming::CodegenTypeName};
+
+    #[test]
+    fn test_tagged_union() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            components:
+              schemas:
+                Dog:
+                  type: object
+                  properties:
+                    bark:
+                      type: string
+                Cat:
+                  type: object
+                  properties:
+                    meow:
+                      type: string
+                Pet:
+                  oneOf:
+                    - $ref: '#/components/schemas/Dog'
+                    - $ref: '#/components/schemas/Cat'
+                  discriminator:
+                    propertyName: petType
+                    mapping:
+                      dog: '#/components/schemas/Dog'
+                      cat: '#/components/schemas/Cat'
+        "})
+        .unwrap();
+
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
+
+        let schema = graph.schemas().find(|s| s.name() == "Pet");
+        let Some(schema @ SchemaIrTypeView::Tagged(_, tagged)) = &schema else {
+            panic!("expected tagged union `Pet`; got `{schema:?}`");
+        };
+
+        let name = CodegenTypeName::Schema(schema).display().to_string();
+        let comments = Comments::new();
+        let ty = ts_tagged_type(tagged, &comments);
+        let items = vec![ts_quote!(
+            "export type #{n} = #{t}" as ModuleItem,
+            n: Ident = name,
+            t: TsType = ty
+        )];
+        assert_eq!(
+            TsSource::new(
+                String::new(),
+                comments,
+                Module {
+                    body: items,
+                    ..Module::default()
+                }
+            )
+            .into_string()
+            .unwrap(),
+            indoc::indoc! {r#"
+                export type Pet = {
+                  petType: "dog";
+                } & Dog | {
+                  petType: "cat";
+                } & Cat;
+            "#}
+        );
+    }
+
+    #[test]
+    fn test_tagged_union_with_rename() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            components:
+              schemas:
+                Dog:
+                  type: object
+                  properties:
+                    bark:
+                      type: string
+                Cat:
+                  type: object
+                  properties:
+                    meow:
+                      type: string
+                Pet:
+                  oneOf:
+                    - $ref: '#/components/schemas/Dog'
+                    - $ref: '#/components/schemas/Cat'
+                  discriminator:
+                    propertyName: type
+                    mapping:
+                      canine: '#/components/schemas/Dog'
+                      feline: '#/components/schemas/Cat'
+        "})
+        .unwrap();
+
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
+
+        let schema = graph.schemas().find(|s| s.name() == "Pet");
+        let Some(schema @ SchemaIrTypeView::Tagged(_, tagged)) = &schema else {
+            panic!("expected tagged union `Pet`; got `{schema:?}`");
+        };
+
+        let name = CodegenTypeName::Schema(schema).display().to_string();
+        let comments = Comments::new();
+        let ty = ts_tagged_type(tagged, &comments);
+        let items = vec![ts_quote!(
+            "export type #{n} = #{t}" as ModuleItem,
+            n: Ident = name,
+            t: TsType = ty
+        )];
+        assert_eq!(
+            TsSource::new(
+                String::new(),
+                comments,
+                Module {
+                    body: items,
+                    ..Module::default()
+                }
+            )
+            .into_string()
+            .unwrap(),
+            indoc::indoc! {r#"
+                export type Pet = {
+                  type: "canine";
+                } & Dog | {
+                  type: "feline";
+                } & Cat;
+            "#}
+        );
+    }
+
+    #[test]
+    fn test_tagged_union_with_description() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            components:
+              schemas:
+                Dog:
+                  type: object
+                  properties:
+                    bark:
+                      type: string
+                Cat:
+                  type: object
+                  properties:
+                    meow:
+                      type: string
+                Pet:
+                  description: Represents different types of pets
+                  oneOf:
+                    - $ref: '#/components/schemas/Dog'
+                    - $ref: '#/components/schemas/Cat'
+                  discriminator:
+                    propertyName: type
+                    mapping:
+                      dog: '#/components/schemas/Dog'
+                      cat: '#/components/schemas/Cat'
+        "})
+        .unwrap();
+
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
+
+        let schema = graph.schemas().find(|s| s.name() == "Pet");
+        let Some(schema @ SchemaIrTypeView::Tagged(_, tagged)) = &schema else {
+            panic!("expected tagged union `Pet`; got `{schema:?}`");
+        };
+
+        let name = CodegenTypeName::Schema(schema).display().to_string();
+
+        // Description is handled by the caller (schema.rs) via Comments.
+        let comments = Comments::new();
+        let ty = ts_tagged_type(tagged, &comments);
+        let items = vec![ts_quote!(
+            "export type #{n} = #{t}" as ModuleItem,
+            n: Ident = name,
+            t: TsType = ty
+        )];
+        assert_eq!(
+            TsSource::new(
+                String::new(),
+                comments,
+                Module {
+                    body: items,
+                    ..Module::default()
+                }
+            )
+            .into_string()
+            .unwrap(),
+            indoc::indoc! {r#"
+                export type Pet = {
+                  type: "dog";
+                } & Dog | {
+                  type: "cat";
+                } & Cat;
+            "#}
+        );
+    }
+}

--- a/ploidy-codegen-typescript/src/tests.rs
+++ b/ploidy-codegen-typescript/src/tests.rs
@@ -1,0 +1,17 @@
+/// Asserts that `$expr` matches `$pattern`, panicking with the actual
+/// value if it doesn't.
+#[allow(unused_macros)]
+macro_rules! assert_matches {
+    ($expr:expr, $pattern:pat) => {
+        let value = $expr;
+        assert!(
+            matches!(&value, $pattern),
+            "expected {}, got `{:?}`",
+            stringify!($pattern),
+            value
+        );
+    };
+}
+
+#[allow(unused_imports)]
+pub(crate) use assert_matches;

--- a/ploidy-codegen-typescript/src/types.rs
+++ b/ploidy-codegen-typescript/src/types.rs
@@ -1,0 +1,99 @@
+use itertools::Itertools;
+use quasiquodo_ts::{Comments, swc::ecma_ast::Module, ts_quote};
+
+use super::{
+    TsSource,
+    graph::CodegenGraph,
+    naming::{CodegenTypeName, CodegenTypeNameSortKey},
+};
+
+/// Generates the barrel `types/index.ts` that re-exports all schema types.
+pub struct CodegenTypesModule<'a> {
+    graph: &'a CodegenGraph<'a>,
+}
+
+impl<'a> CodegenTypesModule<'a> {
+    pub fn new(graph: &'a CodegenGraph<'a>) -> Self {
+        Self { graph }
+    }
+}
+
+impl CodegenTypesModule<'_> {
+    /// Generates the barrel module and returns it as a [`TsSource`].
+    pub fn into_code(self) -> TsSource<Module> {
+        let mut tys = self.graph.schemas().collect_vec();
+        tys.sort_by(|a, b| {
+            CodegenTypeNameSortKey::for_schema(a).cmp(&CodegenTypeNameSortKey::for_schema(b))
+        });
+
+        let comments = Comments::new();
+        let mut module = Module::default();
+        for ty in &tys {
+            let name = CodegenTypeName::Schema(ty);
+            let type_name = name.display().to_string();
+            let module_name = name.into_module_name();
+            let file_name = module_name.display();
+            let spec = format!("./{file_name}");
+            module.body.push(ts_quote!(
+                r#"export type { #{n} } from #{spec}"# as ModuleItem,
+                n: Ident = type_name,
+                spec: &str = &spec,
+            ));
+        }
+
+        TsSource::new("types/index.ts".to_owned(), comments, module)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use ploidy_core::{codegen::Code, ir::Ir, parse::Document};
+    use pretty_assertions::assert_eq;
+
+    use crate::CodegenGraph;
+
+    #[test]
+    fn test_types_module_barrel_export() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Pet:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                Status:
+                  type: string
+                  enum:
+                    - active
+                    - inactive
+                Order:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+        "})
+        .unwrap();
+
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
+
+        let code = CodegenTypesModule::new(&graph).into_code();
+        let content = code.into_string().unwrap();
+        assert_eq!(
+            content,
+            indoc::indoc! {r#"
+                export type { Order } from "./order";
+                export type { Pet } from "./pet";
+                export type { Status } from "./status";
+            "#}
+        );
+    }
+}

--- a/ploidy-codegen-typescript/src/untagged.rs
+++ b/ploidy-codegen-typescript/src/untagged.rs
@@ -1,0 +1,195 @@
+use itertools::Itertools;
+use ploidy_core::ir::IrUntaggedView;
+use quasiquodo_ts::{Comments, swc::ecma_ast::TsType, ts_quote};
+
+use super::ref_::ts_type_ref;
+
+/// Resolves an untagged union to a TypeScript union type expression.
+pub fn ts_untagged_type(ty: &IrUntaggedView<'_>, comments: &Comments) -> TsType {
+    let mut types = ty.variants().map(|variant| match variant.ty() {
+        Some(variant) => ts_type_ref(&variant.view, comments),
+        None => ts_quote!("null" as TsType),
+    });
+    let Some(first) = types.next() else {
+        return ts_quote!("never" as TsType);
+    };
+    ts_quote!(
+        "#{first} | #{rest}" as TsType,
+        first: TsType = first,
+        rest: Vec<Box<TsType>> = types.map(Box::new).collect_vec(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use ploidy_core::{
+        codegen::Code,
+        ir::{Ir, SchemaIrTypeView},
+        parse::Document,
+    };
+    use pretty_assertions::assert_eq;
+    use quasiquodo_ts::{Comments, swc::ecma_ast::Module};
+
+    use crate::{CodegenGraph, TsSource, naming::CodegenTypeName};
+
+    #[test]
+    fn test_untagged_union_primitives() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                StringOrInt:
+                  oneOf:
+                    - type: string
+                    - type: integer
+                      format: int32
+        "})
+        .unwrap();
+
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
+
+        let schema = graph.schemas().find(|s| s.name() == "StringOrInt");
+        let Some(schema @ SchemaIrTypeView::Untagged(_, untagged_view)) = &schema else {
+            panic!("expected untagged union `StringOrInt`; got `{schema:?}`");
+        };
+
+        let name = CodegenTypeName::Schema(schema).display().to_string();
+        let comments = Comments::new();
+        let ty = ts_untagged_type(untagged_view, &comments);
+        let items = vec![ts_quote!(
+            "export type #{n} = #{t}" as ModuleItem,
+            n: Ident = name,
+            t: TsType = ty
+        )];
+        assert_eq!(
+            TsSource::new(
+                String::new(),
+                comments,
+                Module {
+                    body: items,
+                    ..Module::default()
+                }
+            )
+            .into_string()
+            .unwrap(),
+            "export type StringOrInt = string | number;\n"
+        );
+    }
+
+    #[test]
+    fn test_untagged_union_with_refs() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Dog:
+                  type: object
+                  properties:
+                    bark:
+                      type: string
+                Cat:
+                  type: object
+                  properties:
+                    meow:
+                      type: string
+                Animal:
+                  oneOf:
+                    - $ref: '#/components/schemas/Dog'
+                    - $ref: '#/components/schemas/Cat'
+        "})
+        .unwrap();
+
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
+
+        let schema = graph.schemas().find(|s| s.name() == "Animal");
+        let Some(schema @ SchemaIrTypeView::Untagged(_, untagged_view)) = &schema else {
+            panic!("expected untagged union `Animal`; got `{schema:?}`");
+        };
+
+        let name = CodegenTypeName::Schema(schema).display().to_string();
+        let comments = Comments::new();
+        let ty = ts_untagged_type(untagged_view, &comments);
+        let items = vec![ts_quote!(
+            "export type #{n} = #{t}" as ModuleItem,
+            n: Ident = name,
+            t: TsType = ty
+        )];
+        assert_eq!(
+            TsSource::new(
+                String::new(),
+                comments,
+                Module {
+                    body: items,
+                    ..Module::default()
+                }
+            )
+            .into_string()
+            .unwrap(),
+            "export type Animal = Dog | Cat;\n"
+        );
+    }
+
+    #[test]
+    fn test_untagged_union_with_description() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                StringOrInt:
+                  description: A union that can be either a string or an integer.
+                  oneOf:
+                    - type: string
+                    - type: integer
+                      format: int32
+        "})
+        .unwrap();
+
+        let ir = Ir::from_doc(&doc).unwrap();
+        let graph = CodegenGraph::new(ir.graph().finalize());
+
+        let schema = graph.schemas().find(|s| s.name() == "StringOrInt");
+        let Some(schema @ SchemaIrTypeView::Untagged(_, untagged_view)) = &schema else {
+            panic!("expected untagged union `StringOrInt`; got `{schema:?}`");
+        };
+
+        let name = CodegenTypeName::Schema(schema).display().to_string();
+
+        // Description is handled by the caller (schema.rs) via Comments.
+        let comments = Comments::new();
+        let ty = ts_untagged_type(untagged_view, &comments);
+        let items = vec![ts_quote!(
+            "export type #{n} = #{t}" as ModuleItem,
+            n: Ident = name,
+            t: TsType = ty
+        )];
+        assert_eq!(
+            TsSource::new(
+                String::new(),
+                comments,
+                Module {
+                    body: items,
+                    ..Module::default()
+                }
+            )
+            .into_string()
+            .unwrap(),
+            "export type StringOrInt = string | number;\n"
+        );
+    }
+}

--- a/ploidy-core/src/ir/mod.rs
+++ b/ploidy-core/src/ir/mod.rs
@@ -8,7 +8,7 @@ mod views;
 #[cfg(test)]
 mod tests;
 
-pub use graph::{EdgeKind, IrGraph, Traversal};
+pub use graph::{EdgeKind, Ir, IrGraph, RawGraph, Traversal};
 pub use spec::IrSpec;
 pub use types::*;
 

--- a/ploidy-core/src/ir/tests/graph.rs
+++ b/ploidy-core/src/ir/tests/graph.rs
@@ -3,7 +3,7 @@
 use itertools::Itertools;
 
 use crate::{
-    ir::{IrGraph, IrSpec, IrStructFieldName, SchemaIrTypeView, View},
+    ir::{Ir, IrStructFieldName, SchemaIrTypeView, View},
     parse::Document,
     tests::assert_matches,
 };
@@ -32,8 +32,8 @@ fn test_graph_basic_construction() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     // Should be able to iterate over schemas.
     // The order of iteration isn't guaranteed.
@@ -69,8 +69,8 @@ fn test_graph_deduplication() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     // Should have all 3 schemas, with `Shared` appearing only once.
     let mut schema_names = graph.schemas().map(|s| s.name()).collect_vec();
@@ -100,8 +100,8 @@ fn test_graph_struct_field_edges() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     // Both schemas should be present.
     let mut schema_names = graph.schemas().map(|s| s.name()).collect_vec();
@@ -140,8 +140,8 @@ fn test_graph_tagged_variant_edges() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     // Should have all schemas.
     let mut schema_names = graph.schemas().map(|s| s.name()).collect_vec();
@@ -175,8 +175,8 @@ fn test_graph_untagged_variant_edges() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     // Should have all schemas.
     let mut schema_names = graph.schemas().map(|s| s.name()).collect_vec();
@@ -208,8 +208,8 @@ fn test_graph_array_edge() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     // Should have both schemas.
     let mut schema_names = graph.schemas().map(|s| s.name()).collect_vec();
@@ -241,8 +241,8 @@ fn test_graph_map_edge() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     // Should have both schemas.
     let mut schema_names = graph.schemas().map(|s| s.name()).collect_vec();
@@ -273,8 +273,8 @@ fn test_graph_nullable_edge() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     // Should have both schemas.
     let mut schema_names = graph.schemas().map(|s| s.name()).collect_vec();
@@ -306,8 +306,8 @@ fn test_graph_ref_resolution() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     // Should have both `Parent` and `Child` schemas.
     let mut schema_names = graph.schemas().map(|s| s.name()).collect_vec();
@@ -339,8 +339,8 @@ fn test_circular_refs_simple_cycle() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     // The field pointing to B should need indirection due to the cycle.
     let a_schema = graph.schemas().find(|s| s.name() == "A").unwrap();
@@ -372,8 +372,8 @@ fn test_circular_refs_self_reference() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     // Self-references should be detected as cycles.
     let node_schema = graph.schemas().find(|s| s.name() == "Node").unwrap();
@@ -415,8 +415,8 @@ fn test_circular_refs_complex_cycle() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     // At least one edge in the cycle should need indirection.
     let a_schema = graph.schemas().find(|s| s.name() == "A").unwrap();
@@ -455,8 +455,8 @@ fn test_circular_refs_no_cycles() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     // Tree structure without direct or indirect self-references
     // shouldn't have any circular dependencies.
@@ -505,8 +505,8 @@ fn test_circular_refs_multiple_sccs() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     // Both cycles should be detected.
     let a_schema = graph.schemas().find(|s| s.name() == "A").unwrap();
@@ -558,8 +558,8 @@ fn test_circular_refs_through_containers() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     // Cycles through containers should be detected.
     let a_schema = graph.schemas().find(|s| s.name() == "A").unwrap();
@@ -605,8 +605,8 @@ fn test_circular_refs_diamond_no_false_positive() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     // Diamond inheritance shouldn't be marked as circular.
     let top_schema = graph.schemas().find(|s| s.name() == "Top").unwrap();
@@ -654,8 +654,8 @@ fn test_circular_refs_tarjan_correctness() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     // A and B should be in a cycle.
     let a_schema = graph.schemas().find(|s| s.name() == "A").unwrap();
@@ -706,8 +706,8 @@ fn test_needs_indirection_through_nullable() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let a_schema = graph.schemas().find(|s| s.name() == "A").unwrap();
     let a_struct = match a_schema {
@@ -740,8 +740,8 @@ fn test_needs_indirection_through_array() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let node_schema = graph.schemas().find(|s| s.name() == "Node").unwrap();
     let node_struct = match node_schema {
@@ -774,8 +774,8 @@ fn test_needs_indirection_through_map() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let node_schema = graph.schemas().find(|s| s.name() == "Node").unwrap();
     let node_struct = match node_schema {
@@ -813,8 +813,8 @@ fn test_indirect_and_direct_siblings() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let container_schema = graph.schemas().find(|s| s.name() == "Container").unwrap();
     let container_struct = match container_schema {
@@ -874,8 +874,8 @@ fn test_operations_transitive() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     // Both `UserList` and `User` have no `x-resourceId`, and
     // the operation has no `x-resource-name`. The operation should
@@ -933,8 +933,8 @@ fn test_operations_multiple() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     // `User` has no `x-resourceId`, and neither operation has `x-resource-name`.
     // Each operation without a resource contributes `None` to `used_by`.
@@ -1015,8 +1015,8 @@ fn test_dependencies_propagation() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     // Dependencies are computed transitively through different edge types:
     // direct references, array items, and map values.
@@ -1135,8 +1135,8 @@ fn test_used_by_propagation() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     // Propagation through cycles: `Cat` and `Pet` are in a cycle.
     // The operation directly uses `Cat`, but `Pet` should also be
@@ -1211,8 +1211,8 @@ fn test_depends_on_simple_chain() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let a = graph.schemas().find(|s| s.name() == "A").unwrap();
     let b = graph.schemas().find(|s| s.name() == "B").unwrap();
@@ -1254,8 +1254,8 @@ fn test_depends_on_cycle() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let a = graph.schemas().find(|s| s.name() == "A").unwrap();
     let b = graph.schemas().find(|s| s.name() == "B").unwrap();
@@ -1293,8 +1293,8 @@ fn test_depends_on_independent() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let a = graph.schemas().find(|s| s.name() == "A").unwrap();
     let b = graph.schemas().find(|s| s.name() == "B").unwrap();
@@ -1334,8 +1334,8 @@ fn test_dependents_simple_chain() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let c = graph.schemas().find(|s| s.name() == "C").unwrap();
     let mut c_dependents = c
@@ -1395,8 +1395,8 @@ fn test_dependents_multiple_dependents() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let c = graph.schemas().find(|s| s.name() == "C").unwrap();
     let mut c_dependents = c
@@ -1437,8 +1437,8 @@ fn test_dependents_cycle() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     // In a cycle, all nodes transitively depend on each other,
     // but a type's dependents shouldn't include itself.
@@ -1493,8 +1493,8 @@ fn test_dependents_is_inverse_of_dependencies() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let container = graph.schemas().find(|s| s.name() == "Container").unwrap();
     let item = graph.schemas().find(|s| s.name() == "Item").unwrap();
@@ -1552,8 +1552,8 @@ fn test_dependencies_diamond() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let a = graph.schemas().find(|s| s.name() == "A").unwrap();
     let b = graph.schemas().find(|s| s.name() == "B").unwrap();
@@ -1606,8 +1606,8 @@ fn test_operation_with_no_types() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let op = graph
         .operations()
@@ -1663,8 +1663,8 @@ fn test_parents_returns_immediate_parents() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let user = graph.schemas().find(|s| s.name() == "User").unwrap();
     let user_struct = match user {
@@ -1714,8 +1714,8 @@ fn test_all_of_inheritance_with_fields() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let child = graph.schemas().find(|s| s.name() == "Child").unwrap();
     let child_struct = match child {
@@ -1794,8 +1794,8 @@ fn test_circular_refs_excludes_inherits_edges() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let parent = graph.schemas().find(|s| s.name() == "Parent").unwrap();
     let parent_struct = match parent {
@@ -1846,8 +1846,8 @@ fn test_multiple_parents() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let combined = graph.schemas().find(|s| s.name() == "Combined").unwrap();
     let combined_struct = match combined {
@@ -1919,8 +1919,8 @@ fn test_circular_all_of_terminates() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let a = graph.schemas().find(|s| s.name() == "A").unwrap();
     let a_struct = match a {
@@ -1939,13 +1939,13 @@ fn test_circular_all_of_terminates() {
         .collect_vec();
     assert_matches!(&*field_names, ["b_field", "kind", "a_field"]);
 
-    // `discriminator()` must also terminate, and B's `kind` discriminator
-    // should be visible on A's inherited field.
+    // `discriminator()` must also terminate. Both `A` and `B` are standalone
+    // (no incoming edges from tagged unions), so no field is a discriminator.
     let kind_field = a_struct
         .fields()
         .find(|f| matches!(f.name(), IrStructFieldName::Name("kind")))
         .unwrap();
-    assert!(kind_field.discriminator());
+    assert!(!kind_field.discriminator());
     assert!(kind_field.inherited());
 
     // A's own field should not be a discriminator.

--- a/ploidy-core/src/ir/tests/transform.rs
+++ b/ploidy-core/src/ir/tests/transform.rs
@@ -756,16 +756,27 @@ fn test_struct_with_nullable_field_ref() {
         )) => struct_,
         other => panic!("expected struct `Container`; got `{other:?}`"),
     };
+    // The field is nullable (3.0 `nullable: true`) and non-required,
+    // so it gets two `Optional` layers: outer for absence, inner for
+    // nullability.
     let [
         IrStructField {
             name: IrStructFieldName::Name("value"),
             ty:
-                IrType::Inline(InlineIrType::Container(_, Container::Optional(Inner { ty: inner, .. }))),
+                IrType::Inline(InlineIrType::Container(_, Container::Optional(Inner { ty: outer, .. }))),
             ..
         },
     ] = &*struct_.fields
     else {
-        panic!("expected single nullable field; got `{:?}`", struct_.fields);
+        panic!(
+            "expected double-wrapped nullable field; got `{:?}`",
+            struct_.fields
+        );
+    };
+    let IrType::Inline(InlineIrType::Container(_, Container::Optional(Inner { ty: inner, .. }))) =
+        &**outer
+    else {
+        panic!("expected inner Optional; got `{outer:?}`");
     };
     assert_matches!(&**inner, IrType::Ref(_));
 }
@@ -799,16 +810,26 @@ fn test_struct_with_nullable_field_inline() {
         )) => struct_,
         other => panic!("expected struct `Container`; got `{other:?}`"),
     };
+    // The field is nullable (3.0 `nullable: true`) and non-required,
+    // so it gets two `Optional` layers.
     let [
         IrStructField {
             name: IrStructFieldName::Name("value"),
             ty:
-                IrType::Inline(InlineIrType::Container(_, Container::Optional(Inner { ty: inner, .. }))),
+                IrType::Inline(InlineIrType::Container(_, Container::Optional(Inner { ty: outer, .. }))),
             ..
         },
     ] = &*struct_.fields
     else {
-        panic!("expected single nullable field; got `{:?}`", struct_.fields);
+        panic!(
+            "expected double-wrapped nullable field; got `{:?}`",
+            struct_.fields
+        );
+    };
+    let IrType::Inline(InlineIrType::Container(_, Container::Optional(Inner { ty: inner, .. }))) =
+        &**outer
+    else {
+        panic!("expected inner Optional; got `{outer:?}`");
     };
     assert_matches!(
         &**inner,

--- a/ploidy-core/src/ir/tests/views.rs
+++ b/ploidy-core/src/ir/tests/views.rs
@@ -5,9 +5,9 @@ use itertools::Itertools;
 use crate::{
     ir::{
         ContainerView, EdgeKind, ExtendableView, InlineIrTypePathRoot, InlineIrTypePathSegment,
-        InlineIrTypeView, IrEnumVariant, IrGraph, IrParameterStyle, IrRequestView, IrResponseView,
-        IrSpec, IrStructFieldName, IrTypeView, PrimitiveIrType, Reach, SchemaIrTypeView,
-        SchemaTypeInfo, SomeIrUntaggedVariant, Traversal, View,
+        InlineIrTypeView, Ir, IrEnumVariant, IrParameterStyle, IrRequestView, IrResponseView,
+        IrStructFieldName, IrTypeView, PrimitiveIrType, Reach, SchemaIrTypeView, SchemaTypeInfo,
+        SomeIrUntaggedVariant, Traversal, View,
     },
     parse::{Document, Method, path::PathFragment},
     tests::assert_matches,
@@ -36,8 +36,8 @@ fn test_struct_view_fields_iterator() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let person_schema = graph.schemas().find(|s| s.name() == "Person").unwrap();
     let person_struct = match person_schema {
@@ -76,8 +76,8 @@ fn test_struct_field_view_accessors() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let record_schema = graph.schemas().find(|s| s.name() == "Record").unwrap();
     let record_struct = match record_schema {
@@ -113,8 +113,8 @@ fn test_schema_view_from_graph() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     // Should be able to construct views for different schema types.
     let struct_view = graph.schemas().find(|s| s.name() == "MyStruct").unwrap();
@@ -144,8 +144,8 @@ fn test_extension_insertion_retrieval() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let mut schema_view = graph.schemas().next().unwrap();
 
@@ -175,8 +175,8 @@ fn test_extension_type_safety() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let mut schema_view = graph.schemas().next().unwrap();
 
@@ -225,8 +225,8 @@ fn test_extension_per_node_type() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let mut schema1 = graph.schemas().find(|s| s.name() == "Struct1").unwrap();
     let mut schema2 = graph.schemas().find(|s| s.name() == "Struct2").unwrap();
@@ -312,8 +312,8 @@ fn test_dependencies_multiple() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let branch_schema = graph.schemas().find(|s| s.name() == "Branch").unwrap();
 
@@ -348,8 +348,8 @@ fn test_dependencies_none() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let standalone_schema = graph.schemas().next().unwrap();
 
@@ -382,8 +382,8 @@ fn test_dependencies_handles_cycles_without_infinite_loop() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let a_schema = graph.schemas().find(|s| s.name() == "A").unwrap();
 
@@ -417,8 +417,8 @@ fn test_dependencies_from_array_includes_inner_types() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let container_schema = graph.schemas().find(|s| s.name() == "Container").unwrap();
     let container_struct = match container_schema {
@@ -483,8 +483,8 @@ fn test_dependencies_from_map_includes_inner_types() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let container_schema = graph.schemas().find(|s| s.name() == "Container").unwrap();
     let container_struct = match container_schema {
@@ -548,8 +548,8 @@ fn test_dependencies_from_nullable_includes_inner_types() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let container_schema = graph.schemas().find(|s| s.name() == "Container").unwrap();
     let container_struct = match container_schema {
@@ -618,8 +618,8 @@ fn test_dependencies_from_inline_includes_inner_types() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let container_schema = graph.schemas().find(|s| s.name() == "Container").unwrap();
     let container_struct = match container_schema {
@@ -679,8 +679,8 @@ fn test_dependencies_from_primitive_returns_empty() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let simple_schema = graph.schemas().next().unwrap();
     let simple_struct = match simple_schema {
@@ -720,8 +720,8 @@ fn test_dependencies_from_any_returns_empty() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let container_schema = graph.schemas().next().unwrap();
     let container_struct = match container_schema {
@@ -772,8 +772,8 @@ fn test_traverse_skip_excludes_node_but_continues_traversal() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let root = graph.schemas().find(|s| s.name() == "Root").unwrap();
 
@@ -825,8 +825,8 @@ fn test_traverse_stop_includes_node_but_stops_traversal() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let root = graph.schemas().find(|s| s.name() == "Root").unwrap();
 
@@ -877,8 +877,8 @@ fn test_traverse_ignore_excludes_node_and_stops_traversal() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let root = graph.schemas().find(|s| s.name() == "Root").unwrap();
 
@@ -930,8 +930,8 @@ fn test_traverse_dependents_yields_types_that_depend_on_node() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let leaf = graph.schemas().find(|s| s.name() == "Leaf").unwrap();
 
@@ -980,8 +980,8 @@ fn test_traverse_filter_on_edge_kind() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let child = graph.schemas().find(|s| s.name() == "Child").unwrap();
 
@@ -1034,8 +1034,8 @@ fn test_inlines_finds_inline_structs_in_struct_fields() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let parent_schema = graph.schemas().next().unwrap();
 
@@ -1067,8 +1067,8 @@ fn test_inlines_finds_inline_types_in_nested_arrays() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let container_schema = graph.schemas().next().unwrap();
 
@@ -1100,8 +1100,8 @@ fn test_inlines_empty_for_schemas_with_no_inlines() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let simple_schema = graph.schemas().find(|s| s.name() == "Simple").unwrap();
 
@@ -1142,8 +1142,8 @@ fn test_tagged_variant_names_and_aliases() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let animal_schema = graph.schemas().find(|s| s.name() == "Animal").unwrap();
     let tagged_view = match animal_schema {
@@ -1184,8 +1184,8 @@ fn test_tagged_variant_type_access() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let animal_schema = graph.schemas().find(|s| s.name() == "Animal").unwrap();
     let tagged_view = match animal_schema {
@@ -1228,8 +1228,8 @@ fn test_untagged_variant_iteration() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let animal_schema = graph.schemas().find(|s| s.name() == "Animal").unwrap();
     let untagged_view = match animal_schema {
@@ -1263,8 +1263,8 @@ fn test_array_view_provides_access_to_item_type() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let container_schema = graph.schemas().next().unwrap();
     let container_struct = match container_schema {
@@ -1309,8 +1309,8 @@ fn test_map_view_provides_access_to_value_type() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let container_schema = graph.schemas().next().unwrap();
     let container_struct = match container_schema {
@@ -1356,8 +1356,8 @@ fn test_nullable_view_provides_access_to_inner_type() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let container_schema = graph.schemas().next().unwrap();
     let container_struct = match container_schema {
@@ -1404,8 +1404,8 @@ fn test_inline_struct_view_construction_and_path_access() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let container_schema = graph.schemas().next().unwrap();
     let container_struct = match container_schema {
@@ -1451,8 +1451,8 @@ fn test_inline_enum_view_construction() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let container_schema = graph.schemas().next().unwrap();
     let container_struct = match container_schema {
@@ -1501,8 +1501,8 @@ fn test_inline_untagged_view_construction() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let container_schema = graph.schemas().next().unwrap();
     let container_struct = match container_schema {
@@ -1555,8 +1555,8 @@ fn test_inline_view_path_method() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let parent_schema = graph.schemas().next().unwrap();
     let parent_struct = match parent_schema {
@@ -1614,8 +1614,8 @@ fn test_inline_view_with_view_trait_methods() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let operation = graph.operations().next().unwrap();
     let request = operation.request().unwrap();
@@ -1680,8 +1680,8 @@ fn test_untagged_variant_with_null_type() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let animal_schema = graph.schemas().find(|s| s.name() == "Animal").unwrap();
     let untagged_view = match animal_schema {
@@ -1733,8 +1733,8 @@ fn test_enum_view_variants() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let status_schema = graph.schemas().find(|s| s.name() == "Status").unwrap();
     let enum_view = match status_schema {
@@ -1770,8 +1770,8 @@ fn test_enum_view_with_description() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let priority_schema = graph.schemas().find(|s| s.name() == "Priority").unwrap();
     let enum_view = match priority_schema {
@@ -1796,8 +1796,8 @@ fn test_enum_view_without_description() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let status_schema = graph.schemas().find(|s| s.name() == "Status").unwrap();
     let enum_view = match status_schema {
@@ -1822,8 +1822,8 @@ fn test_enum_view_variants_with_numbers() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let priority_schema = graph.schemas().find(|s| s.name() == "Priority").unwrap();
     let enum_view = match priority_schema {
@@ -1861,8 +1861,8 @@ fn test_enum_view_variants_with_booleans() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let toggle_schema = graph.schemas().find(|s| s.name() == "Toggle").unwrap();
     let enum_view = match toggle_schema {
@@ -1908,8 +1908,8 @@ fn test_enum_view_with_view_trait_methods() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let status_schema = graph.schemas().find(|s| s.name() == "Status").unwrap();
     let enum_view = match &status_schema {
@@ -1956,8 +1956,8 @@ fn test_operation_view_resource() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let operation = graph.operations().next().unwrap();
     assert_eq!(operation.resource(), Some("UserResource"));
@@ -2002,8 +2002,8 @@ fn test_operation_view_method() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let operations = graph.operations().collect_vec();
     assert_eq!(operations.len(), 5);
@@ -2061,8 +2061,8 @@ fn test_operation_view_inlines_excludes_schema_references() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let operation = graph.operations().next().unwrap();
 
@@ -2109,8 +2109,8 @@ fn test_operation_view_inlines_with_mixed_types() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let operation = graph.operations().next().unwrap();
 
@@ -2152,8 +2152,8 @@ fn test_operation_parameter_ty() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let operation = graph.operations().next().unwrap();
 
@@ -2233,8 +2233,8 @@ fn test_operation_parameter_style() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let operation = graph.operations().next().unwrap();
     let query_params = operation.query().collect_vec();
@@ -2310,8 +2310,8 @@ fn test_operation_request_json() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let operation = graph.operations().next().unwrap();
     assert_matches!(
@@ -2346,8 +2346,8 @@ fn test_operation_request_multipart() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let operation = graph.operations().next().unwrap();
     assert_matches!(operation.request(), Some(IrRequestView::Multipart));
@@ -2383,8 +2383,8 @@ fn test_operation_path() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let operation = graph.operations().next().unwrap();
     let segments = operation.path().segments().as_slice();
@@ -2420,8 +2420,8 @@ fn test_operation_response_without_schema() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let operation = graph.operations().next().unwrap();
 
@@ -2465,8 +2465,8 @@ fn test_operation_query() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let operation = graph.operations().next().unwrap();
 
@@ -2519,8 +2519,8 @@ fn test_operation_view_inlines_finds_inline_types() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let operation = graph.operations().next().unwrap();
 
@@ -2608,8 +2608,8 @@ fn test_operation_request_and_response() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let operation = graph.operations().next().unwrap();
 
@@ -2687,8 +2687,8 @@ fn test_variant_field_matching_tagged_union_discriminator_is_discriminator() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     // `Comment.kind` should be detected as a discriminator because
     // `Comment` is a direct variant of the `Post` tagged union.
@@ -2759,8 +2759,8 @@ fn test_transitive_dependency_field_matching_discriminator_is_not_discriminator(
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     // `Wrapper.kind` _is_ a discriminator, because `Wrapper` is a
     // direct variant of `Outer`.
@@ -2789,8 +2789,8 @@ fn test_transitive_dependency_field_matching_discriminator_is_not_discriminator(
 
 #[test]
 fn test_own_struct_discriminator_field() {
-    // A struct with its own `discriminator` property should mark that field
-    // as a discriminator.
+    // A struct used only inside a tagged union whose tag matches a field
+    // should mark that field as a discriminator.
     let doc = Document::from_yaml(indoc::indoc! {"
         openapi: 3.0.0
         info:
@@ -2807,11 +2807,18 @@ fn test_own_struct_discriminator_field() {
                   type: string
               discriminator:
                 propertyName: kind
+            Container:
+              oneOf:
+                - $ref: '#/components/schemas/Base'
+              discriminator:
+                propertyName: kind
+                mapping:
+                  base: '#/components/schemas/Base'
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let base = graph.schemas().find(|s| s.name() == "Base").unwrap();
     let SchemaIrTypeView::Struct(_, base_struct) = base else {
@@ -2835,8 +2842,8 @@ fn test_own_struct_discriminator_field() {
 
 #[test]
 fn test_inherited_discriminator_field() {
-    // A child struct that inherits from a parent with a discriminator should
-    // mark inherited fields with the same name as discriminators.
+    // A child struct that inherits a field matching the tag of an incoming
+    // tagged union should mark that inherited field as a discriminator.
     let doc = Document::from_yaml(indoc::indoc! {"
         openapi: 3.0.0
         info:
@@ -2857,11 +2864,18 @@ fn test_inherited_discriminator_field() {
               properties:
                 name:
                   type: string
+            Container:
+              oneOf:
+                - $ref: '#/components/schemas/Child'
+              discriminator:
+                propertyName: kind
+                mapping:
+                  child: '#/components/schemas/Child'
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let child = graph.schemas().find(|s| s.name() == "Child").unwrap();
     let SchemaIrTypeView::Struct(_, child_struct) = child else {
@@ -2912,8 +2926,8 @@ fn test_fields_linearizes_inline_all_of_parents() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let person = graph.schemas().find(|s| s.name() == "Person").unwrap();
     let SchemaIrTypeView::Struct(_, person_struct) = person else {
@@ -2989,8 +3003,8 @@ fn test_inline_tagged_view_construction() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let container_schema = graph.schemas().find(|s| s.name() == "Container").unwrap();
     let container_struct = match container_schema {
@@ -3052,8 +3066,8 @@ fn test_inline_tagged_view_variant_types() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let container_schema = graph.schemas().find(|s| s.name() == "Container").unwrap();
     let container_struct = match container_schema {
@@ -3116,8 +3130,8 @@ fn test_inlines_finds_inline_tagged_unions() {
     "})
     .unwrap();
 
-    let spec = IrSpec::from_doc(&doc).unwrap();
-    let graph = IrGraph::new(&spec);
+    let ir = Ir::from_doc(&doc).unwrap();
+    let graph = ir.graph().finalize();
 
     let container_schema = graph.schemas().find(|s| s.name() == "Container").unwrap();
 
@@ -3129,5 +3143,241 @@ fn test_inlines_finds_inline_tagged_unions() {
             InlineIrTypeView::Container(_, _),
             InlineIrTypeView::Tagged(_, _)
         ]
+    );
+}
+
+// MARK: Discriminator detection
+
+#[test]
+fn test_discriminator_false_for_standalone_struct() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test
+          version: 1.0.0
+        components:
+          schemas:
+            Dog:
+              type: object
+              properties:
+                kind:
+                  type: string
+                bark:
+                  type: string
+            Pet:
+              oneOf:
+                - $ref: '#/components/schemas/Dog'
+              discriminator:
+                propertyName: kind
+                mapping:
+                  dog: '#/components/schemas/Dog'
+            Owner:
+              type: object
+              properties:
+                dog:
+                  $ref: '#/components/schemas/Dog'
+    "})
+    .unwrap();
+
+    let ir = Ir::from_doc(&doc).unwrap();
+    let mut raw = ir.graph();
+    raw.lower_tagged_variants();
+    let graph = raw.finalize();
+
+    let dog = graph.schemas().find(|s| s.name() == "Dog").unwrap();
+    let SchemaIrTypeView::Struct(_, dog_struct) = dog else {
+        panic!("expected struct `Dog`; got `{dog:?}`");
+    };
+
+    // `Dog` is standalone (referenced by `Owner.dog`). After lowering,
+    // the tagged union no longer references `Dog` directly, so `kind`
+    // is not treated as a discriminator.
+    let kind_field = dog_struct
+        .fields()
+        .find(|f| matches!(f.name(), IrStructFieldName::Name("kind")))
+        .unwrap();
+    assert!(!kind_field.discriminator());
+}
+
+#[test]
+fn test_standalone_when_tagged_unions_disagree_on_discriminator() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test
+          version: 1.0.0
+        components:
+          schemas:
+            Dog:
+              type: object
+              properties:
+                kind:
+                  type: string
+                category:
+                  type: string
+                bark:
+                  type: string
+            ByKind:
+              oneOf:
+                - $ref: '#/components/schemas/Dog'
+              discriminator:
+                propertyName: kind
+                mapping:
+                  dog: '#/components/schemas/Dog'
+            ByCategory:
+              oneOf:
+                - $ref: '#/components/schemas/Dog'
+              discriminator:
+                propertyName: category
+                mapping:
+                  dog: '#/components/schemas/Dog'
+    "})
+    .unwrap();
+
+    let ir = Ir::from_doc(&doc).unwrap();
+    let mut raw = ir.graph();
+    raw.lower_tagged_variants();
+    let graph = raw.finalize();
+
+    // `Dog` is standalone because the two tagged unions disagree on
+    // their discriminator. The original struct keeps all fields.
+    let dog = graph.schemas().find(|s| s.name() == "Dog").unwrap();
+    let SchemaIrTypeView::Struct(_, dog_struct) = dog else {
+        panic!("expected struct `Dog`; got `{dog:?}`");
+    };
+    let field_names = dog_struct.fields().map(|f| f.name()).collect_vec();
+    assert_matches!(
+        &*field_names,
+        [
+            IrStructFieldName::Name("kind"),
+            IrStructFieldName::Name("category"),
+            IrStructFieldName::Name("bark"),
+        ]
+    );
+
+    // Each tagged union should have an inline variant with all
+    // fields present, but `discriminator()` true for the tag field.
+    let by_kind = graph.schemas().find(|s| s.name() == "ByKind").unwrap();
+    let SchemaIrTypeView::Tagged(_, by_kind_tagged) = by_kind else {
+        panic!("expected tagged `ByKind`; got `{by_kind:?}`");
+    };
+    let variant = by_kind_tagged.variants().next().unwrap();
+    let IrTypeView::Inline(InlineIrTypeView::Struct(_, inline_struct)) = variant.ty() else {
+        panic!("expected inline struct variant; got `{:?}`", variant.ty());
+    };
+    let inline_fields = inline_struct.fields().map(|f| f.name()).collect_vec();
+    assert_matches!(
+        &*inline_fields,
+        [
+            IrStructFieldName::Name("kind"),
+            IrStructFieldName::Name("category"),
+            IrStructFieldName::Name("bark"),
+        ]
+    );
+    let discriminators = inline_struct
+        .fields()
+        .filter(|f| f.discriminator())
+        .map(|f| f.name())
+        .collect_vec();
+    assert_matches!(&*discriminators, [IrStructFieldName::Name("kind")]);
+
+    let by_category = graph.schemas().find(|s| s.name() == "ByCategory").unwrap();
+    let SchemaIrTypeView::Tagged(_, by_category_tagged) = by_category else {
+        panic!("expected tagged `ByCategory`; got `{by_category:?}`");
+    };
+    let variant = by_category_tagged.variants().next().unwrap();
+    let IrTypeView::Inline(InlineIrTypeView::Struct(_, inline_struct)) = variant.ty() else {
+        panic!("expected inline struct variant; got `{:?}`", variant.ty());
+    };
+    let inline_fields = inline_struct.fields().map(|f| f.name()).collect_vec();
+    assert_matches!(
+        &*inline_fields,
+        [
+            IrStructFieldName::Name("kind"),
+            IrStructFieldName::Name("category"),
+            IrStructFieldName::Name("bark"),
+        ]
+    );
+    let discriminators = inline_struct
+        .fields()
+        .filter(|f| f.discriminator())
+        .map(|f| f.name())
+        .collect_vec();
+    assert_matches!(&*discriminators, [IrStructFieldName::Name("category")]);
+}
+
+#[test]
+fn test_standalone_variant_inline_field_types_not_leaked() {
+    // `Dog` is standalone (referenced by `Owner.dog`) and has an
+    // inline field type (`details`). After lowering, `Pet`'s
+    // `inlines()` should contain the inline variant struct for
+    // `Dog`, but NOT `Dog`'s inline `Details` type.
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test
+          version: 1.0.0
+        components:
+          schemas:
+            Dog:
+              type: object
+              properties:
+                kind:
+                  type: string
+                details:
+                  type: object
+                  properties:
+                    color:
+                      type: string
+            Pet:
+              oneOf:
+                - $ref: '#/components/schemas/Dog'
+              discriminator:
+                propertyName: kind
+                mapping:
+                  dog: '#/components/schemas/Dog'
+            Owner:
+              type: object
+              properties:
+                dog:
+                  $ref: '#/components/schemas/Dog'
+    "})
+    .unwrap();
+
+    let ir = Ir::from_doc(&doc).unwrap();
+    let mut raw = ir.graph();
+    raw.lower_tagged_variants();
+    let graph = raw.finalize();
+
+    let pet = graph.schemas().find(|s| s.name() == "Pet").unwrap();
+    let pet_inlines = pet.inlines().collect_vec();
+
+    // Only the inline variant struct for `Dog`, not `Dog`'s
+    // inline `Details` field type.
+    assert_matches!(&*pet_inlines, [InlineIrTypeView::Struct(..)]);
+    let InlineIrTypeView::Struct(path, _) = &pet_inlines[0] else {
+        unreachable!()
+    };
+    assert_matches!(path.root, InlineIrTypePathRoot::Type("Pet"));
+    assert_matches!(
+        &*path.segments,
+        [InlineIrTypePathSegment::TaggedVariant("Dog")]
+    );
+
+    // `Dog`'s own `inlines()` still contains its inline types
+    // (containers for optional fields, the `Details` struct, etc.).
+    let dog = graph.schemas().find(|s| s.name() == "Dog").unwrap();
+    let dog_inlines = dog.inlines().collect_vec();
+    assert!(
+        dog_inlines
+            .iter()
+            .any(|i| matches!(i, InlineIrTypeView::Struct(..))),
+        "expected `Dog` to have an inline struct (`Details`)"
+    );
+    assert!(
+        dog_inlines
+            .iter()
+            .all(|i| i.path().root == InlineIrTypePathRoot::Type("Dog")),
+        "all of `Dog`'s inlines should be rooted at `Dog`"
     );
 }

--- a/ploidy-core/src/ir/tests/views.rs
+++ b/ploidy-core/src/ir/tests/views.rs
@@ -1370,14 +1370,22 @@ fn test_nullable_view_provides_access_to_inner_type() {
         .find(|f| matches!(f.name(), IrStructFieldName::Name("nullable_field")))
         .unwrap();
 
-    // Verify the optional's inner type is accessible, and is an inline struct.
+    // The field is nullable + non-required, so it has two `Optional`
+    // layers: outer for absence, inner for nullability. The inner
+    // `Optional` wraps the inline struct.
+    let IrTypeView::Inline(InlineIrTypeView::Container(_, ContainerView::Optional(outer))) =
+        nullable_field.ty()
+    else {
+        panic!("expected outer Optional; got `{:?}`", nullable_field.ty());
+    };
+    let IrTypeView::Inline(InlineIrTypeView::Container(_, ContainerView::Optional(inner))) =
+        outer.ty()
+    else {
+        panic!("expected inner Optional; got `{:?}`", outer.ty());
+    };
     assert_matches!(
-        nullable_field.ty(),
-        IrTypeView::Inline(InlineIrTypeView::Container(_, ContainerView::Optional(inner)))
-            if matches!(
-                inner.ty(),
-                IrTypeView::Inline(InlineIrTypeView::Struct(_, _)),
-            ),
+        inner.ty(),
+        IrTypeView::Inline(InlineIrTypeView::Struct(_, _))
     );
 }
 

--- a/ploidy-core/src/ir/transform.rs
+++ b/ploidy-core/src/ir/transform.rs
@@ -319,11 +319,6 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
             description: self.schema.description.as_deref(),
             fields: all_fields,
             parents,
-            discriminator: self
-                .schema
-                .discriminator
-                .as_ref()
-                .map(|d| d.property_name.as_str()),
         };
 
         Ok(match self.name {
@@ -369,11 +364,6 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
             description: self.schema.description.as_deref(),
             fields,
             parents,
-            discriminator: self
-                .schema
-                .discriminator
-                .as_ref()
-                .map(|d| d.property_name.as_str()),
         };
         Ok(match self.name {
             IrTypeName::Schema(info) => SchemaIrType::Struct(info, ty).into(),

--- a/ploidy-core/src/ir/transform.rs
+++ b/ploidy-core/src/ir/transform.rs
@@ -689,10 +689,17 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
                     }
                     _ => false,
                 };
-                // Wrap the type in `Optional` if the field is either
-                // explicitly nullable, or implicitly optional. The `required`
-                // flag distinguishes between the two for codegen.
-                let ty = if nullable || !required {
+                // Wrap nullable and non-required fields in `Optional`.
+                //
+                // These are applied as two independent layers so that
+                // codegen backends can distinguish "absent" from "null":
+                // - Inner `Optional` = nullable (value can be `null`)
+                // - Outer `Optional` = non-required (field can be absent)
+                //
+                // OpenAPI 3.1 `type: [T, "null"]` already produces an
+                // inner `Optional` from `other()`, so the `nullable`
+                // wrap is skipped to avoid triple-wrapping.
+                let wrap_optional = |description, ty: IrType<'a>| -> IrType<'a> {
                     let path = match &self.name {
                         IrTypeName::Schema(info) => InlineIrTypePath {
                             root: InlineIrTypePathRoot::Type(info.name),
@@ -716,6 +723,23 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
                         }),
                     )
                     .into()
+                };
+                let is_already_optional = matches!(
+                    ty,
+                    IrType::Inline(InlineIrType::Container(_, Container::Optional(_)))
+                        | IrType::Schema(SchemaIrType::Container(_, Container::Optional(_)))
+                );
+                // The nullable layer carries the field description. If
+                // there's no nullable layer, the non-required layer
+                // carries it instead.
+                let (ty, desc_consumed) = if nullable && !is_already_optional {
+                    (wrap_optional(description, ty), true)
+                } else {
+                    (ty, false)
+                };
+                let ty = if !required {
+                    let desc = if desc_consumed { None } else { description };
+                    wrap_optional(desc, ty)
                 } else {
                     ty
                 };

--- a/ploidy-core/src/ir/types.rs
+++ b/ploidy-core/src/ir/types.rs
@@ -200,6 +200,10 @@ pub enum InlineIrTypePathSegment<'a> {
     ArrayItem,
     Variant(usize),
     Parent(usize),
+    /// An inline struct for a named variant of a tagged union,
+    /// with the tag field pre-stripped. Carries the referenced
+    /// schema name (not the discriminator value).
+    TaggedVariant(&'a str),
 }
 
 /// An enum type.
@@ -224,8 +228,6 @@ pub struct IrStruct<'a> {
     pub fields: Vec<IrStructField<'a>>,
     /// Immediate parent types from `allOf`, in declaration order.
     pub parents: Vec<IrType<'a>>,
-    /// The discriminator property name, if this struct defines one.
-    pub discriminator: Option<&'a str>,
 }
 
 /// A field in a struct.

--- a/ploidy-core/src/ir/views/container.rs
+++ b/ploidy-core/src/ir/views/container.rs
@@ -73,7 +73,7 @@ impl<'a> ContainerView<'a> {
         index: NodeIndex<usize>,
         container: &'a Container<'a>,
     ) -> Self {
-        let node = IrGraphNode::from_ref(graph.spec(), container.inner().ty.as_ref().as_ref());
+        let node = graph.resolve_type(container.inner().ty.as_ref().as_ref());
         let inner = InnerView {
             graph,
             container: index,

--- a/ploidy-core/src/ir/views/operation.rs
+++ b/ploidy-core/src/ir/views/operation.rs
@@ -67,7 +67,7 @@ impl<'a> IrOperationView<'a> {
     pub fn request(&self) -> Option<IrRequestView<'a>> {
         self.op.request.as_ref().map(|ty| match ty {
             IrRequest::Json(ty) => {
-                let node = IrGraphNode::from_ref(self.graph.spec, ty.as_ref());
+                let node = self.graph.resolve_type(ty.as_ref());
                 IrRequestView::Json(IrTypeView::new(self.graph, self.graph.indices[&node]))
             }
             IrRequest::Multipart => IrRequestView::Multipart,
@@ -79,7 +79,7 @@ impl<'a> IrOperationView<'a> {
     pub fn response(&self) -> Option<IrResponseView<'a>> {
         self.op.response.as_ref().map(|ty| match ty {
             IrResponse::Json(ty) => {
-                let node = IrGraphNode::from_ref(self.graph.spec, ty.as_ref());
+                let node = self.graph.resolve_type(ty.as_ref());
                 IrResponseView::Json(IrTypeView::new(self.graph, self.graph.indices[&node]))
             }
         })
@@ -239,7 +239,7 @@ impl<'a, T> IrParameterView<'a, T> {
     #[inline]
     pub fn ty(&self) -> IrTypeView<'a> {
         let graph = self.graph;
-        let node = IrGraphNode::from_ref(graph.spec, self.info.ty.as_ref());
+        let node = graph.resolve_type(self.info.ty.as_ref());
         IrTypeView::new(graph, graph.indices[&node])
     }
 

--- a/ploidy-core/src/ir/views/tagged.rs
+++ b/ploidy-core/src/ir/views/tagged.rs
@@ -1,7 +1,7 @@
 use petgraph::graph::NodeIndex;
 
 use crate::ir::{
-    graph::{IrGraph, IrGraphNode},
+    graph::IrGraph,
     types::{IrTagged, IrTaggedVariant},
 };
 
@@ -37,7 +37,7 @@ impl<'a> IrTaggedView<'a> {
     /// Returns an iterator over this tagged union's variants.
     pub fn variants(&self) -> impl Iterator<Item = IrTaggedVariantView<'a>> {
         self.ty.variants.iter().map(move |variant| {
-            let node = IrGraphNode::from_ref(self.graph.spec, variant.ty.as_ref());
+            let node = self.graph.resolve_type(variant.ty.as_ref());
             IrTaggedVariantView::new(self.graph, self.graph.indices[&node], variant)
         })
     }
@@ -88,7 +88,7 @@ impl<'a> IrTaggedVariantView<'a> {
 
     /// Returns a view of this variant's type.
     pub fn ty(&self) -> IrTypeView<'a> {
-        let node = IrGraphNode::from_ref(self.graph.spec, self.variant.ty.as_ref());
+        let node = self.graph.resolve_type(self.variant.ty.as_ref());
         IrTypeView::new(self.graph, self.graph.indices[&node])
     }
 }

--- a/ploidy-core/src/ir/views/untagged.rs
+++ b/ploidy-core/src/ir/views/untagged.rs
@@ -2,7 +2,7 @@ use petgraph::graph::NodeIndex;
 
 use crate::ir::{
     IrUntaggedVariantNameHint,
-    graph::{IrGraph, IrGraphNode},
+    graph::IrGraph,
     types::{IrUntagged, IrUntaggedVariant},
 };
 
@@ -66,7 +66,7 @@ impl<'view, 'a> IrUntaggedVariantView<'view, 'a> {
     pub fn ty(&self) -> Option<SomeIrUntaggedVariant<'a>> {
         match self.variant {
             IrUntaggedVariant::Some(hint, ty) => {
-                let node = IrGraphNode::from_ref(self.parent.graph.spec, ty.as_ref());
+                let node = self.parent.graph.resolve_type(ty.as_ref());
                 Some(SomeIrUntaggedVariant {
                     hint: *hint,
                     view: IrTypeView::new(self.parent.graph, self.parent.graph.indices[&node]),

--- a/ploidy/Cargo.toml
+++ b/ploidy/Cargo.toml
@@ -16,6 +16,7 @@ itertools = "0.14"
 miette = { version = "7", features = ["fancy"] }
 mimalloc = { version = "0.1", optional = true }
 ploidy-codegen-rust = { workspace = true }
+ploidy-codegen-typescript = { workspace = true }
 ploidy-core = { workspace = true }
 semver = "1"
 

--- a/ploidy/src/config.rs
+++ b/ploidy/src/config.rs
@@ -46,7 +46,8 @@ pub struct CodegenCommand {
 
 #[derive(Debug)]
 pub enum CodegenCommandLanguage {
-    Rust(RustCodegenCommand),
+    Rust(Box<RustCodegenCommand>),
+    TypeScript,
 }
 
 #[derive(Debug)]
@@ -117,10 +118,10 @@ impl CodegenCommandArgs {
                             })?;
                             package.version.set(bump_version(&base, bump).to_string());
                         }
-                        CodegenCommandLanguage::Rust(RustCodegenCommand {
+                        CodegenCommandLanguage::Rust(Box::new(RustCodegenCommand {
                             manifest,
                             check: args.check,
-                        })
+                        }))
                     }
                     Err(cargo_toml::Error::Io(err)) if err.kind() == IoErrorKind::NotFound => {
                         let name = args
@@ -142,10 +143,10 @@ impl CodegenCommandArgs {
                             package: Some(Package::new(name, DEFAULT_VERSION.to_string())),
                             ..Default::default()
                         };
-                        CodegenCommandLanguage::Rust(RustCodegenCommand {
+                        CodegenCommandLanguage::Rust(Box::new(RustCodegenCommand {
                             manifest,
                             check: args.check,
-                        })
+                        }))
                     }
                     Err(err) => {
                         return Err(ClapError::raw(
@@ -155,6 +156,7 @@ impl CodegenCommandArgs {
                     }
                 }
             }
+            CodegenCommandLanguageArgs::TypeScript => CodegenCommandLanguage::TypeScript,
         };
         Ok(CodegenCommand {
             input: self.input,
@@ -168,6 +170,9 @@ impl CodegenCommandArgs {
 enum CodegenCommandLanguageArgs {
     /// Generate a Rust package.
     Rust(RustCodegenCommandArgs),
+    /// Generate TypeScript type declarations.
+    #[clap(name = "typescript", alias = "ts")]
+    TypeScript,
 }
 
 #[derive(Debug, Default, clap::Args)]

--- a/ploidy/src/main.rs
+++ b/ploidy/src/main.rs
@@ -1,6 +1,6 @@
 use itertools::Itertools;
 use miette::{Context, IntoDiagnostic, Result};
-use ploidy_codegen_rust::{CodegenCargoManifest, CodegenErrorModule, CodegenGraph, CodegenLibrary};
+use ploidy_codegen_rust::{CodegenCargoManifest, CodegenErrorModule, CodegenLibrary};
 use ploidy_core::{codegen::write_to_disk, ir::Ir, parse::Document};
 
 mod config;
@@ -41,8 +41,8 @@ fn main() -> Result<()> {
             let graph = {
                 let graph = raw.finalize();
                 match config {
-                    Some(config) => CodegenGraph::with_config(graph, config),
-                    None => CodegenGraph::new(graph),
+                    Some(config) => ploidy_codegen_rust::CodegenGraph::with_config(graph, config),
+                    None => ploidy_codegen_rust::CodegenGraph::new(graph),
                 }
             };
 
@@ -89,6 +89,34 @@ fn main() -> Result<()> {
                     miette::bail!("`cargo check` exited with status {status}");
                 }
             }
+        }
+        Command::Codegen(CodegenCommand {
+            input,
+            output,
+            language: CodegenCommandLanguage::TypeScript,
+        }) => {
+            let source = std::fs::read_to_string(&input)
+                .into_diagnostic()
+                .with_context(|| format!("Failed to read `{}`", input.display()))?;
+
+            let doc = Document::from_yaml(&source)
+                .into_diagnostic()
+                .context("Failed to parse OpenAPI document")?;
+
+            println!("OpenAPI: {} (version {})", doc.info.title, doc.info.version);
+
+            let ir = Ir::from_doc(&doc).into_diagnostic()?;
+            let mut raw = ir.graph();
+            raw.lower_tagged_variants();
+            let graph = ploidy_codegen_typescript::CodegenGraph::new(raw.finalize());
+
+            println!("Writing generated code to `{}`...", output.display());
+            println!("Generating {} types...", graph.schemas().count());
+            ploidy_codegen_typescript::write_types_to_disk(&output, &graph)?;
+
+            ploidy_codegen_typescript::write_client_to_disk(&output, &graph)?;
+
+            println!("Generation complete");
         }
     }
 


### PR DESCRIPTION
An early draft—less rough than Python, but still early—adding TypeScript generation to Ploidy. We use the SWC ecosystem to emit TypeScript, and [Quasiquodo](https://github.com/linabutler/quasiquodo/) to write inline TypeScript.

One related fix that we'll want to merge separately, so that Python and Rust can take advantage of it, too: handling inherited and diverging discriminators. The case here is: we have a vanilla interface type (`type: object`) that's included in two different unions (with `oneOf`), and those unions have different discriminators. Since we emit discriminators as anonymous intersection types, they shouldn't be present in the object..._but_, only the discriminator that corresponds to the `oneOf` should be omitted. The Python branch has a clunkier workaround for this.

(In TypeScript and Python, we can actually just include the discriminator inline; but in Rust, a variant of a Serde tagged enum _can't_ include the discriminator).