### PR TITLE
Add Python code generation.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,6 +86,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,6 +102,36 @@ name = "atomic_refcell"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41e67cd8309bbd06cd603a9e693a784ac2e5d1e955f11286e355089fcab3047c"
+
+[[package]]
+name = "attribute-derive"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05832cdddc8f2650cc2cc187cc2e952b8c133a48eb055f35211f61ee81502d77"
+dependencies = [
+ "attribute-derive-macro",
+ "derive-where",
+ "manyhow",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "attribute-derive-macro"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7cdbbd4bd005c5d3e2e9c885e6fa575db4f4a3572335b974d8db853b6beb61"
+dependencies = [
+ "collection_literals",
+ "interpolator",
+ "manyhow",
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
+ "quote-use",
+ "syn",
+]
 
 [[package]]
 name = "autocfg"
@@ -131,6 +176,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -159,6 +215,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,9 +247,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -196,9 +261,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.56"
+version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75ca66430e33a14957acc24c5077b503e7d374151b2b4b3a10c83b4ceb4be0e"
+checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -206,9 +271,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.56"
+version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793207c7fa6300a0608d1080b858e5fdbe713cdc1c8db9fb17777d8a13e63df0"
+checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
 dependencies = [
  "anstream",
  "anstyle",
@@ -218,9 +283,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -235,16 +300,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
+name = "collection_literals"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2550f75b8cfac212855f6b1885455df8eaee8fe8e246b647d69146142e016084"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "compact_str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "derive-where"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef941ded77d15ca19b40374869ac6000af1c9f2a4c0f3d4c70926287e6364a8f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "diff"
@@ -340,41 +436,74 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-task",
  "pin-project-lite",
- "pin-utils",
+ "slab",
+]
+
+[[package]]
+name = "get-size-derive2"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab21d7bd2c625f2064f04ce54bcb88bc57c45724cde45cba326d784e22d3f71a"
+dependencies = [
+ "attribute-derive",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "get-size2"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879272b0de109e2b67b39fcfe3d25fdbba96ac07e44a254f5a0b4d7ff55340cb"
+dependencies = [
+ "compact_str",
+ "get-size-derive2",
+ "hashbrown 0.16.1",
+ "ordermap",
+ "smallvec",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -402,6 +531,19 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -530,14 +672,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "base64",
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "http",
  "http-body",
@@ -658,6 +799,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -700,6 +847,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "interpolator"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71dd52191aae121e8611f1e8dc3e324dd0dd1dee1e6dd91d10ee07a3cfb4d9d8"
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -713,6 +866,18 @@ checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "is-macro"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57a3e447e24c22647738e4607f1df1e0ec6f72e16182c4cd199f647cdfb0e4"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -753,6 +918,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -787,10 +958,71 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "logos"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2c55a318a87600ea870ff8c2012148b44bf18b74fad48d0f835c38c7d07c5f"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58b3ffaa284e1350d017a57d04ada118c4583cf260c8fb01e0fe28a2e9cf8970"
+dependencies = [
+ "fnv",
+ "proc-macro2",
+ "quote",
+ "regex-automata",
+ "regex-syntax",
+ "syn",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d3a9855747c17eaf4383823f135220716ab49bea5fbea7dd42cc9a92f8aa31"
+dependencies = [
+ "logos-codegen",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "manyhow"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b33efb3ca6d3b07393750d4030418d594ab1139cee518f0dc88db70fec873587"
+dependencies = [
+ "manyhow-macros",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "manyhow-macros"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46fce34d199b78b6e6073abf984c9cf5fd3e9330145a93ee0738a7443e371495"
+dependencies = [
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "matches"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "memchr"
@@ -904,6 +1136,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "ordermap"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfa78c92071bbd3628c22b1a964f7e0eb201dc1456555db072beb1662ecd6715"
+dependencies = [
+ "indexmap",
+]
+
+[[package]]
 name = "owo-colors"
 version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -928,10 +1169,48 @@ dependencies = [
 ]
 
 [[package]]
-name = "pin-project-lite"
-version = "0.2.16"
+name = "phf"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -948,9 +1227,29 @@ dependencies = [
  "itertools",
  "miette",
  "mimalloc",
+ "ploidy-codegen-python",
  "ploidy-codegen-rust",
  "ploidy-core",
  "semver",
+]
+
+[[package]]
+name = "ploidy-codegen-python"
+version = "0.9.0"
+dependencies = [
+ "heck",
+ "indoc",
+ "itertools",
+ "miette",
+ "ploidy-core",
+ "pretty_assertions",
+ "quasiquodo-py",
+ "ref-cast",
+ "ruff_python_codegen",
+ "ruff_source_file",
+ "textwrap",
+ "thiserror",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1094,12 +1393,60 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.106"
+name = "proc-macro-utils"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "eeaf08a13de400bc215877b5bdc088f241b12eb42f0a548d3390dc1c56bb7071"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "smallvec",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quasiquodo-py"
+version = "0.4.1"
+source = "git+https://github.com/linabutler/quasiquodo?rev=55e23bac85f7f7c09e9275f0181a3399b2a97063#55e23bac85f7f7c09e9275f0181a3399b2a97063"
+dependencies = [
+ "quasiquodo-py-macros",
+ "ruff_python_ast",
+ "ruff_python_stdlib",
+ "ruff_text_size",
+]
+
+[[package]]
+name = "quasiquodo-py-core"
+version = "0.4.1"
+source = "git+https://github.com/linabutler/quasiquodo?rev=55e23bac85f7f7c09e9275f0181a3399b2a97063#55e23bac85f7f7c09e9275f0181a3399b2a97063"
+dependencies = [
+ "logos",
+ "proc-macro2",
+ "quote",
+ "ruff_python_ast",
+ "ruff_python_parser",
+ "ruff_text_size",
+ "syn",
+ "thiserror",
+ "unicode-ident",
+ "unindent",
+ "winnow",
+]
+
+[[package]]
+name = "quasiquodo-py-macros"
+version = "0.4.1"
+source = "git+https://github.com/linabutler/quasiquodo?rev=55e23bac85f7f7c09e9275f0181a3399b2a97063#55e23bac85f7f7c09e9275f0181a3399b2a97063"
+dependencies = [
+ "quasiquodo-py-core",
 ]
 
 [[package]]
@@ -1131,7 +1478,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1159,11 +1506,33 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "quote-use"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9619db1197b497a36178cfc736dc96b271fe918875fbf1344c436a7e93d0321e"
+dependencies = [
+ "quote",
+ "quote-use-macros",
+]
+
+[[package]]
+name = "quote-use-macros"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82ebfb7faafadc06a7ab141a6f67bcfb24cb8beb158c6fe933f2f035afa99f35"
+dependencies = [
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1174,12 +1543,33 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1189,7 +1579,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1220,6 +1619,23 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -1277,6 +1693,104 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruff_python_ast"
+version = "0.0.0"
+source = "git+https://github.com/astral-sh/ruff?tag=0.15.4#f14edd8661e2803254f89265548c7487f47a09f6"
+dependencies = [
+ "aho-corasick",
+ "bitflags",
+ "compact_str",
+ "get-size2",
+ "is-macro",
+ "memchr",
+ "ruff_python_trivia",
+ "ruff_source_file",
+ "ruff_text_size",
+ "rustc-hash",
+ "thiserror",
+]
+
+[[package]]
+name = "ruff_python_codegen"
+version = "0.0.0"
+source = "git+https://github.com/astral-sh/ruff?tag=0.15.4#f14edd8661e2803254f89265548c7487f47a09f6"
+dependencies = [
+ "ruff_python_ast",
+ "ruff_python_literal",
+ "ruff_python_parser",
+ "ruff_source_file",
+ "ruff_text_size",
+]
+
+[[package]]
+name = "ruff_python_literal"
+version = "0.0.0"
+source = "git+https://github.com/astral-sh/ruff?tag=0.15.4#f14edd8661e2803254f89265548c7487f47a09f6"
+dependencies = [
+ "bitflags",
+ "itertools",
+ "ruff_python_ast",
+ "unic-ucd-category",
+]
+
+[[package]]
+name = "ruff_python_parser"
+version = "0.0.0"
+source = "git+https://github.com/astral-sh/ruff?tag=0.15.4#f14edd8661e2803254f89265548c7487f47a09f6"
+dependencies = [
+ "bitflags",
+ "bstr",
+ "compact_str",
+ "get-size2",
+ "memchr",
+ "ruff_python_ast",
+ "ruff_python_trivia",
+ "ruff_text_size",
+ "rustc-hash",
+ "static_assertions",
+ "unicode-ident",
+ "unicode-normalization",
+ "unicode_names2",
+]
+
+[[package]]
+name = "ruff_python_stdlib"
+version = "0.0.0"
+source = "git+https://github.com/astral-sh/ruff?tag=0.15.4#f14edd8661e2803254f89265548c7487f47a09f6"
+dependencies = [
+ "bitflags",
+ "unicode-ident",
+]
+
+[[package]]
+name = "ruff_python_trivia"
+version = "0.0.0"
+source = "git+https://github.com/astral-sh/ruff?tag=0.15.4#f14edd8661e2803254f89265548c7487f47a09f6"
+dependencies = [
+ "itertools",
+ "ruff_source_file",
+ "ruff_text_size",
+ "unicode-ident",
+]
+
+[[package]]
+name = "ruff_source_file"
+version = "0.0.0"
+source = "git+https://github.com/astral-sh/ruff?tag=0.15.4#f14edd8661e2803254f89265548c7487f47a09f6"
+dependencies = [
+ "memchr",
+ "ruff_text_size",
+]
+
+[[package]]
+name = "ruff_text_size"
+version = "0.0.0"
+source = "git+https://github.com/astral-sh/ruff?tag=0.15.4#f14edd8661e2803254f89265548c7487f47a09f6"
+dependencies = [
+ "get-size2",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1303,9 +1817,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "once_cell",
  "ring",
@@ -1460,6 +1974,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1486,6 +2006,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -1573,18 +2099,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1763,6 +2289,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "unic-char-property"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8c57a407d9b6fa02b4795eb81c5b6652060a15a7903ea981f3d723e6c0be221"
+dependencies = [
+ "unic-char-range",
+]
+
+[[package]]
+name = "unic-char-range"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0398022d5f700414f6b899e10b8348231abf9173fa93144cbc1a43b9793c1fbc"
+
+[[package]]
+name = "unic-common"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d7ff825a6a654ee85a63e80f92f054f904f21e7d12da4e22f9834a4aaa35bc"
+
+[[package]]
+name = "unic-ucd-category"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8d4591f5fcfe1bd4453baaf803c40e1b1e69ff8455c47620440b46efef91c0"
+dependencies = [
+ "matches",
+ "unic-char-property",
+ "unic-char-range",
+ "unic-ucd-version",
+]
+
+[[package]]
+name = "unic-ucd-version"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
+dependencies = [
+ "unic-common",
+]
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1781,6 +2349,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1791,6 +2368,40 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unicode_names2"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1673eca9782c84de5f81b82e4109dcfb3611c8ba0d52930ec4a9478f547b2dd"
+dependencies = [
+ "phf",
+ "unicode_names2_generator",
+]
+
+[[package]]
+name = "unicode_names2_generator"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91e5b84611016120197efd7dc93ef76774f4e084cd73c9fb3ea4a86c570c56e"
+dependencies = [
+ "getopts",
+ "log",
+ "phf_codegen",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "unindent"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -1831,11 +2442,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.20.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
+checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -1861,6 +2472,15 @@ name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
@@ -1924,6 +2544,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1945,9 +2599,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -2181,6 +2835,88 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
@@ -2219,18 +2955,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.37"
+version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7456cf00f0685ad319c5b1693f291a650eaf345e941d082fc4e03df8a03996ac"
+checksum = "668f5168d10b9ee831de31933dc111a459c97ec93225beb307aed970d1372dfd"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.37"
+version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1328722bbf2115db7e19d69ebcc15e795719e2d66b60827c6a69a117365e37a0"
+checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "ploidy",
+    "ploidy-codegen-python",
     "ploidy-codegen-rust",
     "ploidy-core",
     "ploidy-pointer",
@@ -20,6 +21,11 @@ rust-version = "1.89"
 [workspace.dependencies]
 either = "1"
 indoc = "2"
+petgraph = "0.8"
+quasiquodo-py = { git = "https://github.com/linabutler/quasiquodo", rev = "55e23bac85f7f7c09e9275f0181a3399b2a97063" }
+ruff_python_codegen = { git = "https://github.com/astral-sh/ruff", tag = "0.15.4" }
+ruff_source_file = { git = "https://github.com/astral-sh/ruff", tag = "0.15.4" }
+ploidy-codegen-python = { path = "ploidy-codegen-python", version = "0.9.0" }
 ploidy-codegen-rust = { path = "ploidy-codegen-rust", version = "0.9.0" }
 ploidy-core = { path = "ploidy-core", version = "0.9.0" }
 ploidy-pointer = { path = "ploidy-pointer", version = "0.9.0" }

--- a/openapi-pretty.json
+++ b/openapi-pretty.json
@@ -1,0 +1,631 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "Claims Review API",
+        "version": "1.0.0",
+        "description": "API for managing claims review workflow with state machine transitions"
+    },
+    "paths": {
+        "/cases/{id}/available-transitions": {
+            "get": {
+                "summary": "Get available transitions for a case",
+                "description": "Returns the list of valid actions that can be performed on a case from its current state.",
+                "operationId": "get_available_transitions",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "The case UUID [example: 550e8400-e29b-41d4-a716-446655440000]",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Available transitions (AvailableTransitionsResponse)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AvailableTransitionsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Case not found (ErrorResponse)"
+                    },
+                    "500": {
+                        "description": "Internal server error (ErrorResponse)"
+                    }
+                }
+            }
+        },
+        "/cases/{id}/transition": {
+            "post": {
+                "summary": "Transition a case to a new state",
+                "description": "Applies a state transition to a case. The transition must be valid for the case's current state. See the TransitionRequest schema for available actions and their required data.",
+                "operationId": "transition_case",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "The case UUID [example: 550e8400-e29b-41d4-a716-446655440000]",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "description": "Request body",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/TransitionRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Transition applied successfully (TransitionResponse)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TransitionResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error (ErrorResponse)"
+                    },
+                    "400": {
+                        "description": "Invalid transition for current state (ErrorResponse)"
+                    },
+                    "404": {
+                        "description": "Case not found (ErrorResponse)"
+                    }
+                }
+            }
+        },
+        "/cases/{id}/history": {
+            "get": {
+                "summary": "Get transition history for a case",
+                "description": "Returns the complete audit trail of state transitions for a case in chronological order.",
+                "operationId": "get_case_history",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "The case UUID [example: 550e8400-e29b-41d4-a716-446655440000]",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Transition history (TransitionHistoryResponse)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TransitionHistoryResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error (ErrorResponse)"
+                    },
+                    "404": {
+                        "description": "Case not found (ErrorResponse)"
+                    }
+                }
+            }
+        },
+        "/cases/{id}": {
+            "get": {
+                "summary": "Get a case by ID",
+                "description": "Retrieves detailed information about a specific case.",
+                "operationId": "get_case",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "The case UUID [example: 550e8400-e29b-41d4-a716-446655440000]",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ],
+                "responses": {
+                    "404": {
+                        "description": "Case not found (ErrorResponse)"
+                    },
+                    "500": {
+                        "description": "Internal server error (ErrorResponse)"
+                    },
+                    "200": {
+                        "description": "Successfully retrieved case (Case)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CaseData"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete a case",
+                "description": "Permanently deletes a case and its transition history.",
+                "operationId": "delete_case",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "The case UUID [example: 550e8400-e29b-41d4-a716-446655440000]",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Case deleted successfully"
+                    },
+                    "404": {
+                        "description": "Case not found (ErrorResponse)"
+                    },
+                    "500": {
+                        "description": "Internal server error (ErrorResponse)"
+                    }
+                }
+            }
+        },
+        "/cases": {
+            "get": {
+                "summary": "List all cases",
+                "description": "Returns a paginated list of cases with optional filtering by state and assigned analyst.",
+                "operationId": "list_cases",
+                "parameters": [
+                    {
+                        "name": "state",
+                        "in": "query",
+                        "description": "Filter by case state",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "assigned_to",
+                        "in": "query",
+                        "description": "Filter by assigned analyst ID",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Maximum results to return [default: 50]",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "offset",
+                        "in": "query",
+                        "description": "Pagination offset [default: 0]",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "500": {
+                        "description": "Internal server error (ErrorResponse)"
+                    },
+                    "200": {
+                        "description": "Successfully retrieved case list (CaseListResponse)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CaseData"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "summary": "Create a new case",
+                "description": "Creates a new review case with the specified claim amount. The case starts in the \"new\" state.",
+                "operationId": "create_case",
+                "requestBody": {
+                    "description": "Request body",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateCaseRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "400": {
+                        "description": "Validation error (ErrorResponse)"
+                    },
+                    "201": {
+                        "description": "Case created successfully (Case)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CaseData"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error (ErrorResponse)"
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "CaseData": {
+                "type": "object",
+                "properties": {
+                    "assigned_to": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "claim_amount": {
+                        "type": "string",
+                        "description": "Decimal number as string for precision",
+                        "example": 1500.0
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "state": {
+                        "$ref": "#/components/schemas/CaseState"
+                    },
+                    "name": {
+                        "type": "string",
+                        "example": "Smith Medical Claim"
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid"
+                    }
+                },
+                "required": [
+                    "id",
+                    "name",
+                    "state",
+                    "claim_amount",
+                    "created_at",
+                    "updated_at"
+                ]
+            },
+            "CloseData": {
+                "type": "object",
+                "properties": {
+                    "resolution_notes": {
+                        "type": "string"
+                    }
+                }
+            },
+            "TransitionRequest": {
+                "type": "object",
+                "oneOf": [
+                    {
+                        "$ref": "#/components/schemas/AssignData"
+                    },
+                    {
+                        "$ref": "#/components/schemas/RequestInfoData"
+                    },
+                    {
+                        "$ref": "#/components/schemas/InfoReceivedData"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ApproveData"
+                    },
+                    {
+                        "$ref": "#/components/schemas/DenyData"
+                    },
+                    {
+                        "$ref": "#/components/schemas/UpdateAmountData"
+                    },
+                    {
+                        "$ref": "#/components/schemas/AppealData"
+                    },
+                    {
+                        "$ref": "#/components/schemas/CloseData"
+                    }
+                ],
+                "discriminator": {
+                    "propertyName": "action",
+                    "mapping": {
+                        "request_info": "#/components/schemas/RequestInfoData",
+                        "close": "#/components/schemas/CloseData",
+                        "appeal": "#/components/schemas/AppealData",
+                        "assign": "#/components/schemas/AssignData",
+                        "info_received": "#/components/schemas/InfoReceivedData",
+                        "deny": "#/components/schemas/DenyData",
+                        "approve": "#/components/schemas/ApproveData",
+                        "update_amount": "#/components/schemas/UpdateAmountData"
+                    }
+                }
+            },
+            "RequestInfoData": {
+                "type": "object",
+                "properties": {
+                    "due_date": {
+                        "type": "string",
+                        "example": "2025-03-01",
+                        "format": "date"
+                    },
+                    "info_needed": {
+                        "type": "string",
+                        "example": "Please provide itemized receipts"
+                    }
+                },
+                "required": [
+                    "info_needed",
+                    "due_date"
+                ]
+            },
+            "TransitionResponse": {
+                "type": "object",
+                "properties": {
+                    "from_state": {
+                        "$ref": "#/components/schemas/CaseState"
+                    },
+                    "to_state": {
+                        "$ref": "#/components/schemas/CaseState"
+                    },
+                    "case": {
+                        "$ref": "#/components/schemas/CaseData"
+                    }
+                },
+                "required": [
+                    "case",
+                    "from_state",
+                    "to_state"
+                ]
+            },
+            "UpdateAmountData": {
+                "type": "object",
+                "properties": {
+                    "justification": {
+                        "type": "string",
+                        "example": "Additional damage discovered"
+                    },
+                    "new_amount": {
+                        "type": "string",
+                        "description": "Decimal number as string for precision",
+                        "example": 1800.0
+                    }
+                },
+                "required": [
+                    "new_amount",
+                    "justification"
+                ]
+            },
+            "AppealData": {
+                "type": "object",
+                "properties": {
+                    "appeal_reason": {
+                        "type": "string",
+                        "example": "New evidence available"
+                    }
+                },
+                "required": [
+                    "appeal_reason"
+                ]
+            },
+            "AvailableTransitionsResponse": {
+                "type": "object",
+                "properties": {
+                    "current_state": {
+                        "$ref": "#/components/schemas/CaseState"
+                    },
+                    "available_actions": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "required": [
+                    "current_state",
+                    "available_actions"
+                ]
+            },
+            "ApproveData": {
+                "type": "object",
+                "properties": {
+                    "approved_amount": {
+                        "type": "string",
+                        "description": "Decimal number as string for precision",
+                        "example": 1200.0
+                    },
+                    "notes": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "approved_amount"
+                ]
+            },
+            "InfoReceivedData": {
+                "type": "object",
+                "properties": {
+                    "notes": {
+                        "type": "string"
+                    }
+                }
+            },
+            "CaseState": {
+                "type": "string",
+                "enum": [
+                    "new",
+                    "under_review",
+                    "pending_information",
+                    "approved",
+                    "denied",
+                    "appealed",
+                    "closed"
+                ]
+            },
+            "AssignData": {
+                "type": "object",
+                "properties": {
+                    "analyst_id": {
+                        "type": "string",
+                        "example": "550e8400-e29b-41d4-a716-446655440000",
+                        "format": "uuid"
+                    }
+                },
+                "required": [
+                    "analyst_id"
+                ]
+            },
+            "DenyData": {
+                "type": "object",
+                "properties": {
+                    "reason": {
+                        "type": "string",
+                        "example": "Claim exceeds policy limits"
+                    }
+                },
+                "required": [
+                    "reason"
+                ]
+            },
+            "StateTransition": {
+                "type": "object",
+                "properties": {
+                    "from_state": {
+                        "$ref": "#/components/schemas/CaseState"
+                    },
+                    "case_id": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "action": {
+                        "type": "string",
+                        "example": "approve"
+                    },
+                    "performed_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "to_state": {
+                        "$ref": "#/components/schemas/CaseState"
+                    },
+                    "metadata": {
+                        "type": "object",
+                        "description": "JSON object",
+                        "additionalProperties": true
+                    },
+                    "performed_by": {
+                        "type": "string",
+                        "format": "uuid"
+                    }
+                },
+                "required": [
+                    "id",
+                    "case_id",
+                    "from_state",
+                    "to_state",
+                    "action",
+                    "performed_by",
+                    "performed_at"
+                ]
+            },
+            "TransitionHistoryResponse": {
+                "type": "object",
+                "properties": {
+                    "case_id": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "transitions": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/StateTransition"
+                        }
+                    }
+                },
+                "required": [
+                    "case_id",
+                    "transitions"
+                ]
+            },
+            "CreateCaseRequest": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "example": "Smith Medical Claim"
+                    },
+                    "claim_amount": {
+                        "type": "string",
+                        "description": "Decimal number as string for precision",
+                        "example": 1500.0
+                    }
+                },
+                "required": [
+                    "name",
+                    "claim_amount"
+                ]
+            }
+        }
+    },
+    "tags": [
+        {
+            "name": "cases",
+            "description": "Case management operations"
+        },
+        {
+            "name": "transitions",
+            "description": "State transition operations"
+        },
+        {
+            "name": "history",
+            "description": "Audit trail operations"
+        }
+    ]
+}

--- a/ploidy-codegen-python/Cargo.toml
+++ b/ploidy-codegen-python/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "ploidy-codegen-python"
+description = "A Ploidy generator that emits Python code using Pydantic models"
+readme = "README.md"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
+keywords.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+heck = "0.5"
+itertools = "0.14"
+miette = "7"
+ploidy-core = { workspace = true }
+quasiquodo-py = { workspace = true }
+ref-cast = { workspace = true }
+ruff_python_codegen = { workspace = true }
+ruff_source_file = { workspace = true }
+textwrap = { version = "0.16", default-features = false, features = [
+    "unicode-linebreak",
+    "unicode-width",
+] }
+thiserror = "2"
+unicode-ident = "1"
+
+[dev-dependencies]
+indoc = { workspace = true }
+pretty_assertions = { workspace = true }
+
+[lints]
+workspace = true

--- a/ploidy-codegen-python/src/enum_.rs
+++ b/ploidy-codegen-python/src/enum_.rs
@@ -1,0 +1,331 @@
+//! Python enum generation from IR enums.
+
+use std::collections::BTreeSet;
+
+use ploidy_core::ir::{IrEnumVariant, IrEnumView};
+use quasiquodo_py::{
+    py_quote,
+    ruff::{
+        python_ast::{Identifier, Suite},
+        text_size::TextRange,
+    },
+};
+
+use super::naming::{CodegenIdent, CodegenIdentUsage, CodegenTypeName};
+
+/// Generates a Python `Enum` class from an IR enum.
+#[derive(Clone, Debug)]
+pub struct CodegenEnum<'a> {
+    name: CodegenTypeName<'a>,
+    ty: &'a IrEnumView<'a>,
+}
+
+impl<'a> CodegenEnum<'a> {
+    pub fn new(name: CodegenTypeName<'a>, ty: &'a IrEnumView<'a>) -> Self {
+        Self { name, ty }
+    }
+
+    /// Generates the enum definition.
+    pub fn to_suite(&self) -> Suite {
+        // Check if all variants can be represented as Python enum members.
+        // Non-string variants, and string variants without at least one
+        // usable identifier character, can't be valid Python identifiers.
+        let has_unrepresentable = self.ty.variants().iter().any(|variant| match variant {
+            IrEnumVariant::Number(_) | IrEnumVariant::Bool(_) => true,
+            IrEnumVariant::String(s) => !s.chars().any(unicode_ident::is_xid_continue),
+        });
+
+        let class_name = self.name.as_class_name();
+        let name_ident = Identifier::new(&class_name, TextRange::default());
+
+        if has_unrepresentable {
+            // If any variant is unrepresentable, emit a type alias for
+            // the union of all variant types.
+            let types: BTreeSet<_> = self
+                .ty
+                .variants()
+                .iter()
+                .map(|variant| match variant {
+                    IrEnumVariant::String(_) => "str",
+                    IrEnumVariant::Number(n) => {
+                        if n.is_i64() || n.is_u64() {
+                            "int"
+                        } else {
+                            "float"
+                        }
+                    }
+                    IrEnumVariant::Bool(_) => "bool",
+                })
+                .collect();
+            let union_ty = types
+                .into_iter()
+                .map(|ty| {
+                    py_quote!(
+                        "#{ty}" as Expr,
+                        ty: Identifier = Identifier::new(ty, TextRange::default())
+                    )
+                })
+                .reduce(|a, b| py_quote!("#{a} | #{b}" as Expr, a: Expr = a, b: Expr = b))
+                .unwrap_or_else(|| py_quote!("never" as Expr));
+            py_quote!(
+                {"
+                    #{desc}
+                    #{name} = #{ty}
+                "} as Suite,
+                desc: Option<&str> = self.ty.description(),
+                name: Identifier = name_ident,
+                ty: Expr = union_ty,
+            )
+        } else {
+            // Otherwise, emit an enum class.
+            let class_body = self
+                .ty
+                .variants()
+                .iter()
+                .filter_map(|variant| match variant {
+                    &IrEnumVariant::String(name) => Some(name),
+                    _ => None,
+                })
+                .map(|name| {
+                    let ident = CodegenIdent::new(name);
+                    let variant_name = CodegenIdentUsage::Variant(&ident).display().to_string();
+                    py_quote!(
+                        "#{name} = #{value}" as Stmt,
+                        name: Identifier = Identifier::new(&variant_name, TextRange::default()),
+                        value: &str = name
+                    )
+                })
+                .collect::<Suite>();
+            py_quote!(
+                {"
+                    from enum import Enum
+
+                    class #{name}(Enum):
+                        #{desc}
+                        #{body}
+                "} as Suite,
+                name: Identifier = name_ident,
+                desc: Option<&str> = self.ty.description(),
+                body: Suite = class_body,
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::generate_source;
+    use indoc::indoc;
+    use ploidy_core::{
+        ir::{IrGraph, IrSpec, SchemaIrTypeView},
+        parse::Document,
+    };
+    use pretty_assertions::assert_eq;
+
+    use crate::CodegenGraph;
+
+    fn to_source(suite: &Suite) -> String {
+        generate_source(suite)
+    }
+
+    #[test]
+    fn test_enum_string_variants() {
+        let doc = Document::from_yaml(indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Status:
+                  type: string
+                  enum:
+                    - active
+                    - inactive
+                    - pending
+        "})
+        .unwrap();
+
+        let spec = IrSpec::from_doc(&doc).unwrap();
+        let ir = IrGraph::new(&spec);
+        let graph = CodegenGraph::new(ir);
+
+        let schema = graph.schemas().find(|s| s.name() == "Status");
+        let Some(schema @ SchemaIrTypeView::Enum(_, enum_view)) = &schema else {
+            panic!("expected enum `Status`; got `{schema:?}`");
+        };
+
+        let name = CodegenTypeName::Schema(schema);
+        let suite = CodegenEnum::new(name, enum_view).to_suite();
+
+        let source = to_source(&suite);
+        assert_eq!(
+            source,
+            indoc! {"
+                from enum import Enum
+                class Status(Enum):
+                    ACTIVE = 'active'
+                    INACTIVE = 'inactive'
+                    PENDING = 'pending'"
+            },
+        );
+    }
+
+    #[test]
+    fn test_enum_with_description() {
+        let doc = Document::from_yaml(indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Status:
+                  description: The status of an entity.
+                  type: string
+                  enum:
+                    - active
+                    - inactive
+        "})
+        .unwrap();
+
+        let spec = IrSpec::from_doc(&doc).unwrap();
+        let ir = IrGraph::new(&spec);
+        let graph = CodegenGraph::new(ir);
+
+        let schema = graph.schemas().find(|s| s.name() == "Status");
+        let Some(schema @ SchemaIrTypeView::Enum(_, enum_view)) = &schema else {
+            panic!("expected enum `Status`; got `{schema:?}`");
+        };
+
+        let name = CodegenTypeName::Schema(schema);
+        let suite = CodegenEnum::new(name, enum_view).to_suite();
+
+        let source = to_source(&suite);
+        assert_eq!(
+            source,
+            indoc! {"
+                from enum import Enum
+                class Status(Enum):
+                    'The status of an entity.'
+                    ACTIVE = 'active'
+                    INACTIVE = 'inactive'"
+            },
+        );
+    }
+
+    #[test]
+    fn test_enum_unrepresentable_becomes_type_alias() {
+        let doc = Document::from_yaml(indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Priority:
+                  type: integer
+                  enum:
+                    - 1
+                    - 2
+                    - 3
+        "})
+        .unwrap();
+
+        let spec = IrSpec::from_doc(&doc).unwrap();
+        let ir = IrGraph::new(&spec);
+        let graph = CodegenGraph::new(ir);
+
+        let schema = graph.schemas().find(|s| s.name() == "Priority");
+        let Some(schema @ SchemaIrTypeView::Enum(_, view)) = &schema else {
+            panic!("expected enum `Priority`; got `{schema:?}`");
+        };
+
+        let name = CodegenTypeName::Schema(schema);
+        let suite = CodegenEnum::new(name, view).to_suite();
+
+        let source = to_source(&suite);
+        assert_eq!(source, "Priority = int");
+    }
+
+    #[test]
+    fn test_enum_mixed_types_becomes_union() {
+        let doc = Document::from_yaml(indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Mixed:
+                  enum:
+                    - text
+                    - 42
+                    - true
+        "})
+        .unwrap();
+
+        let spec = IrSpec::from_doc(&doc).unwrap();
+        let ir = IrGraph::new(&spec);
+        let graph = CodegenGraph::new(ir);
+
+        let schema = graph.schemas().find(|s| s.name() == "Mixed");
+        let Some(schema @ SchemaIrTypeView::Enum(_, view)) = &schema else {
+            panic!("expected enum `Mixed`; got `{schema:?}`");
+        };
+
+        let name = CodegenTypeName::Schema(schema);
+        let suite = CodegenEnum::new(name, view).to_suite();
+
+        let source = to_source(&suite);
+        assert_eq!(source, "Mixed = bool | int | str");
+    }
+
+    #[test]
+    fn test_enum_kebab_case_variants() {
+        let doc = Document::from_yaml(indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                ContentType:
+                  type: string
+                  enum:
+                    - application-json
+                    - text-plain
+        "})
+        .unwrap();
+
+        let spec = IrSpec::from_doc(&doc).unwrap();
+        let ir = IrGraph::new(&spec);
+        let graph = CodegenGraph::new(ir);
+
+        let schema = graph.schemas().find(|s| s.name() == "ContentType");
+        let Some(schema @ SchemaIrTypeView::Enum(_, enum_view)) = &schema else {
+            panic!("expected enum `ContentType`; got `{schema:?}`");
+        };
+
+        let name = CodegenTypeName::Schema(schema);
+        let suite = CodegenEnum::new(name, enum_view).to_suite();
+
+        let source = to_source(&suite);
+        assert_eq!(
+            source,
+            indoc! {"
+                from enum import Enum
+                class ContentType(Enum):
+                    APPLICATION_JSON = 'application-json'
+                    TEXT_PLAIN = 'text-plain'"
+            },
+        );
+    }
+}

--- a/ploidy-codegen-python/src/graph.rs
+++ b/ploidy-codegen-python/src/graph.rs
@@ -1,0 +1,90 @@
+//! The codegen graph wrapper with Python-specific metadata.
+
+use std::{
+    collections::{BTreeMap, HashMap},
+    ops::Deref,
+};
+
+use ploidy_core::{
+    codegen::UniqueNames,
+    ir::{ExtendableView, IrGraph, IrTypeView, SchemaIrTypeView},
+};
+
+use super::naming::CodegenIdentScope;
+
+/// Decorates an [`IrGraph`] with Python-specific information.
+#[derive(Debug)]
+pub struct CodegenGraph<'a>(IrGraph<'a>);
+
+impl<'a> CodegenGraph<'a> {
+    /// Creates a new codegen graph, computing unique Python names for all
+    /// schemas and tracking discriminator fields for tagged union variants.
+    pub fn new(graph: IrGraph<'a>) -> Self {
+        let unique = UniqueNames::new();
+        let mut scope = CodegenIdentScope::new(&unique);
+
+        // First pass: assign unique identifiers to all schemas.
+        for mut view in graph.schemas() {
+            let ident = scope.uniquify(view.name());
+            view.extensions_mut().insert(ident);
+        }
+
+        // Second pass: collect discriminator info for all variant schemas.
+        // Use BTreeMap to maintain sorted order and deduplicate by field name.
+        let mut discriminators: HashMap<&str, BTreeMap<String, Vec<String>>> = HashMap::new();
+        for schema in graph.schemas() {
+            if let SchemaIrTypeView::Tagged(_, tagged) = schema {
+                let tag = tagged.tag();
+                for variant in tagged.variants() {
+                    let value = variant.aliases().first().copied().unwrap_or(variant.name());
+                    if let IrTypeView::Schema(variant_schema) = variant.ty() {
+                        discriminators
+                            .entry(variant_schema.name())
+                            .or_default()
+                            .entry(tag.to_owned())
+                            .or_default()
+                            .push(value.to_owned());
+                    }
+                }
+            }
+        }
+
+        // Third pass: insert collected discriminator info into schema extensions.
+        for mut schema in graph.schemas() {
+            if let Some(fields_by_name) = discriminators.remove(schema.name()) {
+                let fields = fields_by_name
+                    .into_iter()
+                    .map(|(field_name, values)| DiscriminatorField { field_name, values })
+                    .collect();
+                schema.extensions_mut().insert(DiscriminatorFields(fields));
+            }
+        }
+
+        Self(graph)
+    }
+}
+
+impl<'a> Deref for CodegenGraph<'a> {
+    type Target = IrGraph<'a>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// Information about a discriminator field that should be added to a schema
+/// because it's used as a variant in a tagged union.
+#[derive(Clone, Debug)]
+pub struct DiscriminatorField {
+    /// The discriminator field name.
+    pub field_name: String,
+    /// The discriminator values for this variant. Multiple values occur when a
+    /// schema participates in multiple tagged unions with the same discriminator
+    /// field name.
+    pub values: Vec<String>,
+}
+
+/// Collection of discriminator fields for a schema that's used as a variant
+/// in one or more tagged unions.
+#[derive(Clone, Debug, Default)]
+pub struct DiscriminatorFields(pub Vec<DiscriminatorField>);

--- a/ploidy-codegen-python/src/imports.rs
+++ b/ploidy-codegen-python/src/imports.rs
@@ -1,0 +1,314 @@
+//! Utilities for grouping and sorting imports, inspired by
+//! the Python `isort` utility, and Ruff's `Isort` linter.
+//!
+//! Each codegen type includes its own imports independently,
+//! which may produce duplicate imports in the combined module.
+//! This module provides the [`isort`] function, which rewrites
+//! the module's syntax tree to consolidate, deduplicate, and sort
+//! all its import statements.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use itertools::Itertools;
+use ploidy_core::ir::{
+    ExtendableView, InlineIrTypeView, IrTypeView, PrimitiveIrType, SccId, SchemaIrTypeView, View,
+    ViewNode,
+};
+use quasiquodo_py::{
+    py_quote,
+    ruff::{
+        python_ast::{Alias, AtomicNodeIndex, Identifier, Stmt, StmtImportFrom, Suite},
+        text_size::TextRange,
+    },
+};
+
+use super::naming::{CodegenIdent, CodegenIdentUsage};
+
+/// Bundles the SCC identity and module-name mapping needed to resolve
+/// cross-SCC imports during codegen.
+#[derive(Clone, Copy, Debug)]
+pub struct ImportContext<'a> {
+    pub this_scc: SccId,
+    pub scc_module_names: &'a BTreeMap<SccId, String>,
+}
+
+impl<'a> ImportContext<'a> {
+    pub fn new(this_scc: SccId, scc_module_names: &'a BTreeMap<SccId, String>) -> Self {
+        Self {
+            this_scc,
+            scc_module_names,
+        }
+    }
+}
+
+/// Returns the import statements needed by a type's transitive
+/// dependencies.
+///
+/// Returns a [`Suite`] of all the import statements
+/// for a type's transitive dependencies.
+///
+/// The suite may contain duplicates; [`isort`] filters them out.
+pub fn collect_imports<'a>(ty: &impl View<'a>, context: ImportContext<'_>) -> Suite {
+    ty.dependencies()
+        .filter_map(|ty| match ty {
+            IrTypeView::Inline(InlineIrTypeView::Primitive(_, prim))
+            | IrTypeView::Schema(SchemaIrTypeView::Primitive(_, prim)) => match prim.ty() {
+                PrimitiveIrType::DateTime | PrimitiveIrType::UnixTime | PrimitiveIrType::Date => {
+                    Some(py_quote!("import datetime" as Stmt))
+                }
+                PrimitiveIrType::Uuid => Some(py_quote!("from uuid import UUID" as Stmt)),
+                _ => None,
+            },
+
+            IrTypeView::Inline(InlineIrTypeView::Any(..))
+            | IrTypeView::Schema(SchemaIrTypeView::Any(..)) => {
+                Some(py_quote!("from typing import Any" as Stmt))
+            }
+
+            IrTypeView::Schema(sv) if sv.scc_id() != context.this_scc => {
+                let ident = sv.extensions().get::<CodegenIdent>()?;
+                let class = CodegenIdentUsage::Class(&ident).display().to_string();
+                let module = &context.scc_module_names[&sv.scc_id()];
+                Some(py_quote!(
+                    "from .#{m} import #{n}" as Stmt,
+                    m: Identifier = Identifier::new(module, TextRange::default()),
+                    n: Alias = py_quote!(
+                        "#{n}" as Alias,
+                        n: Identifier = Identifier::new(&class, TextRange::default())
+                    )
+                ))
+            }
+
+            _ => None,
+        })
+        .collect()
+}
+
+/// A key for grouping and sorting imports in a [`Suite`].
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+enum ImportKey<'a> {
+    /// A future statement: `from __future__ import ...`.
+    Future,
+    /// Imports like `import datetime`, `import pydantic`, `import typing`,
+    /// and so on; sorted lexicographically by module name.
+    Absolute(&'a str),
+    /// Imports like `from enum import ...`, `from uuid import ...`, and so on;
+    /// grouped by module name, and sorted lexicographically.
+    AbsoluteFrom(&'a str),
+    /// Relative imports like `from . import ...`, `from .. import ...`,
+    /// `from .module import ...`, `from ..module import ...`, and so on;
+    /// grouped by `.` level and name, and sorted according to level and name.
+    RelativeFrom(u32, RelativeImportKey<'a>),
+}
+
+impl<'a> From<&'a StmtImportFrom> for ImportKey<'a> {
+    fn from(stmt: &'a StmtImportFrom) -> Self {
+        let Some(module) = stmt.module.as_ref().map(|m| m.as_str()) else {
+            return ImportKey::RelativeFrom(stmt.level, RelativeImportKey::Root);
+        };
+
+        if stmt.level > 0 {
+            return ImportKey::RelativeFrom(stmt.level, RelativeImportKey::Named(module));
+        }
+
+        match module {
+            "__future__" => ImportKey::Future,
+            other => ImportKey::AbsoluteFrom(other),
+        }
+    }
+}
+
+/// The module name suffix of a relative import, following the `.`.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+enum RelativeImportKey<'a> {
+    Root,
+    Named(&'a str),
+}
+
+/// Groups and sorts import statements in a [`Suite`].
+///
+/// Partitions the suite into import and non-import statements,
+/// merges `from...import` statements that share the same module,
+/// sorts the imports in [canonical order][`ImportKey`], and
+/// moves them before the non-import statements.
+pub fn isort(suite: &mut Suite) {
+    let (imports, non_imports) = {
+        // Partition the statements in-place.
+        let mut rest = std::mem::take(suite);
+        let imports = rest
+            .extract_if(.., |stmt| {
+                matches!(stmt, Stmt::Import(_) | Stmt::ImportFrom(_))
+            })
+            .collect_vec();
+        (imports, rest)
+    };
+
+    let imports = {
+        let mut grouping: BTreeMap<_, BTreeSet<_>> = BTreeMap::new();
+        for stmt in &imports {
+            match stmt {
+                Stmt::Import(import) => {
+                    for alias in &import.names {
+                        let key = ImportKey::Absolute(alias.name.as_str());
+                        grouping.entry(key).or_default();
+                    }
+                }
+                Stmt::ImportFrom(import_from) => {
+                    let key = ImportKey::from(import_from);
+                    grouping
+                        .entry(key)
+                        .or_default()
+                        .extend(import_from.names.iter().map(|alias| alias.name.as_str()));
+                }
+                // Impossible; we only extracted `import` and `from...import`
+                // statements above.
+                _ => continue,
+            }
+        }
+        grouping
+    };
+
+    // Emit consolidated imports in sorted order.
+    suite.extend(imports.into_iter().map(|(key, names)| {
+        let names: Vec<Alias> = names
+            .into_iter()
+            .map(|n| {
+                py_quote!(
+                    "#{name}" as Alias,
+                    name: Identifier = Identifier::new(n, TextRange::default()),
+                )
+            })
+            .collect();
+        match key {
+            ImportKey::Absolute(module) => py_quote!(
+                "import #{m}" as Stmt,
+                m: Identifier = Identifier::new(module, TextRange::default())
+            ),
+            ImportKey::RelativeFrom(level, name) => {
+                let module = match name {
+                    RelativeImportKey::Root => None,
+                    RelativeImportKey::Named(name) => {
+                        Some(Identifier::new(name, TextRange::default()))
+                    }
+                };
+                // We construct an `Stmt::ImportFrom` directly here,
+                // because there's no `py_quote!` variable type to express
+                // "repeat `.` `level` times".
+                Stmt::ImportFrom(StmtImportFrom {
+                    node_index: AtomicNodeIndex::NONE,
+                    range: TextRange::default(),
+                    module,
+                    names,
+                    level,
+                })
+            }
+            ImportKey::Future => py_quote!(
+                "from __future__ import #{names}" as Stmt,
+                names: Vec<Alias> = names,
+            ),
+            ImportKey::AbsoluteFrom(name) => py_quote!(
+                "from #{m} import #{names}" as Stmt,
+                m: Identifier = Identifier::new(name, TextRange::default()),
+                names: Vec<Alias> = names,
+            ),
+        }
+    }));
+
+    // ...Then append the non-import statements in their original order.
+    suite.extend(non_imports);
+}
+
+#[cfg(test)]
+mod tests {
+    use indoc::indoc;
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    use crate::generate_source;
+
+    #[test]
+    fn test_consolidate_deduplicates_and_sorts() {
+        let mut suite: Suite = vec![
+            py_quote!("from pydantic import BaseModel" as Stmt),
+            py_quote!("import datetime" as Stmt),
+            py_quote!("x = 1" as Stmt),
+            py_quote!("from pydantic import Field" as Stmt),
+            py_quote!("from typing import Annotated" as Stmt),
+            py_quote!("y = 2" as Stmt),
+            py_quote!("from pydantic import BaseModel" as Stmt),
+            py_quote!("z = 3" as Stmt),
+        ];
+
+        isort(&mut suite);
+        let source = generate_source(&suite);
+
+        assert_eq!(
+            source,
+            indoc! {"
+                import datetime
+                from pydantic import BaseModel, Field
+                from typing import Annotated
+                x = 1
+                y = 2
+                z = 3"
+            },
+        );
+    }
+
+    #[test]
+    fn test_consolidate_future_first() {
+        let mut suite: Suite = vec![
+            py_quote!("from pydantic import BaseModel" as Stmt),
+            py_quote!("from __future__ import annotations" as Stmt),
+        ];
+
+        isort(&mut suite);
+        let source = generate_source(&suite);
+
+        assert_eq!(
+            source,
+            indoc! {"
+                from __future__ import annotations
+                from pydantic import BaseModel"
+            },
+        );
+    }
+
+    #[test]
+    fn test_consolidate_relative_imports_sorted() {
+        let mut suite: Suite = vec![
+            py_quote!("from .zebra import Z" as Stmt),
+            py_quote!("from .alpha import A" as Stmt),
+        ];
+
+        isort(&mut suite);
+        let source = generate_source(&suite);
+
+        assert_eq!(
+            source,
+            indoc! {"
+                from .alpha import A
+                from .zebra import Z"
+            },
+        );
+    }
+
+    #[test]
+    fn test_consolidate_merges_relative_imports() {
+        let mut suite: Suite = vec![
+            py_quote!("from .pet import Pet" as Stmt),
+            py_quote!("from .pet import Owner" as Stmt),
+        ];
+
+        isort(&mut suite);
+        let source = generate_source(&suite);
+
+        assert_eq!(
+            source,
+            indoc! {"
+                from .pet import Owner, Pet"
+            },
+        );
+    }
+}

--- a/ploidy-codegen-python/src/lib.rs
+++ b/ploidy-codegen-python/src/lib.rs
@@ -1,0 +1,88 @@
+//! Ploidy Python code generator using Pydantic v2 models.
+//!
+//! This crate generates Python code from OpenAPI schemas, producing Pydantic
+//! `BaseModel` classes with full type hints for Python 3.10+.
+
+use std::{collections::BTreeMap, path::Path};
+
+use ploidy_core::{
+    codegen::{IntoCode, write_to_disk},
+    ir::{ExtendableView, SccId, ViewNode},
+};
+use quasiquodo_py::ruff::python_ast::Suite;
+
+mod enum_;
+mod graph;
+mod imports;
+mod model;
+mod naming;
+mod ref_;
+mod schema;
+mod tagged;
+mod types;
+mod untagged;
+
+#[cfg(test)]
+mod tests;
+
+pub use graph::*;
+pub use naming::*;
+pub use schema::*;
+pub use types::*;
+
+/// Generates Python source code from a list of statements.
+pub(crate) fn generate_source(suite: &Suite) -> String {
+    use ruff_python_codegen::{Generator, Indentation};
+    use ruff_source_file::LineEnding;
+
+    let indent = Indentation::default();
+    suite
+        .iter()
+        .map(|stmt| Generator::new(&indent, LineEnding::Lf).stmt(stmt))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Generates Python source code from an expression.
+#[cfg(test)]
+pub(crate) fn generate_expr_source(expr: &quasiquodo_py::ruff::python_ast::Expr) -> String {
+    use ruff_python_codegen::{Generator, Indentation};
+    use ruff_source_file::LineEnding;
+
+    let indent = Indentation::default();
+    Generator::new(&indent, LineEnding::Lf).expr(expr)
+}
+
+/// Writes generated Python types to disk.
+///
+/// Groups schemas by SCC and emits one `.py` file per SCC, plus an
+/// `__init__.py` module file that exports all types.
+pub fn write_types_to_disk(output: &Path, graph: &CodegenGraph<'_>) -> miette::Result<()> {
+    // Group schemas by SCC.
+    let mut sccs: BTreeMap<SccId, Vec<_>> = BTreeMap::new();
+    for view in graph.schemas() {
+        sccs.entry(view.scc_id()).or_default().push(view);
+    }
+
+    // Pre-compute the module name for each SCC (the alphabetically first
+    // schema's module name).
+    let scc_module_names: BTreeMap<SccId, String> = sccs
+        .iter()
+        .map(|(&scc_id, schemas)| {
+            let first = schemas.iter().min_by_key(|s| s.name()).unwrap();
+            let ident = first.extensions().get::<CodegenIdent>().unwrap();
+            let module_name = CodegenIdentUsage::Module(&ident).display().to_string();
+            (scc_id, module_name)
+        })
+        .collect();
+
+    // Emit one module per SCC.
+    for schemas in sccs.values() {
+        let code = CodegenSccModule::new(schemas, &scc_module_names).into_code();
+        write_to_disk(output, code)?;
+    }
+
+    write_to_disk(output, CodegenTypesModule::new(graph))?;
+
+    Ok(())
+}

--- a/ploidy-codegen-python/src/model.rs
+++ b/ploidy-codegen-python/src/model.rs
@@ -1,0 +1,527 @@
+//! Pydantic `BaseModel` generation from IR structs.
+
+use ploidy_core::{
+    codegen::UniqueNames,
+    ir::{
+        ContainerView, ExtendableView, InlineIrTypeView, IrStructFieldName, IrStructView,
+        IrTypeView, SchemaIrTypeView,
+    },
+};
+use quasiquodo_py::{
+    py_quote,
+    ruff::{
+        python_ast::{Identifier, Stmt, Suite},
+        text_size::TextRange,
+    },
+};
+
+use crate::{
+    graph::DiscriminatorFields,
+    imports::ImportContext,
+    naming::{
+        CodegenIdent, CodegenIdentScope, CodegenIdentUsage, CodegenStructFieldName, CodegenTypeName,
+    },
+    ref_::CodegenRef,
+};
+
+/// Returns the inner type if the given type view is an optional container.
+fn unwrap_optional<'a>(ty: &IrTypeView<'a>) -> Option<IrTypeView<'a>> {
+    match ty {
+        IrTypeView::Inline(InlineIrTypeView::Container(_, ContainerView::Optional(inner)))
+        | IrTypeView::Schema(SchemaIrTypeView::Container(_, ContainerView::Optional(inner))) => {
+            Some(inner.ty())
+        }
+        _ => None,
+    }
+}
+
+/// Generates a Pydantic `BaseModel` class from an IR struct.
+#[derive(Clone, Debug)]
+pub struct CodegenModel<'a> {
+    name: CodegenTypeName<'a>,
+    ty: &'a IrStructView<'a>,
+}
+
+impl<'a> CodegenModel<'a> {
+    pub fn new(name: CodegenTypeName<'a>, ty: &'a IrStructView<'a>) -> Self {
+        Self { name, ty }
+    }
+
+    /// Generates all statements for this model: imports + class def.
+    pub fn to_suite(&self, context: ImportContext<'_>) -> Suite {
+        let mut suite = Suite::new();
+
+        // Dependency imports (datetime, uuid, Any, cross-SCC refs).
+        match &self.name {
+            CodegenTypeName::Schema(sv) => {
+                suite.extend(crate::imports::collect_imports(*sv, context));
+            }
+            CodegenTypeName::Inline(iv) => {
+                suite.extend(crate::imports::collect_imports(*iv, context));
+            }
+        }
+
+        // Structural imports.
+        suite.push(py_quote!("from pydantic import BaseModel" as Stmt));
+
+        // Check if any field needs a `Field(alias=...)` call.
+        let needs_field_alias = {
+            let unique = UniqueNames::new();
+            let mut scope = CodegenIdentScope::new(&unique);
+            self.ty.fields().any(|field| {
+                if field.discriminator() {
+                    return false;
+                }
+                match field.name() {
+                    IrStructFieldName::Name(n) => {
+                        let python_name = CodegenIdentUsage::Field(&scope.uniquify(n))
+                            .display()
+                            .to_string();
+                        n != python_name
+                    }
+                    IrStructFieldName::Hint(_) => false,
+                }
+            })
+        };
+        if needs_field_alias {
+            suite.push(py_quote!("from pydantic import Field" as Stmt));
+        }
+
+        let has_discriminator_fields = matches!(&self.name, CodegenTypeName::Schema(schema)
+            if schema.extensions().get::<DiscriminatorFields>().is_some());
+        if has_discriminator_fields {
+            suite.push(py_quote!("from typing import Literal" as Stmt));
+        }
+
+        // Class definition.
+        let unique = UniqueNames::new();
+        let mut scope = CodegenIdentScope::new(&unique);
+
+        // Collect fields, sorting required fields before optional ones.
+        // Python requires fields with defaults to come after required fields.
+        let mut required_fields = Vec::new();
+        let mut optional_fields = Vec::new();
+
+        // If this struct is used as a variant in tagged unions, add
+        // discriminator fields. These have defaults so they go with optional
+        // fields, but should come first among optionals.
+        let mut discriminator_stmts = Vec::new();
+        if let CodegenTypeName::Schema(schema) = &self.name
+            && let Some(discriminators) = schema.extensions().get::<DiscriminatorFields>()
+        {
+            for disc in &discriminators.0 {
+                let field_name = CodegenIdentUsage::Field(&CodegenIdent::new(&disc.field_name))
+                    .display()
+                    .to_string();
+                let value = &disc.values[0];
+                discriminator_stmts.push(py_quote!(
+                    r#"#{name}: Literal[#{value}] = #{value}"# as Stmt,
+                    name: Identifier = Identifier::new(&field_name, TextRange::default()),
+                    value: &str = value
+                ));
+            }
+        }
+
+        for field in self.ty.fields() {
+            // Skip discriminator fields from the IR; we handle them above
+            // based on tagged union membership with proper Literal types.
+            if field.discriminator() {
+                continue;
+            }
+
+            let stmt = generate_field_stmt(field.name(), &field.ty(), field.required(), &mut scope);
+
+            if field.required() {
+                required_fields.push(stmt);
+            } else {
+                optional_fields.push(stmt);
+            }
+        }
+
+        // Combine required fields first, then discriminator fields (which
+        // have defaults), then optional fields.
+        let mut class_body: Suite = required_fields;
+        class_body.extend(discriminator_stmts);
+        class_body.extend(optional_fields);
+
+        if class_body.is_empty() {
+            class_body.push(py_quote!("pass" as Stmt));
+        }
+
+        if let Some(desc) = self.ty.description() {
+            class_body.insert(0, py_quote!("#{desc}" as Stmt, desc: &str = desc));
+        }
+
+        let class_name = self.name.as_class_name();
+        suite.push(py_quote!(
+            "class #{name}(BaseModel):
+                 #{body}
+            " as Stmt,
+            name: Identifier = Identifier::new(&class_name, TextRange::default()),
+            body: Suite = class_body
+        ));
+        suite
+    }
+}
+
+/// Generates a single field statement with proper type hints and aliasing.
+fn generate_field_stmt(
+    name: IrStructFieldName<'_>,
+    field_ty: &IrTypeView<'_>,
+    required: bool,
+    scope: &mut CodegenIdentScope<'_>,
+) -> Stmt {
+    let field_name: String = match name {
+        IrStructFieldName::Name(n) => CodegenIdentUsage::Field(&scope.uniquify(n))
+            .display()
+            .to_string(),
+        IrStructFieldName::Hint(hint) => CodegenStructFieldName(hint).to_string(),
+    };
+    let json_name = match name {
+        IrStructFieldName::Name(n) => Some(n),
+        IrStructFieldName::Hint(_) => None,
+    };
+    let name_ident = Identifier::new(&field_name, TextRange::default());
+
+    let (type_expr, is_optional) = if required {
+        if let Some(inner_ty) = unwrap_optional(field_ty) {
+            // Required but nullable: `T | None` with no default.
+            let inner = CodegenRef::new(&inner_ty).to_expr();
+            (
+                py_quote!("#{inner} | None" as Expr, inner: Expr = inner),
+                false,
+            )
+        } else {
+            (CodegenRef::new(field_ty).to_expr(), false)
+        }
+    } else {
+        // Optional field: always `T | None = None`.
+        let unwrapped = unwrap_optional(field_ty);
+        let inner_ty = unwrapped.as_ref().unwrap_or(field_ty);
+        let inner = CodegenRef::new(inner_ty).to_expr();
+        (
+            py_quote!("#{inner} | None" as Expr, inner: Expr = inner),
+            true,
+        )
+    };
+
+    let needs_alias = json_name.is_some_and(|n| n != field_name);
+
+    match (is_optional, needs_alias) {
+        (false, false) => {
+            // Required, no alias: `name: Type`
+            py_quote!(
+                "#{name}: #{ty}" as Stmt,
+                name: Identifier = name_ident,
+                ty: Expr = type_expr
+            )
+        }
+        (true, false) => {
+            // Optional, no alias: `name: Type = None`
+            py_quote!(
+                "#{name}: #{ty} = None" as Stmt,
+                name: Identifier = name_ident,
+                ty: Expr = type_expr
+            )
+        }
+        (false, true) => {
+            // Required, aliased: `name: Type = Field(alias='original')`
+            let alias = json_name.unwrap();
+            py_quote!(
+                r#"#{name}: #{ty} = Field(alias=#{alias})"# as Stmt,
+                name: Identifier = name_ident,
+                ty: Expr = type_expr,
+                alias: &str = alias
+            )
+        }
+        (true, true) => {
+            // Optional, aliased: `name: Type = Field(None, alias='original')`
+            let alias = json_name.unwrap();
+            py_quote!(
+                r#"#{name}: #{ty} = Field(None, alias=#{alias})"# as Stmt,
+                name: Identifier = name_ident,
+                ty: Expr = type_expr,
+                alias: &str = alias
+            )
+        }
+    }
+}
+
+/// Generates field statements for use in inline contexts (like tagged union
+/// variants).
+pub fn generate_field_stmts(ty: &IrStructView<'_>) -> Suite {
+    let unique = UniqueNames::new();
+    let mut scope = CodegenIdentScope::new(&unique);
+
+    let mut required_fields = Vec::new();
+    let mut optional_fields = Vec::new();
+
+    for field in ty.fields() {
+        // Skip discriminator fields; they're handled separately in the calling
+        // context (e.g., tagged union variants).
+        if field.discriminator() {
+            continue;
+        }
+
+        let stmt = generate_field_stmt(field.name(), &field.ty(), field.required(), &mut scope);
+
+        if field.required() {
+            required_fields.push(stmt);
+        } else {
+            optional_fields.push(stmt);
+        }
+    }
+
+    let mut suite = required_fields;
+    suite.extend(optional_fields);
+    suite
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+
+    use crate::generate_source;
+    use indoc::indoc;
+    use ploidy_core::ir::{IrGraph, IrSpec, SchemaIrTypeView, ViewNode};
+    use ploidy_core::parse::Document;
+    use pretty_assertions::assert_eq;
+
+    use crate::CodegenGraph;
+
+    fn to_source(suite: &Suite) -> String {
+        generate_source(suite)
+    }
+
+    #[test]
+    fn test_model_basic_struct() {
+        let doc = Document::from_yaml(indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Pet:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    age:
+                      type: integer
+                      format: int32
+                  required:
+                    - name
+        "})
+        .unwrap();
+
+        let spec = IrSpec::from_doc(&doc).unwrap();
+        let ir = IrGraph::new(&spec);
+        let graph = CodegenGraph::new(ir);
+
+        let schema = graph.schemas().find(|s| s.name() == "Pet");
+        let Some(schema @ SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
+            panic!("expected struct `Pet`; got `{schema:?}`");
+        };
+
+        let name = CodegenTypeName::Schema(schema);
+        let suite = CodegenModel::new(name, struct_view)
+            .to_suite(ImportContext::new(schema.scc_id(), &BTreeMap::new()));
+
+        let source = to_source(&suite);
+        assert_eq!(
+            source,
+            indoc! {"
+                from pydantic import BaseModel
+                class Pet(BaseModel):
+                    name: str
+                    age: int | None = None"
+            },
+        );
+    }
+
+    #[test]
+    fn test_model_with_description() {
+        let doc = Document::from_yaml(indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Pet:
+                  description: A pet in the store.
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                  required:
+                    - name
+        "})
+        .unwrap();
+
+        let spec = IrSpec::from_doc(&doc).unwrap();
+        let ir = IrGraph::new(&spec);
+        let graph = CodegenGraph::new(ir);
+
+        let schema = graph.schemas().find(|s| s.name() == "Pet");
+        let Some(schema @ SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
+            panic!("expected struct `Pet`; got `{schema:?}`");
+        };
+
+        let name = CodegenTypeName::Schema(schema);
+        let suite = CodegenModel::new(name, struct_view)
+            .to_suite(ImportContext::new(schema.scc_id(), &BTreeMap::new()));
+
+        let source = to_source(&suite);
+        assert_eq!(
+            source,
+            indoc! {"
+                from pydantic import BaseModel
+                class Pet(BaseModel):
+                    'A pet in the store.'
+                    name: str"
+            },
+        );
+    }
+
+    #[test]
+    fn test_model_field_alias() {
+        let doc = Document::from_yaml(indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Pet:
+                  type: object
+                  properties:
+                    petName:
+                      type: string
+                  required:
+                    - petName
+        "})
+        .unwrap();
+
+        let spec = IrSpec::from_doc(&doc).unwrap();
+        let ir = IrGraph::new(&spec);
+        let graph = CodegenGraph::new(ir);
+
+        let schema = graph.schemas().find(|s| s.name() == "Pet");
+        let Some(schema @ SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
+            panic!("expected struct `Pet`; got `{schema:?}`");
+        };
+
+        let name = CodegenTypeName::Schema(schema);
+        let suite = CodegenModel::new(name, struct_view)
+            .to_suite(ImportContext::new(schema.scc_id(), &BTreeMap::new()));
+
+        let source = to_source(&suite);
+        assert_eq!(
+            source,
+            indoc! {"
+                from pydantic import BaseModel
+                from pydantic import Field
+                class Pet(BaseModel):
+                    pet_name: str = Field(alias='petName')"
+            },
+        );
+    }
+
+    #[test]
+    fn test_model_required_nullable_field() {
+        let doc = Document::from_yaml(indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Record:
+                  type: object
+                  properties:
+                    deleted_at:
+                      type: string
+                      format: date-time
+                      nullable: true
+                  required:
+                    - deleted_at
+        "})
+        .unwrap();
+
+        let spec = IrSpec::from_doc(&doc).unwrap();
+        let ir = IrGraph::new(&spec);
+        let graph = CodegenGraph::new(ir);
+
+        let schema = graph.schemas().find(|s| s.name() == "Record");
+        let Some(schema @ SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
+            panic!("expected struct `Record`; got `{schema:?}`");
+        };
+
+        let name = CodegenTypeName::Schema(schema);
+        let suite = CodegenModel::new(name, struct_view)
+            .to_suite(ImportContext::new(schema.scc_id(), &BTreeMap::new()));
+
+        let source = to_source(&suite);
+        assert_eq!(
+            source,
+            indoc! {"
+                import datetime
+                from pydantic import BaseModel
+                class Record(BaseModel):
+                    deleted_at: datetime.datetime | None"
+            },
+        );
+    }
+
+    #[test]
+    fn test_model_struct_all_optional_fields() {
+        // Note: A truly empty object (no properties) is treated as `Any` in the IR,
+        // not as a struct. This test verifies structs with all optional fields.
+        let doc = Document::from_yaml(indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Config:
+                  type: object
+                  properties:
+                    debug:
+                      type: boolean
+        "})
+        .unwrap();
+
+        let spec = IrSpec::from_doc(&doc).unwrap();
+        let ir = IrGraph::new(&spec);
+        let graph = CodegenGraph::new(ir);
+
+        let schema = graph.schemas().find(|s| s.name() == "Config");
+        let Some(schema @ SchemaIrTypeView::Struct(_, struct_view)) = &schema else {
+            panic!("expected struct `Config`; got `{schema:?}`");
+        };
+
+        let name = CodegenTypeName::Schema(schema);
+        let suite = CodegenModel::new(name, struct_view)
+            .to_suite(ImportContext::new(schema.scc_id(), &BTreeMap::new()));
+
+        let source = to_source(&suite);
+        assert_eq!(
+            source,
+            indoc! {"
+                from pydantic import BaseModel
+                class Config(BaseModel):
+                    debug: bool | None = None"
+            },
+        );
+    }
+}

--- a/ploidy-codegen-python/src/naming.rs
+++ b/ploidy-codegen-python/src/naming.rs
@@ -1,0 +1,649 @@
+//! Python identifier naming and case conversion.
+//!
+//! This module handles converting OpenAPI schema names into valid Python
+//! identifiers following PEP 8 naming conventions:
+//! - Classes: `PascalCase`
+//! - Functions/methods/fields: `snake_case`
+//! - Constants/enum variants: `SCREAMING_SNAKE_CASE`
+//! - Modules: `snake_case`
+
+use std::{borrow::Cow, cmp::Ordering, fmt::Display, ops::Deref};
+
+use heck::{AsPascalCase, AsShoutySnekCase, AsSnekCase};
+use itertools::Itertools;
+use ploidy_core::{
+    codegen::{
+        UniqueNames,
+        unique::{UniqueNamesScope, WordSegments},
+    },
+    ir::{
+        ExtendableView, InlineIrTypePathSegment, InlineIrTypeView, IrStructFieldName,
+        IrStructFieldNameHint, IrUntaggedVariantNameHint, PrimitiveIrType, SchemaIrTypeView,
+    },
+};
+use ref_cast::{RefCastCustom, ref_cast_custom};
+
+/// Python reserved keywords that can't be used as identifiers.
+const KEYWORDS: &[&str] = &[
+    "False", "None", "True", "and", "as", "assert", "async", "await", "break", "class", "continue",
+    "def", "del", "elif", "else", "except", "finally", "for", "from", "global", "if", "import",
+    "in", "is", "lambda", "nonlocal", "not", "or", "pass", "raise", "return", "try", "while",
+    "with", "yield",
+];
+
+/// Python soft keywords (context-dependent, but best avoided).
+const SOFT_KEYWORDS: &[&str] = &["match", "case", "type", "_"];
+
+/// Pydantic BaseModel attributes that shouldn't be shadowed by field names.
+/// These cause `UserWarning: Field name "X" shadows an attribute in parent "BaseModel"`.
+const PYDANTIC_RESERVED: &[&str] = &[
+    // Deprecated v1 methods that still exist in v2.
+    "schema",
+    "schema_json",
+    "json",
+    "dict",
+    "copy",
+    "parse_obj",
+    "parse_raw",
+    "parse_file",
+    "construct",
+    "validate",
+    // Current v2 methods and attributes.
+    "model_config",
+    "model_fields",
+    "model_computed_fields",
+    "model_extra",
+    "model_fields_set",
+    "model_construct",
+    "model_copy",
+    "model_dump",
+    "model_dump_json",
+    "model_json_schema",
+    "model_parametrized_name",
+    "model_post_init",
+    "model_rebuild",
+    "model_validate",
+    "model_validate_json",
+    "model_validate_strings",
+];
+
+/// Python built-in names that shouldn't be shadowed.
+const BUILTINS: &[&str] = &[
+    "abs",
+    "all",
+    "any",
+    "ascii",
+    "bin",
+    "bool",
+    "breakpoint",
+    "bytearray",
+    "bytes",
+    "callable",
+    "chr",
+    "classmethod",
+    "compile",
+    "complex",
+    "copyright",
+    "credits",
+    "delattr",
+    "dict",
+    "dir",
+    "divmod",
+    "enumerate",
+    "eval",
+    "exec",
+    "exit",
+    "filter",
+    "float",
+    "format",
+    "frozenset",
+    "getattr",
+    "globals",
+    "hasattr",
+    "hash",
+    "help",
+    "hex",
+    "id",
+    "input",
+    "int",
+    "isinstance",
+    "issubclass",
+    "iter",
+    "len",
+    "license",
+    "list",
+    "locals",
+    "map",
+    "max",
+    "memoryview",
+    "min",
+    "next",
+    "object",
+    "oct",
+    "open",
+    "ord",
+    "pow",
+    "print",
+    "property",
+    "quit",
+    "range",
+    "repr",
+    "reversed",
+    "round",
+    "set",
+    "setattr",
+    "slice",
+    "sorted",
+    "staticmethod",
+    "str",
+    "sum",
+    "super",
+    "tuple",
+    "type",
+    "vars",
+    "zip",
+];
+
+#[derive(Clone, Copy, Debug)]
+pub enum CodegenTypeName<'a> {
+    Schema(&'a SchemaIrTypeView<'a>),
+    Inline(&'a InlineIrTypeView<'a>),
+}
+
+impl<'a> CodegenTypeName<'a> {
+    #[inline]
+    pub fn into_sort_key(self) -> CodegenTypeNameSortKey<'a> {
+        CodegenTypeNameSortKey(self)
+    }
+
+    /// Returns the Python class name as a string.
+    pub fn as_class_name(&self) -> String {
+        match self {
+            Self::Schema(view) => {
+                let ident = view.extensions().get::<CodegenIdent>().unwrap();
+                CodegenIdentUsage::Class(&ident).display().to_string()
+            }
+            Self::Inline(view) => view
+                .path()
+                .segments
+                .iter()
+                .map(CodegenTypePathSegment)
+                .join(""),
+        }
+    }
+}
+
+impl Display for CodegenTypeName<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.as_class_name())
+    }
+}
+
+/// A comparator that sorts type names lexicographically.
+#[derive(Clone, Copy, Debug)]
+pub struct CodegenTypeNameSortKey<'a>(CodegenTypeName<'a>);
+
+impl<'a> CodegenTypeNameSortKey<'a> {
+    #[inline]
+    pub fn into_name(self) -> CodegenTypeName<'a> {
+        self.0
+    }
+}
+
+impl Eq for CodegenTypeNameSortKey<'_> {}
+
+impl Ord for CodegenTypeNameSortKey<'_> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match (&self.0, &other.0) {
+            (CodegenTypeName::Schema(a), CodegenTypeName::Schema(b)) => a.name().cmp(b.name()),
+            (CodegenTypeName::Inline(a), CodegenTypeName::Inline(b)) => a.path().cmp(b.path()),
+            (CodegenTypeName::Schema(_), CodegenTypeName::Inline(_)) => Ordering::Less,
+            (CodegenTypeName::Inline(_), CodegenTypeName::Schema(_)) => Ordering::Greater,
+        }
+    }
+}
+
+impl PartialEq for CodegenTypeNameSortKey<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other).is_eq()
+    }
+}
+
+impl PartialOrd for CodegenTypeNameSortKey<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// A string that's statically guaranteed to be valid for any
+/// [`CodegenIdentUsage`].
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct CodegenIdent(String);
+
+impl CodegenIdent {
+    /// Creates an identifier for any usage.
+    pub fn new(s: &str) -> Self {
+        let s = clean(s);
+        if is_reserved(&s) {
+            Self(format!("{s}_"))
+        } else {
+            Self(s)
+        }
+    }
+}
+
+impl Deref for CodegenIdent {
+    type Target = CodegenIdentRef;
+
+    fn deref(&self) -> &Self::Target {
+        CodegenIdentRef::new(&self.0)
+    }
+}
+
+/// A string slice that's guaranteed to be valid for any [`CodegenIdentUsage`].
+#[derive(Debug, Eq, Ord, PartialEq, PartialOrd, RefCastCustom)]
+#[repr(transparent)]
+pub struct CodegenIdentRef(str);
+
+impl CodegenIdentRef {
+    #[ref_cast_custom]
+    fn new(s: &str) -> &Self;
+}
+
+/// Represents different usages of a Python identifier, determining the
+/// appropriate casing.
+#[derive(Clone, Copy, Debug)]
+pub enum CodegenIdentUsage<'a> {
+    /// Module name (snake_case).
+    Module(&'a CodegenIdentRef),
+    /// Class name (PascalCase).
+    Class(&'a CodegenIdentRef),
+    /// Field/attribute name (snake_case).
+    Field(&'a CodegenIdentRef),
+    /// Enum variant name (SCREAMING_SNAKE_CASE).
+    Variant(&'a CodegenIdentRef),
+    /// Method name (snake_case).
+    Method(&'a CodegenIdentRef),
+}
+
+impl<'a> CodegenIdentUsage<'a> {
+    /// Returns a displayable value that formats the identifier with the
+    /// appropriate casing for this usage.
+    pub fn display(&self) -> impl Display + '_ {
+        struct DisplayIdent<'a>(&'a CodegenIdentUsage<'a>);
+
+        impl Display for DisplayIdent<'_> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                match self.0 {
+                    CodegenIdentUsage::Module(name) | CodegenIdentUsage::Method(name) => {
+                        let snake = AsSnekCase(&name.0).to_string();
+                        let snake = if name.0.ends_with('_') && !snake.ends_with('_') {
+                            format!("{snake}_")
+                        } else {
+                            snake
+                        };
+                        if snake.starts_with(|c: char| c.is_ascii_digit()) {
+                            write!(f, "_{snake}")
+                        } else {
+                            write!(f, "{snake}")
+                        }
+                    }
+                    CodegenIdentUsage::Field(name) => {
+                        let snake = AsSnekCase(&name.0).to_string();
+                        let snake = if name.0.ends_with('_') && !snake.ends_with('_') {
+                            format!("{snake}_")
+                        } else {
+                            snake
+                        };
+                        // Use `f_` prefix (not `_`) because Pydantic treats
+                        // `_`-prefixed fields as private attributes.
+                        if snake.starts_with(|c: char| c.is_ascii_digit()) {
+                            write!(f, "f_{snake}")
+                        } else {
+                            write!(f, "{snake}")
+                        }
+                    }
+                    CodegenIdentUsage::Class(name) => {
+                        let pascal = AsPascalCase(&name.0).to_string();
+                        let pascal = if name.0.ends_with('_') && !pascal.ends_with('_') {
+                            format!("{pascal}_")
+                        } else {
+                            pascal
+                        };
+                        if pascal.starts_with(|c: char| c.is_ascii_digit()) {
+                            write!(f, "_{pascal}")
+                        } else {
+                            write!(f, "{pascal}")
+                        }
+                    }
+                    CodegenIdentUsage::Variant(name) => {
+                        let shouty = AsShoutySnekCase(&name.0).to_string();
+                        let shouty = if name.0.ends_with('_') && !shouty.ends_with('_') {
+                            format!("{shouty}_")
+                        } else {
+                            shouty
+                        };
+                        if shouty.starts_with(|c: char| c.is_ascii_digit()) {
+                            write!(f, "_{shouty}")
+                        } else {
+                            write!(f, "{shouty}")
+                        }
+                    }
+                }
+            }
+        }
+
+        DisplayIdent(self)
+    }
+}
+
+/// A scope for generating unique, valid Python identifiers.
+#[derive(Debug)]
+pub struct CodegenIdentScope<'a>(UniqueNamesScope<'a>);
+
+impl<'a> CodegenIdentScope<'a> {
+    /// Creates a new identifier scope that's backed by the given arena.
+    pub fn new(arena: &'a UniqueNames) -> Self {
+        Self::with_reserved(arena, &[])
+    }
+
+    /// Creates a new identifier scope that's backed by the given arena,
+    /// with additional pre-reserved names.
+    pub fn with_reserved(arena: &'a UniqueNames, reserved: &[&str]) -> Self {
+        Self(arena.scope_with_reserved(itertools::chain!(
+            reserved.iter().copied(),
+            KEYWORDS.iter().copied(),
+            SOFT_KEYWORDS.iter().copied(),
+            BUILTINS.iter().copied(),
+            PYDANTIC_RESERVED.iter().copied(),
+            std::iter::once("")
+        )))
+    }
+
+    /// Cleans the input string and returns a name that's unique within this
+    /// scope, and valid for any [`CodegenIdentUsage`].
+    pub fn uniquify(&mut self, name: &str) -> CodegenIdent {
+        CodegenIdent(self.0.uniquify(&clean(name)).into_owned())
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct CodegenUntaggedVariantName(pub IrUntaggedVariantNameHint);
+
+impl Display for CodegenUntaggedVariantName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use IrUntaggedVariantNameHint::*;
+        let s = match self.0 {
+            Primitive(PrimitiveIrType::String) => "Str".into(),
+            Primitive(PrimitiveIrType::I8) => "Int8".into(),
+            Primitive(PrimitiveIrType::U8) => "Uint8".into(),
+            Primitive(PrimitiveIrType::I16) => "Int16".into(),
+            Primitive(PrimitiveIrType::U16) => "Uint16".into(),
+            Primitive(PrimitiveIrType::I32) => "Int32".into(),
+            Primitive(PrimitiveIrType::U32) => "Uint32".into(),
+            Primitive(PrimitiveIrType::I64) => "Int64".into(),
+            Primitive(PrimitiveIrType::U64) => "Uint64".into(),
+            Primitive(PrimitiveIrType::F32) => "Float32".into(),
+            Primitive(PrimitiveIrType::F64) => "Float64".into(),
+            Primitive(PrimitiveIrType::Bool) => "Bool".into(),
+            Primitive(PrimitiveIrType::DateTime) => "DateTime".into(),
+            Primitive(PrimitiveIrType::UnixTime) => "UnixTime".into(),
+            Primitive(PrimitiveIrType::Date) => "Date".into(),
+            Primitive(PrimitiveIrType::Url) => "Url".into(),
+            Primitive(PrimitiveIrType::Uuid) => "Uuid".into(),
+            Primitive(PrimitiveIrType::Bytes) => "Bytes".into(),
+            Primitive(PrimitiveIrType::Binary) => "Binary".into(),
+            Array => "Array".into(),
+            Map => "Map".into(),
+            Index(index) => Cow::Owned(format!("V{index}")),
+        };
+        f.write_str(&s)
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct CodegenStructFieldName(pub IrStructFieldNameHint);
+
+impl Display for CodegenStructFieldName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.0 {
+            IrStructFieldNameHint::Index(index) => {
+                write!(f, "variant_{index}")
+            }
+            IrStructFieldNameHint::AdditionalProperties => {
+                write!(f, "additional_properties")
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct CodegenTypePathSegment<'a>(&'a InlineIrTypePathSegment<'a>);
+
+impl Display for CodegenTypePathSegment<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use InlineIrTypePathSegment::*;
+        match self.0 {
+            Operation(name) => write!(f, "{}", AsPascalCase(clean(name))),
+            Parameter(name) => write!(f, "{}", AsPascalCase(clean(name))),
+            Request => f.write_str("Request"),
+            Response => f.write_str("Response"),
+            Field(IrStructFieldName::Name(name)) => {
+                write!(f, "{}", AsPascalCase(clean(name)))
+            }
+            Field(IrStructFieldName::Hint(IrStructFieldNameHint::Index(index))) => {
+                write!(f, "Variant{index}")
+            }
+            Field(IrStructFieldName::Hint(IrStructFieldNameHint::AdditionalProperties)) => {
+                f.write_str("AdditionalProperties")
+            }
+            MapValue => f.write_str("Value"),
+            ArrayItem => f.write_str("Item"),
+            Variant(index) => write!(f, "V{index}"),
+            Parent(index) => write!(f, "Parent{index}"),
+        }
+    }
+}
+
+/// Returns `true` if the name is a Python reserved word or built-in.
+///
+/// Note: Pydantic reserved names are handled by the scope's uniquifier, not
+/// here, so they get numeric suffixes (e.g., `schema0`) instead of trailing
+/// underscores.
+fn is_reserved(s: &str) -> bool {
+    KEYWORDS.contains(&s) || SOFT_KEYWORDS.contains(&s) || BUILTINS.contains(&s)
+}
+
+/// Makes a string suitable for inclusion within a Python identifier.
+///
+/// Cleaning segments the string on word boundaries, collapses all
+/// non-identifier characters into new boundaries, and reassembles the string.
+fn clean(s: &str) -> String {
+    WordSegments::new(s)
+        .flat_map(|s| s.split(|c: char| !c.is_alphanumeric() && c != '_'))
+        .join("_")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use pretty_assertions::assert_eq;
+
+    // MARK: Usages
+
+    #[test]
+    fn test_codegen_ident_class() {
+        let ident = CodegenIdent::new("pet_store");
+        let usage = CodegenIdentUsage::Class(&ident);
+        assert_eq!(usage.display().to_string(), "PetStore");
+    }
+
+    #[test]
+    fn test_codegen_ident_field() {
+        let ident = CodegenIdent::new("petStore");
+        let usage = CodegenIdentUsage::Field(&ident);
+        assert_eq!(usage.display().to_string(), "pet_store");
+    }
+
+    #[test]
+    fn test_codegen_ident_module() {
+        let ident = CodegenIdent::new("MyModule");
+        let usage = CodegenIdentUsage::Module(&ident);
+        assert_eq!(usage.display().to_string(), "my_module");
+    }
+
+    #[test]
+    fn test_codegen_ident_variant() {
+        let ident = CodegenIdent::new("http_error");
+        let usage = CodegenIdentUsage::Variant(&ident);
+        assert_eq!(usage.display().to_string(), "HTTP_ERROR");
+    }
+
+    #[test]
+    fn test_codegen_ident_method() {
+        let ident = CodegenIdent::new("getUserById");
+        let usage = CodegenIdentUsage::Method(&ident);
+        assert_eq!(usage.display().to_string(), "get_user_by_id");
+    }
+
+    // MARK: Special characters
+
+    #[test]
+    fn test_codegen_ident_handles_python_keywords() {
+        let ident = CodegenIdent::new("class");
+        let usage = CodegenIdentUsage::Field(&ident);
+        assert_eq!(usage.display().to_string(), "class_");
+    }
+
+    #[test]
+    fn test_codegen_ident_handles_invalid_start_chars() {
+        // Fields use `f_` prefix (not `_`) because Pydantic treats `_` prefixed
+        // fields as private attributes.
+        let ident = CodegenIdent::new("123foo");
+        let usage = CodegenIdentUsage::Field(&ident);
+        assert_eq!(usage.display().to_string(), "f_123_foo");
+    }
+
+    #[test]
+    fn test_codegen_ident_handles_special_chars() {
+        let ident = CodegenIdent::new("foo-bar-baz");
+        let usage = CodegenIdentUsage::Field(&ident);
+        assert_eq!(usage.display().to_string(), "foo_bar_baz");
+    }
+
+    #[test]
+    fn test_codegen_ident_handles_number_prefix() {
+        let ident = CodegenIdent::new("1099KStatus");
+
+        // Fields use `f_` prefix (not `_`) because Pydantic treats `_` prefixed
+        // fields as private attributes.
+        let usage = CodegenIdentUsage::Field(&ident);
+        assert_eq!(usage.display().to_string(), "f_1099_k_status");
+
+        // Classes use `_` prefix.
+        let usage = CodegenIdentUsage::Class(&ident);
+        assert_eq!(usage.display().to_string(), "_1099KStatus");
+    }
+
+    #[test]
+    fn test_codegen_ident_handles_builtins() {
+        let ident = CodegenIdent::new("list");
+        let usage = CodegenIdentUsage::Field(&ident);
+        assert_eq!(usage.display().to_string(), "list_");
+    }
+
+    #[test]
+    fn test_codegen_ident_scope_handles_pydantic_reserved() {
+        // Pydantic reserved names like `schema` and `json` are handled by the
+        // scope's uniquifier, which assigns numeric suffixes.
+        let unique = UniqueNames::new();
+        let mut scope = CodegenIdentScope::new(&unique);
+
+        // `schema` shadows BaseModel.schema (deprecated but still exists).
+        // The uniquifier finds the first available suffix.
+        let ident = scope.uniquify("schema");
+        let usage = CodegenIdentUsage::Field(&ident);
+        assert!(
+            usage.display().to_string().starts_with("schema"),
+            "expected schema with suffix, got: {}",
+            usage.display()
+        );
+        assert_ne!(
+            usage.display().to_string(),
+            "schema",
+            "should have a suffix"
+        );
+
+        // `json` shadows BaseModel.json (deprecated but still exists).
+        let ident = scope.uniquify("json");
+        let usage = CodegenIdentUsage::Field(&ident);
+        assert!(
+            usage.display().to_string().starts_with("json"),
+            "expected json with suffix, got: {}",
+            usage.display()
+        );
+        assert_ne!(usage.display().to_string(), "json", "should have a suffix");
+    }
+
+    // MARK: Untagged variant names
+
+    #[test]
+    fn test_untagged_variant_name_string() {
+        let variant_name = CodegenUntaggedVariantName(IrUntaggedVariantNameHint::Primitive(
+            PrimitiveIrType::String,
+        ));
+        assert_eq!(variant_name.to_string(), "Str");
+    }
+
+    #[test]
+    fn test_untagged_variant_name_i32() {
+        let variant_name =
+            CodegenUntaggedVariantName(IrUntaggedVariantNameHint::Primitive(PrimitiveIrType::I32));
+        assert_eq!(variant_name.to_string(), "Int32");
+    }
+
+    #[test]
+    fn test_untagged_variant_name_index() {
+        let variant_name = CodegenUntaggedVariantName(IrUntaggedVariantNameHint::Index(0));
+        assert_eq!(variant_name.to_string(), "V0");
+
+        let variant_name = CodegenUntaggedVariantName(IrUntaggedVariantNameHint::Index(42));
+        assert_eq!(variant_name.to_string(), "V42");
+    }
+
+    // MARK: `clean()`
+
+    #[test]
+    fn test_clean() {
+        assert_eq!(clean("foo-bar"), "foo_bar");
+        assert_eq!(clean("foo.bar"), "foo_bar");
+        assert_eq!(clean("foo bar"), "foo_bar");
+        assert_eq!(clean("foo@bar"), "foo_bar");
+        assert_eq!(clean("foo#bar"), "foo_bar");
+        assert_eq!(clean("foo!bar"), "foo_bar");
+
+        assert_eq!(clean("foo_bar"), "foo_bar");
+        assert_eq!(clean("FooBar"), "Foo_Bar");
+        assert_eq!(clean("foo123"), "foo123");
+        assert_eq!(clean("_foo"), "foo");
+
+        assert_eq!(clean("123foo"), "123_foo");
+        assert_eq!(clean("9bar"), "9_bar");
+    }
+
+    // MARK: Scopes
+
+    #[test]
+    fn test_codegen_ident_scope_handles_empty() {
+        let unique = UniqueNames::new();
+        let mut scope = CodegenIdentScope::new(&unique);
+        let ident = scope.uniquify("");
+
+        let usage = CodegenIdentUsage::Field(&ident);
+        // Empty string gets a numeric suffix (e.g., "0"), which starts with a
+        // digit, so it gets `f_` prefix (not `_`) because Pydantic treats `_`
+        // prefixed fields as private attributes.
+        assert!(usage.display().to_string().starts_with("f_"));
+    }
+}

--- a/ploidy-codegen-python/src/ref_.rs
+++ b/ploidy-codegen-python/src/ref_.rs
@@ -1,0 +1,206 @@
+//! Type reference generation for Python type hints.
+
+use ploidy_core::ir::{
+    ContainerView, ExtendableView, InlineIrTypeView, IrTypeView, PrimitiveIrType, SchemaIrTypeView,
+};
+use quasiquodo_py::{
+    py_quote,
+    ruff::{
+        python_ast::{Expr, Identifier},
+        text_size::TextRange,
+    },
+};
+
+use crate::naming::{CodegenIdent, CodegenIdentUsage, CodegenTypeName};
+
+/// Generates a Python type hint expression for an IR type.
+pub struct CodegenRef<'a> {
+    ty: &'a IrTypeView<'a>,
+}
+
+impl<'a> CodegenRef<'a> {
+    pub fn new(ty: &'a IrTypeView<'a>) -> Self {
+        Self { ty }
+    }
+
+    /// Converts the IR type to a Python type hint expression.
+    pub fn to_expr(&self) -> Expr {
+        match self.ty {
+            // Inline container types (array, map, optional).
+            IrTypeView::Inline(InlineIrTypeView::Container(_, ContainerView::Array(inner)))
+            | IrTypeView::Schema(SchemaIrTypeView::Container(_, ContainerView::Array(inner))) => {
+                let inner_ty = inner.ty();
+                let inner = CodegenRef::new(&inner_ty).to_expr();
+                py_quote!("list[#{inner}]" as Expr, inner: Expr = inner)
+            }
+            IrTypeView::Inline(InlineIrTypeView::Container(_, ContainerView::Map(inner)))
+            | IrTypeView::Schema(SchemaIrTypeView::Container(_, ContainerView::Map(inner))) => {
+                let inner_ty = inner.ty();
+                let inner = CodegenRef::new(&inner_ty).to_expr();
+                py_quote!("dict[str, #{inner}]" as Expr, inner: Expr = inner)
+            }
+            IrTypeView::Inline(InlineIrTypeView::Container(_, ContainerView::Optional(inner)))
+            | IrTypeView::Schema(SchemaIrTypeView::Container(_, ContainerView::Optional(inner))) => {
+                let inner_ty = inner.ty();
+                let inner = CodegenRef::new(&inner_ty).to_expr();
+                // Use Python 3.10+ union syntax: `T | None`.
+                py_quote!("#{inner} | None" as Expr, inner: Expr = inner)
+            }
+
+            // Primitive types (inline or schema).
+            IrTypeView::Inline(InlineIrTypeView::Primitive(_, view))
+            | IrTypeView::Schema(SchemaIrTypeView::Primitive(_, view)) => {
+                primitive_to_expr(view.ty())
+            }
+
+            // Any type (inline or schema).
+            IrTypeView::Inline(InlineIrTypeView::Any(_, _))
+            | IrTypeView::Schema(SchemaIrTypeView::Any(_, _)) => {
+                py_quote!("Any" as Expr)
+            }
+
+            // Other inline types are defined in the same module, so no import needed.
+            IrTypeView::Inline(ty) => {
+                let type_name = CodegenTypeName::Inline(ty).as_class_name();
+                py_quote!("#{name}" as Expr, name: Identifier = Identifier::new(&type_name, TextRange::default()))
+            }
+
+            // Named schema references.
+            IrTypeView::Schema(view) => {
+                let ext = view.extensions();
+                let ident = ext.get::<CodegenIdent>().unwrap();
+                let class_name = CodegenIdentUsage::Class(&ident).display().to_string();
+                py_quote!("#{name}" as Expr, name: Identifier = Identifier::new(&class_name, TextRange::default()))
+            }
+        }
+    }
+}
+
+/// Converts a primitive IR type to a Python type hint expression.
+fn primitive_to_expr(ty: PrimitiveIrType) -> Expr {
+    match ty {
+        PrimitiveIrType::String => py_quote!("str" as Expr),
+        PrimitiveIrType::I8
+        | PrimitiveIrType::U8
+        | PrimitiveIrType::I16
+        | PrimitiveIrType::U16
+        | PrimitiveIrType::I32
+        | PrimitiveIrType::U32
+        | PrimitiveIrType::I64
+        | PrimitiveIrType::U64 => py_quote!("int" as Expr),
+        PrimitiveIrType::F32 | PrimitiveIrType::F64 => py_quote!("float" as Expr),
+        PrimitiveIrType::Bool => py_quote!("bool" as Expr),
+        PrimitiveIrType::DateTime | PrimitiveIrType::UnixTime => {
+            py_quote!("datetime.datetime" as Expr)
+        }
+        PrimitiveIrType::Date => py_quote!("datetime.date" as Expr),
+        PrimitiveIrType::Url => {
+            // URLs are strings in Python (no standard URL type).
+            py_quote!("str" as Expr)
+        }
+        PrimitiveIrType::Uuid => py_quote!("UUID" as Expr),
+        PrimitiveIrType::Bytes | PrimitiveIrType::Binary => py_quote!("bytes" as Expr),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::generate_expr_source;
+    use pretty_assertions::assert_eq;
+
+    fn expr_to_source(expr: &Expr) -> String {
+        generate_expr_source(expr)
+    }
+
+    // MARK: Primitives
+
+    #[test]
+    fn test_primitive_string() {
+        assert_eq!(
+            expr_to_source(&primitive_to_expr(PrimitiveIrType::String)),
+            "str"
+        );
+    }
+
+    #[test]
+    fn test_primitive_i32() {
+        assert_eq!(
+            expr_to_source(&primitive_to_expr(PrimitiveIrType::I32)),
+            "int"
+        );
+    }
+
+    #[test]
+    fn test_primitive_i64() {
+        assert_eq!(
+            expr_to_source(&primitive_to_expr(PrimitiveIrType::I64)),
+            "int"
+        );
+    }
+
+    #[test]
+    fn test_primitive_f32() {
+        assert_eq!(
+            expr_to_source(&primitive_to_expr(PrimitiveIrType::F32)),
+            "float"
+        );
+    }
+
+    #[test]
+    fn test_primitive_f64() {
+        assert_eq!(
+            expr_to_source(&primitive_to_expr(PrimitiveIrType::F64)),
+            "float"
+        );
+    }
+
+    #[test]
+    fn test_primitive_bool() {
+        assert_eq!(
+            expr_to_source(&primitive_to_expr(PrimitiveIrType::Bool)),
+            "bool"
+        );
+    }
+
+    #[test]
+    fn test_primitive_datetime() {
+        assert_eq!(
+            expr_to_source(&primitive_to_expr(PrimitiveIrType::DateTime)),
+            "datetime.datetime"
+        );
+    }
+
+    #[test]
+    fn test_primitive_date() {
+        assert_eq!(
+            expr_to_source(&primitive_to_expr(PrimitiveIrType::Date)),
+            "datetime.date"
+        );
+    }
+
+    #[test]
+    fn test_primitive_url() {
+        assert_eq!(
+            expr_to_source(&primitive_to_expr(PrimitiveIrType::Url)),
+            "str"
+        );
+    }
+
+    #[test]
+    fn test_primitive_uuid() {
+        assert_eq!(
+            expr_to_source(&primitive_to_expr(PrimitiveIrType::Uuid)),
+            "UUID"
+        );
+    }
+
+    #[test]
+    fn test_primitive_bytes() {
+        assert_eq!(
+            expr_to_source(&primitive_to_expr(PrimitiveIrType::Bytes)),
+            "bytes"
+        );
+    }
+}

--- a/ploidy-codegen-python/src/schema.rs
+++ b/ploidy-codegen-python/src/schema.rs
@@ -1,0 +1,453 @@
+//! Per-SCC Python module file generation.
+//!
+//! Each strongly connected component (SCC) of schemas is emitted into a
+//! single Python module. Cross-SCC imports are guaranteed acyclic, so
+//! `TYPE_CHECKING` guards are no longer needed.
+
+use std::collections::BTreeMap;
+
+use itertools::Itertools;
+use ploidy_core::{
+    codegen::{Code, IntoCode},
+    ir::{InlineIrTypeView, SccId, SchemaIrTypeView, View, ViewNode},
+};
+use quasiquodo_py::{py_quote, ruff::python_ast::Suite};
+
+use crate::{
+    enum_::CodegenEnum,
+    imports::{ImportContext, isort},
+    model::CodegenModel,
+    naming::CodegenTypeName,
+    tagged::CodegenTagged,
+    untagged::CodegenUntagged,
+};
+
+/// Generates a complete Python module for all schemas in one SCC.
+///
+/// Each SCC is emitted as a single `.py` file. Imports are collected by
+/// calling `type_imports()` for each schema's dependencies and emitting
+/// structural imports (pydantic, typing, enum) inline. The final
+/// `consolidate_imports()` pass deduplicates and sorts them.
+#[derive(Debug)]
+pub struct CodegenSccModule<'a> {
+    schemas: &'a [SchemaIrTypeView<'a>],
+    scc_module_names: &'a BTreeMap<SccId, String>,
+}
+
+impl<'a> CodegenSccModule<'a> {
+    /// Creates a new SCC module generator for the given schemas and
+    /// SCC-to-module-name mapping.
+    pub fn new(
+        schemas: &'a [SchemaIrTypeView<'a>],
+        scc_module_names: &'a BTreeMap<SccId, String>,
+    ) -> Self {
+        Self {
+            schemas,
+            scc_module_names,
+        }
+    }
+
+    /// Returns the module name for this SCC from the precomputed mapping.
+    fn module_name(&self) -> &str {
+        let scc_id = self.schemas[0].scc_id();
+        &self.scc_module_names[&scc_id]
+    }
+
+    /// Generates the module content as a list of statements.
+    fn to_suite(&self) -> Suite {
+        // `from __future__ import annotations` enables lazy evaluation of
+        // type hints, so intra-module forward references just work.
+        let mut suite = vec![py_quote!("from __future__ import annotations" as Stmt)];
+        suite.extend(self.type_definition_stmts());
+        isort(&mut suite);
+        suite
+    }
+
+    /// Generates type definition statements for all schemas and their
+    /// inline types in this SCC.
+    ///
+    /// Emits inlines first (sorted for stability), then schemas. Since
+    /// `from __future__ import annotations` is present, order within a
+    /// module doesn't matter for forward references. Each codegen type
+    /// emits its own imports; the caller deduplicates via
+    /// `consolidate_imports`.
+    fn type_definition_stmts(&self) -> Suite {
+        let context = ImportContext::new(self.schemas[0].scc_id(), self.scc_module_names);
+        let mut suite = Suite::new();
+
+        // Collect all inline types across schemas for codegen.
+        let all_inlines: Vec<(usize, Vec<InlineIrTypeView<'_>>)> = self
+            .schemas
+            .iter()
+            .enumerate()
+            .map(|(i, ty)| (i, ty.inlines().collect_vec()))
+            .collect();
+
+        for (_, inlines) in &all_inlines {
+            let mut sorted_inlines: Vec<&InlineIrTypeView<'_>> = inlines.iter().collect();
+            sorted_inlines.sort_by_key(|i| CodegenTypeName::Inline(i).into_sort_key());
+
+            for inline in sorted_inlines {
+                let name = CodegenTypeName::Inline(inline);
+                suite.extend(match inline {
+                    InlineIrTypeView::Struct(_, view) => {
+                        CodegenModel::new(name, view).to_suite(context)
+                    }
+                    InlineIrTypeView::Enum(_, view) => CodegenEnum::new(name, view).to_suite(),
+                    InlineIrTypeView::Tagged(_, view) => {
+                        CodegenTagged::new(name, view).to_suite(context)
+                    }
+                    InlineIrTypeView::Untagged(_, view) => {
+                        CodegenUntagged::new(name, view).to_suite(context)
+                    }
+                    InlineIrTypeView::Container(..)
+                    | InlineIrTypeView::Primitive(..)
+                    | InlineIrTypeView::Any(..) => vec![],
+                });
+            }
+        }
+
+        let mut sorted_schemas: Vec<_> = self.schemas.iter().collect();
+        sorted_schemas.sort_by_key(|s| CodegenTypeName::Schema(s).into_sort_key());
+
+        for ty in sorted_schemas {
+            let name = CodegenTypeName::Schema(ty);
+            suite.extend(match ty {
+                SchemaIrTypeView::Struct(_, view) => CodegenModel::new(name, view).to_suite(context),
+                SchemaIrTypeView::Enum(_, view) => CodegenEnum::new(name, view).to_suite(),
+                SchemaIrTypeView::Tagged(_, view) => CodegenTagged::new(name, view).to_suite(context),
+                SchemaIrTypeView::Untagged(_, view) => {
+                    CodegenUntagged::new(name, view).to_suite(context)
+                }
+                SchemaIrTypeView::Container(..)
+                | SchemaIrTypeView::Primitive(..)
+                | SchemaIrTypeView::Any(..) => vec![],
+            });
+        }
+
+        suite
+    }
+}
+
+impl IntoCode for CodegenSccModule<'_> {
+    type Code = PythonCode;
+
+    fn into_code(self) -> Self::Code {
+        let path = format!("models/{}.py", self.module_name());
+        let suite = self.to_suite();
+
+        PythonCode { path, suite }
+    }
+}
+
+/// Represents generated Python code ready to be written to disk.
+#[derive(Debug)]
+pub struct PythonCode {
+    path: String,
+    suite: Suite,
+}
+
+impl Code for PythonCode {
+    fn path(&self) -> &str {
+        &self.path
+    }
+
+    fn into_string(self) -> miette::Result<String> {
+        Ok(crate::generate_source(&self.suite))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use indoc::indoc;
+    use ploidy_core::{
+        ir::{ExtendableView, IrGraph, IrSpec},
+        parse::Document,
+    };
+    use pretty_assertions::assert_eq;
+
+    use crate::{
+        CodegenGraph,
+        naming::{CodegenIdent, CodegenIdentUsage},
+    };
+
+    /// Builds the SCC module name mapping from a codegen graph.
+    fn build_scc_module_names(graph: &CodegenGraph<'_>) -> BTreeMap<SccId, String> {
+        let mut sccs: BTreeMap<SccId, Vec<_>> = BTreeMap::new();
+        for view in graph.schemas() {
+            sccs.entry(view.scc_id()).or_default().push(view);
+        }
+        sccs.iter()
+            .map(|(&scc_id, schemas)| {
+                let first = schemas.iter().min_by_key(|s| s.name()).unwrap();
+                let ident = first.extensions().get::<CodegenIdent>().unwrap();
+                let module_name = CodegenIdentUsage::Module(&ident).display().to_string();
+                (scc_id, module_name)
+            })
+            .collect()
+    }
+
+    /// Returns all schemas in the same SCC as the named schema.
+    fn schemas_in_scc<'a>(
+        graph: &'a CodegenGraph<'a>,
+        schema_name: &str,
+    ) -> Vec<SchemaIrTypeView<'a>> {
+        let target = graph.schemas().find(|s| s.name() == schema_name).unwrap();
+        let target_scc = target.scc_id();
+        graph
+            .schemas()
+            .filter(|s| s.scc_id() == target_scc)
+            .collect()
+    }
+
+    #[test]
+    fn test_scc_module_struct() {
+        let doc = Document::from_yaml(indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Pet:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    age:
+                      type: integer
+                      format: int32
+                  required:
+                    - name
+        "})
+        .unwrap();
+
+        let spec = IrSpec::from_doc(&doc).unwrap();
+        let ir = IrGraph::new(&spec);
+        let graph = CodegenGraph::new(ir);
+
+        let scc_module_names = build_scc_module_names(&graph);
+        let schemas = schemas_in_scc(&graph, "Pet");
+        let code = CodegenSccModule::new(&schemas, &scc_module_names).into_code();
+
+        assert_eq!(code.path(), "models/pet.py");
+
+        let source = code.into_string().unwrap();
+
+        assert_eq!(
+            source,
+            indoc! {"
+                from __future__ import annotations
+                from pydantic import BaseModel
+                class Pet(BaseModel):
+                    name: str
+                    age: int | None = None"
+            },
+        );
+    }
+
+    #[test]
+    fn test_scc_module_enum() {
+        let doc = Document::from_yaml(indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Status:
+                  type: string
+                  enum:
+                    - active
+                    - inactive
+        "})
+        .unwrap();
+
+        let spec = IrSpec::from_doc(&doc).unwrap();
+        let ir = IrGraph::new(&spec);
+        let graph = CodegenGraph::new(ir);
+
+        let scc_module_names = build_scc_module_names(&graph);
+        let schemas = schemas_in_scc(&graph, "Status");
+        let code = CodegenSccModule::new(&schemas, &scc_module_names).into_code();
+
+        assert_eq!(code.path(), "models/status.py");
+
+        let source = code.into_string().unwrap();
+
+        assert_eq!(
+            source,
+            indoc! {"
+                from __future__ import annotations
+                from enum import Enum
+                class Status(Enum):
+                    ACTIVE = 'active'
+                    INACTIVE = 'inactive'"
+            },
+        );
+    }
+
+    #[test]
+    fn test_scc_module_with_datetime() {
+        let doc = Document::from_yaml(indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Event:
+                  type: object
+                  properties:
+                    created_at:
+                      type: string
+                      format: date-time
+                  required:
+                    - created_at
+        "})
+        .unwrap();
+
+        let spec = IrSpec::from_doc(&doc).unwrap();
+        let ir = IrGraph::new(&spec);
+        let graph = CodegenGraph::new(ir);
+
+        let scc_module_names = build_scc_module_names(&graph);
+        let schemas = schemas_in_scc(&graph, "Event");
+        let code = CodegenSccModule::new(&schemas, &scc_module_names).into_code();
+
+        let source = code.into_string().unwrap();
+
+        assert_eq!(
+            source,
+            indoc! {"
+                from __future__ import annotations
+                import datetime
+                from pydantic import BaseModel
+                class Event(BaseModel):
+                    created_at: datetime.datetime"
+            },
+        );
+    }
+
+    #[test]
+    fn test_scc_module_with_cross_scc_reference() {
+        let doc = Document::from_yaml(indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Pet:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    owner:
+                      $ref: '#/components/schemas/Owner'
+                Owner:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    pets:
+                      type: array
+                      items:
+                        $ref: '#/components/schemas/Pet'
+        "})
+        .unwrap();
+
+        let spec = IrSpec::from_doc(&doc).unwrap();
+        let ir = IrGraph::new(&spec);
+        let graph = CodegenGraph::new(ir);
+
+        let scc_module_names = build_scc_module_names(&graph);
+
+        // Pet and Owner form a cycle, so they should be in the same SCC.
+        let pet = graph.schemas().find(|s| s.name() == "Pet").unwrap();
+        let owner = graph.schemas().find(|s| s.name() == "Owner").unwrap();
+        assert_eq!(
+            pet.scc_id(),
+            owner.scc_id(),
+            "Pet and Owner should be in the same SCC"
+        );
+
+        // Build the SCC module for the Pet/Owner SCC.
+        let schemas = schemas_in_scc(&graph, "Pet");
+        let code = CodegenSccModule::new(&schemas, &scc_module_names).into_code();
+
+        let source = code.into_string().unwrap();
+
+        assert_eq!(
+            source,
+            indoc! {"
+                from __future__ import annotations
+                from pydantic import BaseModel
+                class Owner(BaseModel):
+                    name: str | None = None
+                    pets: list[Pet] | None = None
+                class Pet(BaseModel):
+                    name: str | None = None
+                    owner: Owner | None = None"
+            },
+        );
+    }
+
+    #[test]
+    fn test_scc_module_cross_scc_direct_import() {
+        // Pet references Status (different SCC). The import should be
+        // a direct import, not under TYPE_CHECKING.
+        let doc = Document::from_yaml(indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Pet:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    status:
+                      $ref: '#/components/schemas/Status'
+                Status:
+                  type: string
+                  enum:
+                    - active
+                    - inactive
+        "})
+        .unwrap();
+
+        let spec = IrSpec::from_doc(&doc).unwrap();
+        let ir = IrGraph::new(&spec);
+        let graph = CodegenGraph::new(ir);
+        let scc_module_names = build_scc_module_names(&graph);
+
+        let schemas = schemas_in_scc(&graph, "Pet");
+        let code = CodegenSccModule::new(&schemas, &scc_module_names).into_code();
+
+        assert_eq!(code.path(), "models/pet.py");
+
+        let source = code.into_string().unwrap();
+
+        assert_eq!(
+            source,
+            indoc! {"
+                from __future__ import annotations
+                from pydantic import BaseModel
+                from .status import Status
+                class Pet(BaseModel):
+                    name: str | None = None
+                    status: Status | None = None"
+            },
+        );
+    }
+}

--- a/ploidy-codegen-python/src/tagged.rs
+++ b/ploidy-codegen-python/src/tagged.rs
@@ -1,0 +1,458 @@
+//! Pydantic discriminated union generation from IR tagged unions.
+//!
+//! Tagged unions in OpenAPI (`oneOf` with `discriminator`) are generated as
+//! Pydantic discriminated unions:
+//!
+//! - For schema reference variants, the discriminator field is added to the
+//!   schema itself (in `model.rs`), so we just reference it
+//! - For inline variants, a new `BaseModel` class is generated with the
+//!   discriminator field
+//! - A PEP 695 type alias: `type Pet = Annotated[Dog | Cat, Field(discriminator="tag")]`
+//!
+//! Using PEP 695 `type` statements (Python 3.12+) ensures lazy evaluation of
+//! the right-hand side, which is essential for recursive types like JSON Schema
+//! where a tagged union's variants may reference the union itself.
+//!
+//! This approach avoids duplicating fields from variant schemas and follows
+//! Pydantic's recommended discriminated union pattern.
+
+use ploidy_core::{
+    codegen::UniqueNames,
+    ir::{ExtendableView, IrTaggedView, IrTypeView},
+};
+use quasiquodo_py::{
+    py_quote,
+    ruff::{
+        python_ast::{Expr, Identifier, Suite},
+        text_size::TextRange,
+    },
+};
+
+use crate::{
+    imports::ImportContext,
+    model::generate_field_stmts,
+    naming::{CodegenIdent, CodegenIdentScope, CodegenIdentUsage, CodegenTypeName},
+    ref_::CodegenRef,
+};
+
+/// Generates a Pydantic discriminated union from an IR tagged union.
+#[derive(Clone, Debug)]
+pub struct CodegenTagged<'a> {
+    name: CodegenTypeName<'a>,
+    ty: &'a IrTaggedView<'a>,
+}
+
+impl<'a> CodegenTagged<'a> {
+    pub fn new(name: CodegenTypeName<'a>, ty: &'a IrTaggedView<'a>) -> Self {
+        Self { name, ty }
+    }
+
+    /// Generates all statements for this tagged union: imports + inline
+    /// variant classes + type alias.
+    pub fn to_suite(&self, context: ImportContext<'_>) -> Suite {
+        let mut import_stmts = Suite::new();
+
+        // Dependency imports (cross-SCC refs, datetime, uuid, etc.).
+        match &self.name {
+            CodegenTypeName::Schema(sv) => {
+                import_stmts.extend(crate::imports::collect_imports(*sv, context));
+            }
+            CodegenTypeName::Inline(iv) => {
+                import_stmts.extend(crate::imports::collect_imports(*iv, context));
+            }
+        }
+
+        // Structural imports.
+        import_stmts.push(py_quote!("from typing import Annotated" as Stmt));
+        import_stmts.push(py_quote!("from pydantic import Field" as Stmt));
+
+        let has_inline_variant = self
+            .ty
+            .variants()
+            .any(|v| matches!(v.ty(), IrTypeView::Inline(_)));
+        if has_inline_variant {
+            import_stmts.push(py_quote!("from pydantic import BaseModel" as Stmt));
+            import_stmts.push(py_quote!("from typing import Literal" as Stmt));
+        }
+
+        // Type definitions.
+        let discriminator_field = self.ty.tag();
+        let union_name = self.name.as_class_name();
+
+        let unique = UniqueNames::new();
+        let mut scope = CodegenIdentScope::new(&unique);
+
+        let mut variant_classes = Vec::new();
+        let mut variant_type_exprs: Vec<Expr> = Vec::new();
+
+        for variant in self.ty.variants() {
+            let view = variant.ty();
+            match &view {
+                // For schema references, use direct name references. PEP 695
+                // type statements evaluate lazily, so recursive types work.
+                ploidy_core::ir::IrTypeView::Schema(schema_view) => {
+                    let ident = schema_view.extensions().get::<CodegenIdent>().unwrap();
+                    let class_name = CodegenIdentUsage::Class(&ident).display().to_string();
+
+                    variant_type_exprs.push(py_quote!(
+                        "#{name}" as Expr,
+                        name: Identifier = Identifier::new(&class_name, TextRange::default())
+                    ));
+                }
+
+                // For inline struct types, generate a class with the struct's
+                // fields plus the discriminator.
+                ploidy_core::ir::IrTypeView::Inline(ploidy_core::ir::InlineIrTypeView::Struct(
+                    _,
+                    struct_view,
+                )) => {
+                    let discriminator_value =
+                        variant.aliases().first().copied().unwrap_or(variant.name());
+
+                    let variant_ident = scope.uniquify(variant.name());
+                    let variant_class_name = CodegenIdentUsage::Class(&variant_ident)
+                        .display()
+                        .to_string();
+
+                    let discriminator_field_name =
+                        CodegenIdentUsage::Field(&CodegenIdent::new(discriminator_field))
+                            .display()
+                            .to_string();
+                    let discriminator_stmt = py_quote!(
+                        r#"#{name}: Literal[#{value}] = #{value}"# as Stmt,
+                        name: Identifier = Identifier::new(&discriminator_field_name, TextRange::default()),
+                        value: &str = discriminator_value
+                    );
+
+                    let mut class_body = vec![discriminator_stmt];
+                    class_body.extend(generate_field_stmts(struct_view));
+
+                    let class_name_ident =
+                        Identifier::new(&variant_class_name, TextRange::default());
+                    variant_classes.push(py_quote!(
+                        "class #{name}(BaseModel):
+                             #{body}
+                        " as Stmt,
+                        name: Identifier = class_name_ident,
+                        body: Suite = class_body
+                    ));
+
+                    variant_type_exprs.push(py_quote!(
+                        "#{name}" as Expr,
+                        name: Identifier = Identifier::new(&variant_class_name, TextRange::default())
+                    ));
+                }
+
+                // For other inline types (tagged, untagged, enum), generate a
+                // wrapper class with the discriminator and a `value` field.
+                _ => {
+                    let discriminator_value =
+                        variant.aliases().first().copied().unwrap_or(variant.name());
+
+                    let variant_ident = scope.uniquify(variant.name());
+                    let variant_class_name = CodegenIdentUsage::Class(&variant_ident)
+                        .display()
+                        .to_string();
+
+                    let discriminator_field_name =
+                        CodegenIdentUsage::Field(&CodegenIdent::new(discriminator_field))
+                            .display()
+                            .to_string();
+                    let discriminator_stmt = py_quote!(
+                        r#"#{name}: Literal[#{value}] = #{value}"# as Stmt,
+                        name: Identifier = Identifier::new(&discriminator_field_name, TextRange::default()),
+                        value: &str = discriminator_value
+                    );
+
+                    let ty_ref = CodegenRef::new(&view).to_expr();
+                    let value_stmt = py_quote!(
+                        "#{name}: #{ty}" as Stmt,
+                        name: Identifier = Identifier::new("value", TextRange::default()),
+                        ty: Expr = ty_ref
+                    );
+                    let class_body = vec![discriminator_stmt, value_stmt];
+
+                    let class_name_ident =
+                        Identifier::new(&variant_class_name, TextRange::default());
+                    variant_classes.push(py_quote!(
+                        "class #{name}(BaseModel):
+                             #{body}
+                        " as Stmt,
+                        name: Identifier = class_name_ident,
+                        body: Suite = class_body
+                    ));
+
+                    variant_type_exprs.push(py_quote!(
+                        "#{name}" as Expr,
+                        name: Identifier = Identifier::new(&variant_class_name, TextRange::default())
+                    ));
+                }
+            }
+        }
+
+        import_stmts.extend(variant_classes);
+
+        // Generate the PEP 695 type alias:
+        // `type Pet = Annotated[Dog | Cat, Field(discriminator="pet_type")]`
+        if !variant_type_exprs.is_empty() {
+            let union_expr = variant_type_exprs
+                .into_iter()
+                .reduce(|l, r| py_quote!("#{l} | #{r}" as Expr, l: Expr = l, r: Expr = r))
+                .expect("variant_type_exprs is non-empty");
+
+            let discriminator_python_name =
+                CodegenIdentUsage::Field(&CodegenIdent::new(discriminator_field))
+                    .display()
+                    .to_string();
+
+            let annotated = py_quote!(
+                r#"Annotated[#{union}, Field(discriminator=#{disc})]"# as Expr,
+                union: Expr = union_expr,
+                disc: &str = &discriminator_python_name
+            );
+
+            if let Some(desc) = self.ty.description() {
+                import_stmts.push(py_quote!("#{desc}" as Stmt, desc: &str = desc));
+            }
+
+            import_stmts.push(py_quote!(
+                "type #{name} = #{ty}" as Stmt,
+                name: Identifier = Identifier::new(&union_name, TextRange::default()),
+                ty: Expr = annotated
+            ));
+        }
+
+        import_stmts
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::collections::BTreeMap;
+
+    use crate::{
+        CodegenGraph, generate_source,
+        naming::{CodegenIdent, CodegenIdentUsage},
+    };
+    use indoc::indoc;
+    use ploidy_core::{
+        ir::{ExtendableView, IrGraph, IrSpec, SccId, SchemaIrTypeView, ViewNode},
+        parse::Document,
+    };
+    use pretty_assertions::assert_eq;
+
+    fn to_source(suite: &Suite) -> String {
+        generate_source(suite)
+    }
+
+    #[test]
+    fn test_tagged_union_basic() {
+        let doc = Document::from_yaml(indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Dog:
+                  type: object
+                  properties:
+                    bark:
+                      type: string
+                Cat:
+                  type: object
+                  properties:
+                    meow:
+                      type: string
+                Pet:
+                  oneOf:
+                    - $ref: '#/components/schemas/Dog'
+                    - $ref: '#/components/schemas/Cat'
+                  discriminator:
+                    propertyName: petType
+                    mapping:
+                      dog: '#/components/schemas/Dog'
+                      cat: '#/components/schemas/Cat'
+        "})
+        .unwrap();
+
+        let spec = IrSpec::from_doc(&doc).unwrap();
+        let ir = IrGraph::new(&spec);
+        let graph = CodegenGraph::new(ir);
+
+        let scc_module_names: BTreeMap<SccId, String> = graph
+            .schemas()
+            .map(|s| {
+                let ident = s.extensions().get::<CodegenIdent>().unwrap();
+                (
+                    s.scc_id(),
+                    CodegenIdentUsage::Module(&ident).display().to_string(),
+                )
+            })
+            .collect();
+
+        let schema = graph.schemas().find(|s| s.name() == "Pet");
+        let Some(schema @ SchemaIrTypeView::Tagged(_, tagged)) = &schema else {
+            panic!("expected tagged union `Pet`; got `{schema:?}`");
+        };
+
+        let name = CodegenTypeName::Schema(schema);
+        let suite = CodegenTagged::new(name, tagged)
+            .to_suite(ImportContext::new(schema.scc_id(), &scc_module_names));
+
+        let source = to_source(&suite);
+        assert_eq!(
+            source,
+            indoc! {"
+                from .dog import Dog
+                from .cat import Cat
+                from typing import Annotated
+                from pydantic import Field
+                type Pet = Annotated[Dog | Cat, Field(discriminator='pet_type')]"
+            },
+        );
+    }
+
+    #[test]
+    fn test_tagged_union_with_description() {
+        let doc = Document::from_yaml(indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Dog:
+                  type: object
+                  properties:
+                    bark:
+                      type: string
+                Cat:
+                  type: object
+                  properties:
+                    meow:
+                      type: string
+                Pet:
+                  description: A pet can be either a dog or a cat.
+                  oneOf:
+                    - $ref: '#/components/schemas/Dog'
+                    - $ref: '#/components/schemas/Cat'
+                  discriminator:
+                    propertyName: type
+                    mapping:
+                      dog: '#/components/schemas/Dog'
+                      cat: '#/components/schemas/Cat'
+        "})
+        .unwrap();
+
+        let spec = IrSpec::from_doc(&doc).unwrap();
+        let ir = IrGraph::new(&spec);
+        let graph = CodegenGraph::new(ir);
+
+        let scc_module_names: BTreeMap<SccId, String> = graph
+            .schemas()
+            .map(|s| {
+                let ident = s.extensions().get::<CodegenIdent>().unwrap();
+                (
+                    s.scc_id(),
+                    CodegenIdentUsage::Module(&ident).display().to_string(),
+                )
+            })
+            .collect();
+
+        let schema = graph.schemas().find(|s| s.name() == "Pet");
+        let Some(schema @ SchemaIrTypeView::Tagged(_, tagged)) = &schema else {
+            panic!("expected tagged union `Pet`; got `{schema:?}`");
+        };
+
+        let name = CodegenTypeName::Schema(schema);
+        let suite = CodegenTagged::new(name, tagged)
+            .to_suite(ImportContext::new(schema.scc_id(), &scc_module_names));
+
+        let source = to_source(&suite);
+        assert_eq!(
+            source,
+            indoc! {"
+                from .dog import Dog
+                from .cat import Cat
+                from typing import Annotated
+                from pydantic import Field
+                'A pet can be either a dog or a cat.'
+                type Pet = Annotated[Dog | Cat, Field(discriminator='type_')]"
+            },
+        );
+    }
+
+    #[test]
+    fn test_tagged_union_custom_discriminator_mapping() {
+        let doc = Document::from_yaml(indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Dog:
+                  type: object
+                  properties:
+                    bark:
+                      type: string
+                Cat:
+                  type: object
+                  properties:
+                    meow:
+                      type: string
+                Pet:
+                  oneOf:
+                    - $ref: '#/components/schemas/Dog'
+                    - $ref: '#/components/schemas/Cat'
+                  discriminator:
+                    propertyName: type
+                    mapping:
+                      canine: '#/components/schemas/Dog'
+                      feline: '#/components/schemas/Cat'
+        "})
+        .unwrap();
+
+        let spec = IrSpec::from_doc(&doc).unwrap();
+        let ir = IrGraph::new(&spec);
+        let graph = CodegenGraph::new(ir);
+
+        let scc_module_names: BTreeMap<SccId, String> = graph
+            .schemas()
+            .map(|s| {
+                let ident = s.extensions().get::<CodegenIdent>().unwrap();
+                (
+                    s.scc_id(),
+                    CodegenIdentUsage::Module(&ident).display().to_string(),
+                )
+            })
+            .collect();
+
+        let schema = graph.schemas().find(|s| s.name() == "Pet");
+        let Some(schema @ SchemaIrTypeView::Tagged(_, tagged)) = &schema else {
+            panic!("expected tagged union `Pet`; got `{schema:?}`");
+        };
+
+        let name = CodegenTypeName::Schema(schema);
+        let suite = CodegenTagged::new(name, tagged)
+            .to_suite(ImportContext::new(schema.scc_id(), &scc_module_names));
+
+        let source = to_source(&suite);
+        assert_eq!(
+            source,
+            indoc! {"
+                from .dog import Dog
+                from .cat import Cat
+                from typing import Annotated
+                from pydantic import Field
+                type Pet = Annotated[Dog | Cat, Field(discriminator='type_')]"
+            },
+        );
+    }
+}

--- a/ploidy-codegen-python/src/tests.rs
+++ b/ploidy-codegen-python/src/tests.rs
@@ -1,0 +1,16 @@
+//! Shared test utilities for the Python code generator.
+
+/// A helper macro for pattern matching assertions.
+#[macro_export]
+macro_rules! assert_matches {
+    ($expression:expr, $pattern:pat $(if $guard:expr)? $(,)?) => {
+        match $expression {
+            $pattern $(if $guard)? => {}
+            ref e => panic!(
+                "assertion failed: `{:?}` does not match `{}`",
+                e,
+                stringify!($pattern $(if $guard)?)
+            ),
+        }
+    };
+}

--- a/ploidy-codegen-python/src/types.rs
+++ b/ploidy-codegen-python/src/types.rs
@@ -1,0 +1,327 @@
+//! Generation of the `models/__init__.py` module.
+
+use std::collections::BTreeMap;
+
+use itertools::Itertools;
+use ploidy_core::{
+    codegen::{Code, IntoCode},
+    ir::{ExtendableView, SccId, SchemaIrTypeView, ViewNode},
+};
+use quasiquodo_py::{
+    py_quote,
+    ruff::{
+        python_ast::{Alias, Expr, Identifier, Suite},
+        text_size::TextRange,
+    },
+};
+
+use crate::{
+    graph::CodegenGraph,
+    naming::{CodegenIdent, CodegenIdentUsage},
+};
+
+/// Generates the `models/__init__.py` module that exports all types.
+pub struct CodegenTypesModule<'a> {
+    graph: &'a CodegenGraph<'a>,
+}
+
+impl<'a> CodegenTypesModule<'a> {
+    pub fn new(graph: &'a CodegenGraph<'a>) -> Self {
+        Self { graph }
+    }
+
+    fn to_suite(&self) -> Suite {
+        let mut suite = Suite::new();
+
+        // Group schemas by SCC to determine which module each schema
+        // lives in. Multi-schema SCCs share a module named after the
+        // alphabetically first schema.
+        let mut sccs: BTreeMap<SccId, Vec<SchemaIrTypeView<'_>>> = BTreeMap::new();
+        for view in self.graph.schemas() {
+            sccs.entry(view.scc_id()).or_default().push(view);
+        }
+
+        // Compute the module name for each SCC (alphabetically first
+        // schema's module name).
+        let scc_module_names: BTreeMap<SccId, String> = sccs
+            .iter()
+            .map(|(&scc_id, schemas)| {
+                let first = schemas.iter().min_by_key(|s| s.name()).unwrap();
+                let ident = first.extensions().get::<CodegenIdent>().unwrap();
+                let module_name = CodegenIdentUsage::Module(&ident).display().to_string();
+                (scc_id, module_name)
+            })
+            .collect();
+
+        // Collect all schemas with their idents and SCC module names,
+        // sorted alphabetically by ident.
+        let mut types_with_info: Vec<_> = self
+            .graph
+            .schemas()
+            .filter_map(|view| {
+                let ident = view.extensions().get::<CodegenIdent>()?.clone();
+                let module_name = scc_module_names[&view.scc_id()].clone();
+                Some((ident, module_name))
+            })
+            .collect();
+        // Sort by module name first (so `chunk_by` groups all schemas in
+        // the same SCC module together), then by class name within each
+        // module.
+        types_with_info.sort_by(|(a, ma), (b, mb)| ma.cmp(mb).then_with(|| a.cmp(b)));
+
+        // Generate grouped import statements. Schemas in the same SCC
+        // module produce a single `from .module import A, B` statement.
+        for (_module_name, group) in &types_with_info
+            .iter()
+            .chunk_by(|(_, module_name)| module_name.clone())
+        {
+            let group = group.collect_vec();
+            let module_name = &group[0].1;
+            let names: Vec<Alias> = group
+                .iter()
+                .map(|(ident, _)| {
+                    let type_name = CodegenIdentUsage::Class(ident).display().to_string();
+                    py_quote!(
+                        "#{n}" as Alias,
+                        n: Identifier = Identifier::new(
+                            &type_name,
+                            TextRange::default()
+                        )
+                    )
+                })
+                .collect();
+            suite.push(py_quote!(
+                "from .#{module} import #{names}" as Stmt,
+                module: Identifier = Identifier::new(
+                    module_name,
+                    TextRange::default()
+                ),
+                names: Vec<Alias> = names
+            ));
+        }
+
+        // Generate `__all__` list.
+        if !types_with_info.is_empty() {
+            let all_items: Vec<Expr> = types_with_info
+                .iter()
+                .map(|(ident, _)| {
+                    let type_name = CodegenIdentUsage::Class(ident).display().to_string();
+                    py_quote!("#{name}" as Expr, name: &str = &type_name)
+                })
+                .collect();
+            suite.push(py_quote!(
+                "__all__ = [#{items}]" as Stmt,
+                items: Vec<Expr> = all_items
+            ));
+        }
+
+        suite
+    }
+}
+
+impl IntoCode for CodegenTypesModule<'_> {
+    type Code = PythonInitCode;
+
+    fn into_code(self) -> Self::Code {
+        PythonInitCode {
+            suite: self.to_suite(),
+        }
+    }
+}
+
+/// Represents the generated `__init__.py` code.
+#[derive(Debug)]
+pub struct PythonInitCode {
+    suite: Suite,
+}
+
+impl Code for PythonInitCode {
+    fn path(&self) -> &str {
+        "models/__init__.py"
+    }
+
+    fn into_string(self) -> miette::Result<String> {
+        Ok(crate::generate_source(&self.suite))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use indoc::indoc;
+    use ploidy_core::{
+        ir::{IrGraph, IrSpec},
+        parse::Document,
+    };
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn test_types_module_exports_all_schemas() {
+        let doc = Document::from_yaml(indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Pet:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                User:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                Status:
+                  type: string
+                  enum:
+                    - active
+                    - inactive
+        "})
+        .unwrap();
+
+        let spec = IrSpec::from_doc(&doc).unwrap();
+        let ir = IrGraph::new(&spec);
+        let graph = CodegenGraph::new(ir);
+
+        let code = CodegenTypesModule::new(&graph).into_code();
+
+        assert_eq!(code.path(), "models/__init__.py");
+
+        let source = code.into_string().unwrap();
+
+        assert_eq!(
+            source,
+            indoc! {"
+                from .pet import Pet
+                from .status import Status
+                from .user import User
+                __all__ = ['Pet', 'Status', 'User']"
+            },
+        );
+    }
+
+    #[test]
+    fn test_types_module_empty() {
+        let doc = Document::from_yaml(indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+        "})
+        .unwrap();
+
+        let spec = IrSpec::from_doc(&doc).unwrap();
+        let ir = IrGraph::new(&spec);
+        let graph = CodegenGraph::new(ir);
+
+        let code = CodegenTypesModule::new(&graph).into_code();
+        let source = code.into_string().unwrap();
+
+        assert!(source.is_empty());
+    }
+
+    #[test]
+    fn test_types_module_groups_scc_imports() {
+        let doc = Document::from_yaml(indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Pet:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    owner:
+                      $ref: '#/components/schemas/Owner'
+                Owner:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    pets:
+                      type: array
+                      items:
+                        $ref: '#/components/schemas/Pet'
+                Status:
+                  type: string
+                  enum:
+                    - active
+                    - inactive
+        "})
+        .unwrap();
+
+        let spec = IrSpec::from_doc(&doc).unwrap();
+        let ir = IrGraph::new(&spec);
+        let graph = CodegenGraph::new(ir);
+
+        let code = CodegenTypesModule::new(&graph).into_code();
+        let source = code.into_string().unwrap();
+
+        assert_eq!(
+            source,
+            indoc! {"
+                from .owner import Owner, Pet
+                from .status import Status
+                __all__ = ['Owner', 'Pet', 'Status']"
+            },
+        );
+    }
+
+    #[test]
+    fn test_types_module_groups_scc_imports_interleaved() {
+        // Alpha and Charlie form a cycle (same SCC module = "alpha").
+        // Beta is independent and sorts between them alphabetically.
+        // The grouped import for Alpha/Charlie must not be split by Beta.
+        let doc = Document::from_yaml(indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Alpha:
+                  type: object
+                  properties:
+                    c:
+                      $ref: '#/components/schemas/Charlie'
+                Beta:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                Charlie:
+                  type: object
+                  properties:
+                    a:
+                      $ref: '#/components/schemas/Alpha'
+        "})
+        .unwrap();
+
+        let spec = IrSpec::from_doc(&doc).unwrap();
+        let ir = IrGraph::new(&spec);
+        let graph = CodegenGraph::new(ir);
+
+        let code = CodegenTypesModule::new(&graph).into_code();
+        let source = code.into_string().unwrap();
+
+        assert_eq!(
+            source,
+            indoc! {"
+                from .alpha import Alpha, Charlie
+                from .beta import Beta
+                __all__ = ['Alpha', 'Charlie', 'Beta']"
+            },
+        );
+    }
+}

--- a/ploidy-codegen-python/src/untagged.rs
+++ b/ploidy-codegen-python/src/untagged.rs
@@ -1,0 +1,272 @@
+//! Python union type alias generation from IR untagged unions.
+//!
+//! Untagged unions in OpenAPI (`oneOf` without `discriminator`) are generated
+//! as simple union type aliases: `StringOrInt = str | int`
+
+use ploidy_core::ir::{IrUntaggedView, SomeIrUntaggedVariant};
+use quasiquodo_py::{
+    py_quote,
+    ruff::{
+        python_ast::{Expr, Identifier, Suite},
+        text_size::TextRange,
+    },
+};
+
+use crate::{imports::ImportContext, naming::CodegenTypeName, ref_::CodegenRef};
+
+/// Generates a Python union type alias from an IR untagged union.
+#[derive(Clone, Debug)]
+pub struct CodegenUntagged<'a> {
+    name: CodegenTypeName<'a>,
+    ty: &'a IrUntaggedView<'a>,
+}
+
+impl<'a> CodegenUntagged<'a> {
+    pub fn new(name: CodegenTypeName<'a>, ty: &'a IrUntaggedView<'a>) -> Self {
+        Self { name, ty }
+    }
+
+    /// Generates all statements for this untagged union: dependency
+    /// imports + type alias.
+    pub fn to_suite(&self, context: ImportContext<'_>) -> Suite {
+        let mut suite = Suite::new();
+
+        // Dependency imports (cross-SCC refs, datetime, uuid, etc.).
+        match &self.name {
+            CodegenTypeName::Schema(sv) => {
+                suite.extend(crate::imports::collect_imports(*sv, context));
+            }
+            CodegenTypeName::Inline(iv) => {
+                suite.extend(crate::imports::collect_imports(*iv, context));
+            }
+        }
+
+        // Type definition.
+        let union_name = self.name.as_class_name();
+
+        if let Some(desc) = self.ty.description() {
+            suite.push(py_quote!("#{desc}" as Stmt, desc: &str = desc));
+        }
+
+        // Collect variant types.
+        let variant_exprs: Vec<Expr> = self
+            .ty
+            .variants()
+            .map(|variant| match variant.ty() {
+                Some(SomeIrUntaggedVariant { view, hint: _ }) => CodegenRef::new(&view).to_expr(),
+                None => py_quote!("None" as Expr),
+            })
+            .collect();
+
+        // Create the PEP 695 type alias: `type Name = T1 | T2 | T3`.
+        if let Some(union_expr) = variant_exprs
+            .into_iter()
+            .reduce(|left, right| py_quote!("#{l} | #{r}" as Expr, l: Expr = left, r: Expr = right))
+        {
+            suite.push(py_quote!(
+                "type #{name} = #{ty}" as Stmt,
+                name: Identifier = Identifier::new(&union_name, TextRange::default()),
+                ty: Expr = union_expr
+            ));
+        }
+
+        suite
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::collections::BTreeMap;
+
+    use crate::{
+        CodegenGraph, generate_source,
+        naming::{CodegenIdent, CodegenIdentUsage},
+    };
+    use indoc::indoc;
+    use ploidy_core::{
+        ir::{ExtendableView, IrGraph, IrSpec, SccId, SchemaIrTypeView, ViewNode},
+        parse::Document,
+    };
+    use pretty_assertions::assert_eq;
+
+    fn to_source(suite: &Suite) -> String {
+        generate_source(suite)
+    }
+
+    #[test]
+    fn test_untagged_union_primitives() {
+        let doc = Document::from_yaml(indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                StringOrInt:
+                  oneOf:
+                    - type: string
+                    - type: integer
+                      format: int32
+        "})
+        .unwrap();
+
+        let spec = IrSpec::from_doc(&doc).unwrap();
+        let ir = IrGraph::new(&spec);
+        let graph = CodegenGraph::new(ir);
+
+        let schema = graph.schemas().find(|s| s.name() == "StringOrInt");
+        let Some(schema @ SchemaIrTypeView::Untagged(_, untagged_view)) = &schema else {
+            panic!("expected untagged union `StringOrInt`; got `{schema:?}`");
+        };
+
+        let name = CodegenTypeName::Schema(schema);
+        let suite = CodegenUntagged::new(name, untagged_view)
+            .to_suite(ImportContext::new(schema.scc_id(), &BTreeMap::new()));
+
+        let source = to_source(&suite);
+        assert_eq!(source, "type StringOrInt = str | int");
+    }
+
+    #[test]
+    fn test_untagged_union_with_description() {
+        let doc = Document::from_yaml(indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                StringOrInt:
+                  description: A value that can be either a string or an integer.
+                  oneOf:
+                    - type: string
+                    - type: integer
+                      format: int32
+        "})
+        .unwrap();
+
+        let spec = IrSpec::from_doc(&doc).unwrap();
+        let ir = IrGraph::new(&spec);
+        let graph = CodegenGraph::new(ir);
+
+        let schema = graph.schemas().find(|s| s.name() == "StringOrInt");
+        let Some(schema @ SchemaIrTypeView::Untagged(_, untagged_view)) = &schema else {
+            panic!("expected untagged union `StringOrInt`; got `{schema:?}`");
+        };
+
+        let name = CodegenTypeName::Schema(schema);
+        let suite = CodegenUntagged::new(name, untagged_view)
+            .to_suite(ImportContext::new(schema.scc_id(), &BTreeMap::new()));
+
+        let source = to_source(&suite);
+        assert_eq!(
+            source,
+            indoc! {"
+                'A value that can be either a string or an integer.'
+                type StringOrInt = str | int"
+            },
+        );
+    }
+
+    #[test]
+    fn test_untagged_union_with_refs() {
+        let doc = Document::from_yaml(indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Dog:
+                  type: object
+                  properties:
+                    bark:
+                      type: string
+                Cat:
+                  type: object
+                  properties:
+                    meow:
+                      type: string
+                Animal:
+                  oneOf:
+                    - $ref: '#/components/schemas/Dog'
+                    - $ref: '#/components/schemas/Cat'
+        "})
+        .unwrap();
+
+        let spec = IrSpec::from_doc(&doc).unwrap();
+        let ir = IrGraph::new(&spec);
+        let graph = CodegenGraph::new(ir);
+
+        let scc_module_names: BTreeMap<SccId, String> = graph
+            .schemas()
+            .map(|s| {
+                let ident = s.extensions().get::<CodegenIdent>().unwrap();
+                (
+                    s.scc_id(),
+                    CodegenIdentUsage::Module(&ident).display().to_string(),
+                )
+            })
+            .collect();
+
+        let schema = graph.schemas().find(|s| s.name() == "Animal");
+        let Some(schema @ SchemaIrTypeView::Untagged(_, untagged_view)) = &schema else {
+            panic!("expected untagged union `Animal`; got `{schema:?}`");
+        };
+
+        let name = CodegenTypeName::Schema(schema);
+        let suite = CodegenUntagged::new(name, untagged_view)
+            .to_suite(ImportContext::new(schema.scc_id(), &scc_module_names));
+
+        let source = to_source(&suite);
+        assert_eq!(
+            source,
+            indoc! {"
+                from .dog import Dog
+                from .cat import Cat
+                type Animal = Dog | Cat"
+            },
+        );
+    }
+
+    #[test]
+    fn test_untagged_union_multiple_types() {
+        let doc = Document::from_yaml(indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                MultiType:
+                  oneOf:
+                    - type: string
+                    - type: integer
+                      format: int32
+                    - type: boolean
+        "})
+        .unwrap();
+
+        let spec = IrSpec::from_doc(&doc).unwrap();
+        let ir = IrGraph::new(&spec);
+        let graph = CodegenGraph::new(ir);
+
+        let schema = graph.schemas().find(|s| s.name() == "MultiType");
+        let Some(schema @ SchemaIrTypeView::Untagged(_, untagged_view)) = &schema else {
+            panic!("expected untagged union `MultiType`; got `{schema:?}`");
+        };
+
+        let name = CodegenTypeName::Schema(schema);
+        let suite = CodegenUntagged::new(name, untagged_view)
+            .to_suite(ImportContext::new(schema.scc_id(), &BTreeMap::new()));
+
+        let source = to_source(&suite);
+        assert_eq!(source, "type MultiType = str | int | bool");
+    }
+}

--- a/ploidy-core/src/ir/graph.rs
+++ b/ploidy-core/src/ir/graph.rs
@@ -33,7 +33,8 @@ pub(super) type IrGraphG<'a> = DiGraph<IrGraphNode<'a>, EdgeKind, usize>;
 #[derive(Debug)]
 pub struct IrGraph<'a> {
     pub(super) spec: &'a IrSpec<'a>,
-    pub(super) g: IrGraphG<'a>,
+    /// The underlying directed graph of type references.
+    pub g: IrGraphG<'a>,
     /// An inverted index of nodes to graph indices.
     pub(super) indices: FxHashMap<IrGraphNode<'a>, NodeIndex<usize>>,
     /// Additional metadata for each node.
@@ -91,7 +92,7 @@ impl<'a> IrGraph<'a> {
                     let mut scc = TarjanScc::new();
                     scc.run(&refs, |_| ());
                     g.node_indices()
-                        .map(|node| scc.node_component_index(&refs, node))
+                        .map(|node| SccId(scc.node_component_index(&refs, node)))
                         .collect()
                 },
                 ..Default::default()
@@ -265,12 +266,20 @@ pub enum EdgeKind {
     Inherits,
 }
 
+/// Identifies a strongly connected component in the type graph.
+///
+/// Nodes with the same `SccId` form a cycle through reference edges
+/// and must be co-located to avoid circular imports. The inner value
+/// is opaque; only equality and ordering are meaningful.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct SccId(usize);
+
 /// Precomputed metadata for schema types and operations in the graph.
 #[derive(Debug, Default)]
 pub struct IrGraphMetadata<'a> {
     /// Maps each node index to its strongly connected component index.
     /// Nodes in the same SCC form a cycle.
-    pub scc_indices: Vec<usize>,
+    pub scc_indices: Vec<SccId>,
     pub schemas: FxHashMap<NodeIndex<usize>, IrGraphNodeMeta<'a>>,
     pub operations: FxHashMap<ByAddress<&'a IrOperation<'a>>, IrGraphOperationMeta>,
 }

--- a/ploidy-core/src/ir/mod.rs
+++ b/ploidy-core/src/ir/mod.rs
@@ -8,11 +8,11 @@ mod views;
 #[cfg(test)]
 mod tests;
 
-pub use graph::{EdgeKind, IrGraph, Traversal};
+pub use graph::{EdgeKind, IrGraph, SccId, Traversal};
 pub use spec::IrSpec;
 pub use types::*;
 
 pub use views::{
-    ExtendableView, Reach, View, container::*, enum_::*, inline::*, ir::*, operation::*,
-    primitive::*, schema::*, struct_::*, tagged::*, untagged::*,
+    ExtendableView, Reach, View, ViewNode, any::*, container::*, enum_::*, inline::*, ir::*,
+    operation::*, primitive::*, schema::*, struct_::*, tagged::*, untagged::*,
 };

--- a/ploidy-core/src/ir/tests/graph.rs
+++ b/ploidy-core/src/ir/tests/graph.rs
@@ -3,7 +3,7 @@
 use itertools::Itertools;
 
 use crate::{
-    ir::{IrGraph, IrSpec, IrStructFieldName, SchemaIrTypeView, View},
+    ir::{IrGraph, IrSpec, IrStructFieldName, SchemaIrTypeView, View, ViewNode},
     parse::Document,
     tests::assert_matches,
 };
@@ -530,6 +530,50 @@ fn test_circular_refs_multiple_sccs() {
         .find(|f| matches!(f.name(), IrStructFieldName::Name("d")))
         .unwrap();
     assert!(c_d_field.needs_indirection());
+}
+
+// MARK: SCC identity
+
+#[test]
+fn test_scc_id_same_for_cycle_members() {
+    // A <-> B form a cycle; C is independent.
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test
+          version: 1.0.0
+        components:
+          schemas:
+            A:
+              type: object
+              properties:
+                b:
+                  $ref: '#/components/schemas/B'
+            B:
+              type: object
+              properties:
+                a:
+                  $ref: '#/components/schemas/A'
+            C:
+              type: object
+              properties:
+                name:
+                  type: string
+    "})
+    .unwrap();
+
+    let spec = IrSpec::from_doc(&doc).unwrap();
+    let graph = IrGraph::new(&spec);
+
+    let a = graph.schemas().find(|s| s.name() == "A").unwrap();
+    let b = graph.schemas().find(|s| s.name() == "B").unwrap();
+    let c = graph.schemas().find(|s| s.name() == "C").unwrap();
+
+    // A and B are in the same SCC.
+    assert_eq!(a.scc_id(), b.scc_id());
+
+    // C is in a different SCC.
+    assert_ne!(a.scc_id(), c.scc_id());
 }
 
 #[test]

--- a/ploidy-core/src/ir/views/mod.rs
+++ b/ploidy-core/src/ir/views/mod.rs
@@ -14,7 +14,9 @@ use petgraph::{
 };
 use ref_cast::{RefCastCustom, ref_cast_custom};
 
-use super::graph::{EdgeKind, Extension, ExtensionMap, IrGraph, IrGraphNode, Traversal, Traverse};
+use super::graph::{
+    EdgeKind, Extension, ExtensionMap, IrGraph, IrGraphNode, SccId, Traversal, Traverse,
+};
 
 pub mod any;
 pub mod container;
@@ -187,6 +189,11 @@ where
 pub trait ViewNode<'a> {
     fn graph(&self) -> &'a IrGraph<'a>;
     fn index(&self) -> NodeIndex<usize>;
+
+    /// Returns the SCC that this node belongs to.
+    fn scc_id(&self) -> SccId {
+        self.graph().metadata.scc_indices[self.index().index()]
+    }
 }
 
 pub trait Extendable<'graph> {

--- a/ploidy-core/src/ir/views/struct_.rs
+++ b/ploidy-core/src/ir/views/struct_.rs
@@ -200,7 +200,6 @@ impl<'view, 'a> IrStructFieldView<'view, 'a> {
         let graph = self.parent.graph;
         let node = IrGraphNode::from_ref(graph.spec, self.field.ty.as_ref());
         let target = graph.indices[&node];
-        graph.metadata.scc_indices[self.parent.index.index()]
-            == graph.metadata.scc_indices[target.index()]
+        self.parent.scc_id() == graph.metadata.scc_indices[target.index()]
     }
 }

--- a/ploidy/Cargo.toml
+++ b/ploidy/Cargo.toml
@@ -15,6 +15,7 @@ clap = { version = "4", features = ["cargo", "derive"] }
 itertools = "0.14"
 miette = { version = "7", features = ["fancy"] }
 mimalloc = { version = "0.1", optional = true }
+ploidy-codegen-python = { workspace = true }
 ploidy-codegen-rust = { workspace = true }
 ploidy-core = { workspace = true }
 semver = "1"

--- a/ploidy/src/config.rs
+++ b/ploidy/src/config.rs
@@ -46,7 +46,8 @@ pub struct CodegenCommand {
 
 #[derive(Debug)]
 pub enum CodegenCommandLanguage {
-    Rust(RustCodegenCommand),
+    Python,
+    Rust(Box<RustCodegenCommand>),
 }
 
 #[derive(Debug)]
@@ -87,6 +88,7 @@ struct CodegenCommandArgs {
 impl CodegenCommandArgs {
     fn into_command(self) -> ClapResult<CodegenCommand> {
         let language = match self.language {
+            CodegenCommandLanguageArgs::Python => CodegenCommandLanguage::Python,
             CodegenCommandLanguageArgs::Rust(args) => {
                 let path = self.output.join("Cargo.toml");
                 match Manifest::<CargoMetadata>::from_path_with_metadata(&path) {
@@ -117,10 +119,10 @@ impl CodegenCommandArgs {
                             })?;
                             package.version.set(bump_version(&base, bump).to_string());
                         }
-                        CodegenCommandLanguage::Rust(RustCodegenCommand {
+                        CodegenCommandLanguage::Rust(Box::new(RustCodegenCommand {
                             manifest,
                             check: args.check,
-                        })
+                        }))
                     }
                     Err(cargo_toml::Error::Io(err)) if err.kind() == IoErrorKind::NotFound => {
                         let name = args
@@ -142,10 +144,10 @@ impl CodegenCommandArgs {
                             package: Some(Package::new(name, DEFAULT_VERSION.to_string())),
                             ..Default::default()
                         };
-                        CodegenCommandLanguage::Rust(RustCodegenCommand {
+                        CodegenCommandLanguage::Rust(Box::new(RustCodegenCommand {
                             manifest,
                             check: args.check,
-                        })
+                        }))
                     }
                     Err(err) => {
                         return Err(ClapError::raw(
@@ -166,6 +168,8 @@ impl CodegenCommandArgs {
 
 #[derive(Debug, clap::Subcommand)]
 enum CodegenCommandLanguageArgs {
+    /// Generate Python Pydantic models.
+    Python,
     /// Generate a Rust package.
     Rust(RustCodegenCommandArgs),
 }

--- a/ploidy/src/main.rs
+++ b/ploidy/src/main.rs
@@ -1,5 +1,6 @@
 use itertools::Itertools;
 use miette::{Context, IntoDiagnostic, Result};
+use ploidy_codegen_python::CodegenGraph as PythonCodegenGraph;
 use ploidy_codegen_rust::{CodegenCargoManifest, CodegenErrorModule, CodegenGraph, CodegenLibrary};
 use ploidy_core::{
     codegen::write_to_disk,
@@ -18,6 +19,31 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 fn main() -> Result<()> {
     let Ok(main) = Main::parse().map_err(|err| err.exit());
     match main.command {
+        Command::Codegen(CodegenCommand {
+            input,
+            output,
+            language: CodegenCommandLanguage::Python,
+        }) => {
+            let source = std::fs::read_to_string(&input)
+                .into_diagnostic()
+                .with_context(|| format!("Failed to read `{}`", input.display()))?;
+
+            let doc = Document::from_yaml(&source)
+                .into_diagnostic()
+                .context("Failed to parse OpenAPI document")?;
+
+            println!("OpenAPI: {} (version {})", doc.info.title, doc.info.version);
+
+            let spec = IrSpec::from_doc(&doc).into_diagnostic()?;
+            let graph = PythonCodegenGraph::new(IrGraph::new(&spec));
+
+            println!("Writing generated code to `{}`...", output.display());
+
+            println!("Generating {} types...", graph.schemas().count());
+            ploidy_codegen_python::write_types_to_disk(&output, &graph)?;
+
+            println!("Generation complete");
+        }
         Command::Codegen(CodegenCommand {
             input,
             output,


### PR DESCRIPTION
This is a _very_ rough draft for Python codegen, using the Ruff ecosystem (via [Quasiquodo](https://github.com/linabutler/quasiquodo/)) to construct the AST, then emit Python.

One snag with landing this is that we won't be able to ship Python codegen in the version of Ploidy that's published to crates.io, because Ruff (and `quasiquodo-py`, by extension) aren't published there. I'd like to think a bit more about how to do this...we can have GHA build the binary for us no problem, but it's a little weird to ship binaries with functionality that you can't get if you just `cargo install ploidy`.

I also need to figure out if we're wiring up Pydantic models correctly, especially for cyclic types. And, maybe it's worth thinking about modeling `allOf` schemas as (potentially multiple-) inherited class hierarchies.