### PR TITLE
refactor(ir): Make `IrType::Ref` unrepresentable in the cooked graph.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,7 +142,7 @@ if f.discriminator() { continue; }
 
 ### Other
 
-- **Imports:** Ordered groups (blank lines between): `std::` → external crates (alphabetical) → `crate::` → `super::`. No globs except re-exports in `mod.rs`, `use super::*` in tests.
+- **Imports:** Always add `use` imports; never use inline qualified paths. Rename conflicting imports: `use std::{fmt::Result as FmtResult, io::Result as IoResult}`. Ordered groups (blank lines between): `std::` → external crates (alphabetical) → `crate::` → `super::`. No globs except re-exports in `mod.rs`, `use super::*` in tests.
 - `#[inline]` on small functions only
 - `pub(in crate::path)` for internal constructors
 - `thiserror` for errors, `miette` for user-facing diagnostics

--- a/ploidy-codegen-rust/src/client.rs
+++ b/ploidy-codegen-rust/src/client.rs
@@ -33,7 +33,7 @@ impl ToTokens for CodegenClientModule<'_> {
         });
 
         let client_doc = {
-            let info = self.graph.spec().info;
+            let info = self.graph.info();
             format!("API client for {} (version {})", info.title, info.version)
         };
 

--- a/ploidy-codegen-rust/src/naming.rs
+++ b/ploidy-codegen-rust/src/naming.rs
@@ -55,7 +55,7 @@ impl ToTokens for CodegenTypeName<'_> {
                 CodegenIdentUsage::Type(&ident).to_tokens(tokens);
             }
             Self::Inline(view) => {
-                let ident = CodegenIdent::from_segments(&view.path().segments);
+                let ident = CodegenIdent::from_segments(view.path().segments);
                 CodegenIdentUsage::Type(&ident).to_tokens(tokens);
             }
         }
@@ -91,7 +91,7 @@ impl<'a> CodegenModuleName<'a> {
                         write!(f, "{}", CodegenIdentUsage::Module(&ident).display())
                     }
                     CodegenTypeName::Inline(view) => {
-                        let ident = CodegenIdent::from_segments(&view.path().segments);
+                        let ident = CodegenIdent::from_segments(view.path().segments);
                         write!(f, "{}", CodegenIdentUsage::Module(&ident).display())
                     }
                 }
@@ -109,7 +109,7 @@ impl ToTokens for CodegenModuleName<'_> {
                 CodegenIdentUsage::Module(&ident).to_tokens(tokens);
             }
             CodegenTypeName::Inline(view) => {
-                let ident = CodegenIdent::from_segments(&view.path().segments);
+                let ident = CodegenIdent::from_segments(view.path().segments);
                 CodegenIdentUsage::Module(&ident).to_tokens(tokens);
             }
         }

--- a/ploidy-core/src/arena.rs
+++ b/ploidy-core/src/arena.rs
@@ -1,4 +1,7 @@
-use bumpalo::Bump;
+use bumpalo::{
+    Bump,
+    collections::{CollectIn, Vec as BumpVec},
+};
 
 /// An allocation arena.
 ///
@@ -9,12 +12,54 @@ pub struct Arena(Bump);
 
 impl Arena {
     /// Creates a new, empty arena.
+    #[inline]
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Returns a reference to the underlying [`Bump`] allocator.
-    pub(crate) fn inner(&self) -> &Bump {
-        &self.0
+    /// Allocates and returns a mutable reference to a value.
+    #[inline]
+    pub(crate) fn alloc<T>(&self, value: T) -> &mut T {
+        self.0.alloc(value)
+    }
+
+    /// Copies and returns a mutable reference to a slice.
+    #[inline]
+    pub(crate) fn alloc_slice_copy<T: Copy>(&self, slice: &[T]) -> &mut [T] {
+        self.0.alloc_slice_copy(slice)
+    }
+
+    /// Clones and returns a mutable reference to a slice.
+    /// [`alloc_slice_copy`][Self::alloc_slice_copy] is more efficient if
+    /// `T` is `Copy`.
+    #[inline]
+    pub(crate) fn alloc_slice_clone<T: Clone>(&self, slice: &[T]) -> &mut [T] {
+        self.0.alloc_slice_clone(slice)
+    }
+
+    /// Allocates and fills a slice with items from an iterator of known length.
+    #[inline]
+    pub(crate) fn alloc_slice_exact<I>(&self, iter: I) -> &mut [I::Item]
+    where
+        I: IntoIterator,
+        I::IntoIter: ExactSizeIterator,
+    {
+        self.0.alloc_slice_fill_iter(iter)
+    }
+
+    /// Allocates and fills a slice with items from an iterator. Unlike
+    /// [`alloc_slice_exact`][Self::alloc_slice_exact], the iterator
+    /// doesn't need to know its exact length.
+    #[inline]
+    pub(crate) fn alloc_slice<I: IntoIterator>(&self, iter: I) -> &mut [I::Item] {
+        iter.into_iter()
+            .collect_in::<BumpVec<_>>(&self.0)
+            .into_bump_slice_mut()
+    }
+
+    /// Allocates and returns a mutable reference to a string slice.
+    #[inline]
+    pub(crate) fn alloc_str(&self, s: &str) -> &mut str {
+        self.0.alloc_str(s)
     }
 }

--- a/ploidy-core/src/codegen/unique.rs
+++ b/ploidy-core/src/codegen/unique.rs
@@ -1,6 +1,5 @@
 use std::{borrow::Cow, collections::hash_map::Entry, iter::Peekable, str::CharIndices};
 
-use bumpalo::collections::{CollectIn, Vec as BumpVec};
 use rustc_hash::FxHashMap;
 use unicase::UniCase;
 
@@ -77,15 +76,11 @@ impl<'a> UniqueNamesScope<'a> {
     ) -> Self {
         let space = reserved
             .into_iter()
-            .map(|name| arena.inner().alloc_str(name.as_ref()))
-            .map(|name| {
-                WordSegments::new(name)
-                    .map(UniCase::new)
-                    .collect_in::<BumpVec<_>>(arena.inner())
-            })
+            .map(|name| arena.alloc_str(name.as_ref()))
+            .map(|name| arena.alloc_slice(WordSegments::new(name).map(UniCase::new)))
             .fold(FxHashMap::default(), |mut names, segments| {
                 // Setting the count to 1 automatically filters out duplicates.
-                names.insert(segments.into_bump_slice(), 1);
+                names.insert(&*segments, 1);
                 names
             });
         Self { arena, space }
@@ -106,12 +101,9 @@ impl<'a> UniqueNamesScope<'a> {
     /// assert_eq!(scope.uniquify("httpResponse"), "httpResponse3");
     /// ```
     pub fn uniquify<'b>(&mut self, name: &'b str) -> Cow<'b, str> {
-        match self.space.entry(
-            WordSegments::new(name)
-                .map(|name| UniCase::new(&*self.arena.inner().alloc_str(name)))
-                .collect_in::<BumpVec<_>>(self.arena.inner())
-                .into_bump_slice(),
-        ) {
+        match self.space.entry(&*self.arena.alloc_slice(
+            WordSegments::new(name).map(|name| UniCase::new(&*self.arena.alloc_str(name))),
+        )) {
             Entry::Occupied(mut entry) => {
                 let count = entry.get_mut();
                 *count += 1;

--- a/ploidy-core/src/ir/cooker.rs
+++ b/ploidy-core/src/ir/cooker.rs
@@ -1,0 +1,167 @@
+//! Raw-to-cooked IR type translation.
+
+use petgraph::graph::NodeIndex;
+
+use crate::arena::Arena;
+
+use super::{
+    graph::GraphNode,
+    types::{
+        Container, InlineIrType, Inner, IrOperation, IrParameter, IrParameterInfo, IrRequest,
+        IrResponse, IrStruct, IrStructField, IrTagged, IrTaggedVariant, IrType, IrUntagged,
+        IrUntaggedVariant, SchemaIrType,
+    },
+};
+
+/// Turns raw IR types with [`IrType`] references into
+/// cooked types with [`NodeIndex`] references.
+pub struct Cooker<'a, F> {
+    arena: &'a Arena,
+    resolve: F,
+}
+
+impl<'a, F> Cooker<'a, F>
+where
+    F: Fn(&'a IrType<'a>) -> NodeIndex<usize>,
+{
+    /// Creates a new cooker with the given arena and reference resolver.
+    pub fn new(arena: &'a Arena, resolve: F) -> Self {
+        Self { arena, resolve }
+    }
+
+    /// Cooks a raw [`GraphNode`] by resolving all type references within it.
+    pub fn node(&self, raw: GraphNode<'a>) -> GraphNode<'a, NodeIndex<usize>> {
+        use GraphNode::*;
+        match raw {
+            Schema(ty) => Schema(self.arena.alloc(self.schema(ty))),
+            Inline(ty) => Inline(self.arena.alloc(self.inline(ty))),
+        }
+    }
+
+    /// Cooks an [`IrOperation`] and all the types it references.
+    pub fn operation(&self, raw: &IrOperation<'a>) -> &'a IrOperation<'a, NodeIndex<usize>> {
+        self.arena.alloc(IrOperation {
+            id: raw.id,
+            method: raw.method,
+            path: raw.path,
+            resource: raw.resource,
+            description: raw.description,
+            params: self
+                .arena
+                .alloc_slice_exact(raw.params.iter().map(|p| self.param(p))),
+            request: raw.request.as_ref().map(|r| match r {
+                IrRequest::Json(ty) => IrRequest::Json(self.resolve(ty)),
+                IrRequest::Multipart => IrRequest::Multipart,
+            }),
+            response: raw.response.as_ref().map(|r| match r {
+                IrResponse::Json(ty) => IrResponse::Json(self.resolve(ty)),
+            }),
+        })
+    }
+
+    fn schema(&self, raw: &SchemaIrType<'a>) -> SchemaIrType<'a, NodeIndex<usize>> {
+        use SchemaIrType::*;
+        match raw {
+            Enum(info, e) => Enum(*info, *e),
+            Struct(info, s) => Struct(*info, self.struct_(s)),
+            Tagged(info, t) => Tagged(*info, self.tagged(t)),
+            Untagged(info, u) => Untagged(*info, self.untagged(u)),
+            Container(info, c) => Container(*info, self.container(c)),
+            &Primitive(info, p) => Primitive(info, p),
+            &Any(info) => Any(info),
+        }
+    }
+
+    fn inline(&self, raw: &InlineIrType<'a>) -> InlineIrType<'a, NodeIndex<usize>> {
+        use InlineIrType::*;
+        match raw {
+            Enum(path, e) => Enum(*path, *e),
+            Struct(path, s) => Struct(*path, self.struct_(s)),
+            Tagged(path, t) => Tagged(*path, self.tagged(t)),
+            Untagged(path, u) => Untagged(*path, self.untagged(u)),
+            Container(path, c) => Container(*path, self.container(c)),
+            &Primitive(path, p) => Primitive(path, p),
+            &Any(path) => Any(path),
+        }
+    }
+
+    fn struct_(&self, raw: &IrStruct<'a>) -> IrStruct<'a, NodeIndex<usize>> {
+        IrStruct {
+            description: raw.description,
+            fields: self
+                .arena
+                .alloc_slice_exact(raw.fields.iter().map(|f| IrStructField {
+                    name: f.name,
+                    ty: self.resolve(f.ty),
+                    required: f.required,
+                    description: f.description,
+                    flattened: f.flattened,
+                })),
+            parents: self
+                .arena
+                .alloc_slice_exact(raw.parents.iter().map(|p| self.resolve(p))),
+        }
+    }
+
+    fn tagged(&self, raw: &IrTagged<'a>) -> IrTagged<'a, NodeIndex<usize>> {
+        IrTagged {
+            description: raw.description,
+            tag: raw.tag,
+            variants: self
+                .arena
+                .alloc_slice_exact(raw.variants.iter().map(|v| IrTaggedVariant {
+                    name: v.name,
+                    aliases: v.aliases,
+                    ty: self.resolve(v.ty),
+                })),
+        }
+    }
+
+    fn untagged(&self, raw: &IrUntagged<'a>) -> IrUntagged<'a, NodeIndex<usize>> {
+        IrUntagged {
+            description: raw.description,
+            variants: self
+                .arena
+                .alloc_slice_exact(raw.variants.iter().map(|v| match v {
+                    IrUntaggedVariant::Some(hint, ty) => {
+                        IrUntaggedVariant::Some(*hint, self.resolve(ty))
+                    }
+                    IrUntaggedVariant::Null => IrUntaggedVariant::Null,
+                })),
+        }
+    }
+
+    fn container(&self, raw: &Container<'a>) -> Container<'a, NodeIndex<usize>> {
+        let inner = raw.inner();
+        let cooked = Inner {
+            description: inner.description,
+            ty: self.resolve(inner.ty),
+        };
+        match raw {
+            Container::Array(_) => Container::Array(cooked),
+            Container::Map(_) => Container::Map(cooked),
+            Container::Optional(_) => Container::Optional(cooked),
+        }
+    }
+
+    fn param(&self, raw: &IrParameter<'a>) -> IrParameter<'a, NodeIndex<usize>> {
+        let (IrParameter::Path(info) | IrParameter::Query(info)) = raw;
+        let cooked = IrParameterInfo {
+            name: info.name,
+            ty: self.resolve(info.ty),
+            required: info.required,
+            description: info.description,
+            style: info.style,
+        };
+        match raw {
+            IrParameter::Path(_) => IrParameter::Path(cooked),
+            IrParameter::Query(_) => IrParameter::Query(cooked),
+        }
+    }
+
+    /// Resolves a raw type reference to a cooked graph index.
+    #[inline]
+    fn resolve(&self, ty: &'a IrType<'a>) -> NodeIndex<usize> {
+        (self.resolve)(ty)
+    }
+}

--- a/ploidy-core/src/ir/graph.rs
+++ b/ploidy-core/src/ir/graph.rs
@@ -21,9 +21,10 @@ use petgraph::{
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use crate::arena::Arena;
+use crate::{arena::Arena, parse::Info};
 
 use super::{
+    cooker::Cooker,
     spec::IrSpec,
     types::{
         InlineIrType, InlineIrTypePath, InlineIrTypePathRoot, InlineIrTypePathSegment, IrOperation,
@@ -37,7 +38,10 @@ use super::{
 type RawDiGraph<'a> = StableDiGraph<GraphNode<'a>, EdgeKind, usize>;
 
 /// The immutable, dense graph used for code generation.
-type CookedDiGraph<'a> = DiGraph<GraphNode<'a>, EdgeKind, usize>;
+type CookedDiGraph<'a> = DiGraph<GraphNode<'a, NodeIndex<usize>>, EdgeKind, usize>;
+
+/// An operation with all type references resolved to graph indices.
+pub type CookedOperation<'a> = &'a IrOperation<'a, NodeIndex<usize>>;
 
 /// A mutable intermediate dependency graph of all the types in an [`IrSpec`],
 /// backed by a sparse [`StableDiGraph`].
@@ -70,7 +74,7 @@ impl<'a> RawGraph<'a> {
         let tys = IrTypeVisitor::new(
             spec.schemas
                 .values()
-                .chain(spec.operations.iter().flat_map(|op| op.types())),
+                .chain(spec.operations.iter().flat_map(|op| op.types().copied())),
         );
 
         // Add nodes for all types, and edges for references between them.
@@ -175,7 +179,7 @@ impl<'a> RawGraph<'a> {
                 else {
                     return None;
                 };
-                let mut new_variants = Cow::Borrowed(&tagged.variants);
+                let mut new_variants = Cow::Borrowed(tagged.variants);
                 let mut inlines = vec![];
 
                 for (at, variant) in tagged.variants.iter().enumerate() {
@@ -229,7 +233,7 @@ impl<'a> RawGraph<'a> {
                         std::iter::from_fn(|| dfs.next(&inherits))
                             .flat_map(|ancestor| match self.graph[ancestor] {
                                 GraphNode::Schema(SchemaIrType::Struct(_, s))
-                                | GraphNode::Inline(InlineIrType::Struct(_, s)) => &*s.fields,
+                                | GraphNode::Inline(InlineIrType::Struct(_, s)) => s.fields,
                                 _ => &[],
                             })
                             .any(|f| {
@@ -244,22 +248,19 @@ impl<'a> RawGraph<'a> {
 
                     // Build our new inline type, with the same attributes
                     // as the schema type, but a distinct inline type path.
-                    let ty = &*self
-                        .arena
-                        .inner()
-                        .alloc(IrType::Inline(InlineIrType::Struct(
-                            InlineIrTypePath {
-                                root: InlineIrTypePathRoot::Type(info.name),
-                                segments: vec![InlineIrTypePathSegment::TaggedVariant(
-                                    variant_info.name,
-                                )],
-                            },
-                            IrStruct {
-                                description: variant_struct.description,
-                                fields: variant_struct.fields.clone(),
-                                parents: variant_struct.parents.clone(),
-                            },
-                        )));
+                    let ty: &_ = self.arena.alloc(IrType::Inline(InlineIrType::Struct(
+                        InlineIrTypePath {
+                            root: InlineIrTypePathRoot::Type(info.name),
+                            segments: self.arena.alloc_slice_copy(&[
+                                InlineIrTypePathSegment::TaggedVariant(variant_info.name),
+                            ]),
+                        },
+                        IrStruct {
+                            description: variant_struct.description,
+                            fields: variant_struct.fields,
+                            parents: variant_struct.parents,
+                        },
+                    )));
 
                     let parent_indices = variant_struct
                         .parents
@@ -278,11 +279,11 @@ impl<'a> RawGraph<'a> {
 
                     new_variants.to_mut()[at] = IrTaggedVariant {
                         name: variant.name,
-                        aliases: variant.aliases.clone(),
+                        aliases: variant.aliases,
                         ty,
                     };
                 }
-                if *new_variants == tagged.variants {
+                if new_variants == tagged.variants {
                     // No variants to rewrite.
                     return None;
                 }
@@ -293,7 +294,7 @@ impl<'a> RawGraph<'a> {
                     modified_tagged: IrTagged {
                         description: tagged.description,
                         tag: tagged.tag,
-                        variants: new_variants.into_owned(),
+                        variants: self.arena.alloc_slice_copy(&new_variants),
                     },
                     inlines,
                 })
@@ -328,7 +329,7 @@ impl<'a> RawGraph<'a> {
             for edge_id in edges_to_remove {
                 self.graph.remove_edge(edge_id);
             }
-            for variant in &plan.modified_tagged.variants {
+            for variant in plan.modified_tagged.variants {
                 let variant_node = self.resolve(variant.ty);
                 let variant_index = self.indices[&variant_node];
                 self.graph
@@ -338,7 +339,6 @@ impl<'a> RawGraph<'a> {
             // ...And replace the node for the tagged union itself.
             let new_node = GraphNode::Schema(
                 self.arena
-                    .inner()
                     .alloc(SchemaIrType::Tagged(plan.info, plan.modified_tagged)),
             );
             let old_node = std::mem::replace(&mut self.graph[plan.tagged_index], new_node);
@@ -374,61 +374,60 @@ impl<'a> RawGraph<'a> {
 /// code generation.
 #[derive(Debug)]
 pub struct CookedGraph<'a> {
-    pub(super) spec: &'a IrSpec<'a>,
     pub(super) graph: CookedDiGraph<'a>,
-    /// An inverted index of nodes to graph indices.
-    pub(super) indices: FxHashMap<GraphNode<'a>, NodeIndex<usize>>,
-    /// Maps schema names to their graph indices.
-    schemas: FxHashMap<&'a str, NodeIndex<usize>>,
+    info: &'a Info,
+    ops: &'a [CookedOperation<'a>],
     /// Additional metadata for each node.
     pub(super) metadata: CookedGraphMetadata<'a>,
 }
 
 impl<'a> CookedGraph<'a> {
     fn new(raw: &RawGraph<'a>) -> Self {
-        let mut graph = CookedDiGraph::default();
-        let mut indices = FxHashMap::default();
-        let mut schemas = FxHashMap::default();
+        // Assign a cooked node index to each raw node index.
+        let indices: FxHashMap<_, _> = raw
+            .graph
+            .node_indices()
+            .zip(0..)
+            .map(|(raw, cooked)| (raw, NodeIndex::new(cooked)))
+            .collect();
 
-        for index in raw.graph.node_indices() {
-            use std::collections::hash_map::Entry;
-            let source = raw.graph[index];
-            let &mut from = match indices.entry(source) {
-                Entry::Occupied(from) => from.into_mut(),
-                Entry::Vacant(entry) => {
-                    let index = graph.add_node(*entry.key());
-                    entry.insert(index)
-                }
+        // Cook each node, translating raw types to their
+        // assigned cooked indices.
+        let cooker = Cooker::new(raw.arena, |ty| {
+            let raw = match ty {
+                IrType::Schema(s) => raw.indices[&GraphNode::Schema(s)],
+                IrType::Inline(i) => raw.indices[&GraphNode::Inline(i)],
+                IrType::Ref(r) => raw.schemas[r.name()],
             };
-            if let GraphNode::Schema(ty) = source {
-                schemas.entry(ty.name()).or_insert(from);
-            }
-            // `raw.graph.edges(...)` is guaranteed to yield edges in
-            // reverse order of addition, so we accumulate and reverse to
-            // add them to the cooked graph in their original order.
-            let mut edges = vec![];
-            for edge in raw.graph.edges(index) {
-                let destination = raw.graph[edge.target()];
-                let &mut to = match indices.entry(destination) {
-                    Entry::Occupied(to) => to.into_mut(),
-                    Entry::Vacant(entry) => {
-                        let index = graph.add_node(*entry.key());
-                        entry.insert(index)
-                    }
-                };
-                if let GraphNode::Schema(ty) = destination {
-                    schemas.entry(ty.name()).or_insert(to);
-                }
-                edges.push((from, to, *edge.weight()));
-            }
-            for (from, to, kind) in edges.into_iter().rev() {
+            indices[&raw]
+        });
+
+        // Build a dense graph.
+        let mut graph = CookedDiGraph::with_capacity(indices.len(), raw.graph.edge_count());
+        for index in raw.graph.node_indices() {
+            let node = raw.graph[index];
+            let cooked = graph.add_node(cooker.node(node));
+            assert_eq!(indices[&index], cooked);
+        }
+
+        // Add edges, preserving original insertion order.
+        for index in raw.graph.node_indices() {
+            let from = indices[&index];
+            // `RawDiGraph::edges` yields edges in reverse insertion order;
+            // collect and reverse to preserve the original order.
+            let edges = raw
+                .graph
+                .edges(index)
+                .map(|e| (indices[&e.target()], *e.weight()))
+                .collect_vec();
+            for (to, kind) in edges.into_iter().rev() {
                 graph.add_edge(from, to, kind);
             }
         }
 
         let sccs = TopoSccs::new(&graph);
 
-        let metadata = {
+        let (metadata, operations) = {
             let mut metadata = CookedGraphMetadata {
                 scc_indices: {
                     // Precompute SCC indices, using just the reference edges.
@@ -451,20 +450,16 @@ impl<'a> CookedGraph<'a> {
                 operations: FxHashMap::default(),
             };
 
+            // Cook each operation.
+            let operations: &_ = raw
+                .arena
+                .alloc_slice_exact(raw.spec.operations.iter().map(|op| cooker.operation(op)));
+
             // Precompute the set of type indices that each operation
             // references directly.
-            for op in &raw.spec.operations {
-                metadata.operations.entry(ByAddress(op)).or_default().types = op
-                    .types()
-                    .filter_map(|ty| {
-                        let node = match ty {
-                            IrType::Schema(ty) => GraphNode::Schema(ty),
-                            IrType::Inline(ty) => GraphNode::Inline(ty),
-                            IrType::Ref(r) => graph[schemas[r.name()]],
-                        };
-                        indices.get(&node).map(|node| node.index())
-                    })
-                    .collect();
+            for &op in operations {
+                metadata.operations.entry(ByAddress(op)).or_default().types =
+                    op.types().map(|node| node.index()).collect();
             }
 
             // Forward propagation: for each type, compute all the types
@@ -510,7 +505,7 @@ impl<'a> CookedGraph<'a> {
 
             // Backward propagation: propagate each operation to all the
             // types that it uses, directly and transitively.
-            for op in &raw.spec.operations {
+            for &op in operations {
                 let meta = &metadata.operations[&ByAddress(op)];
 
                 // Collect all the types that this operation depends on.
@@ -526,33 +521,22 @@ impl<'a> CookedGraph<'a> {
                 }
             }
 
-            metadata
+            (metadata, operations)
         };
 
         Self {
-            spec: raw.spec,
-            indices,
-            schemas,
             graph,
+            info: raw.spec.info,
+            ops: operations,
             metadata,
         }
     }
 
-    /// Resolves an [`IrType`] to a [`GraphNode`], following
-    /// [`IrType::Ref`]s through the spec.
+    /// Returns [`Info`] from the [`Document`][crate::parse::Document]
+    /// used to build this graph.
     #[inline]
-    pub(super) fn resolve(&self, ty: &'a IrType<'a>) -> GraphNode<'a> {
-        match ty {
-            IrType::Schema(ty) => GraphNode::Schema(ty),
-            IrType::Inline(ty) => GraphNode::Inline(ty),
-            IrType::Ref(r) => self.graph[self.schemas[r.name()]],
-        }
-    }
-
-    /// Returns the spec used to build this graph.
-    #[inline]
-    pub fn spec(&self) -> &'a IrSpec<'a> {
-        self.spec
+    pub fn info(&self) -> &'a Info {
+        self.info
     }
 
     /// Returns an iterator over all the named schemas in this graph.
@@ -583,10 +567,9 @@ impl<'a> CookedGraph<'a> {
     /// Returns an iterator over all the operations in this graph.
     #[inline]
     pub fn operations(&self) -> impl Iterator<Item = IrOperationView<'_>> {
-        self.spec
-            .operations
+        self.ops
             .iter()
-            .map(move |op| IrOperationView::new(self, op))
+            .map(move |&op| IrOperationView::new(self, op))
     }
 }
 
@@ -597,9 +580,9 @@ impl<'a> CookedGraph<'a> {
 /// will be equal. This is important: all types in an [`IrSpec`] are
 /// distinct in memory, but can refer to the same logical type.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub enum GraphNode<'a> {
-    Schema(&'a SchemaIrType<'a>),
-    Inline(&'a InlineIrType<'a>),
+pub enum GraphNode<'a, Ty = &'a IrType<'a>> {
+    Schema(&'a SchemaIrType<'a, Ty>),
+    Inline(&'a InlineIrType<'a, Ty>),
 }
 
 /// An edge between two types in the type graph.
@@ -618,7 +601,7 @@ pub struct CookedGraphMetadata<'a> {
     /// Nodes in the same SCC form a cycle.
     pub scc_indices: Vec<usize>,
     pub schemas: Vec<GraphNodeMeta<'a>>,
-    pub operations: FxHashMap<ByAddress<&'a IrOperation<'a>>, GraphOperationMeta>,
+    pub operations: FxHashMap<ByAddress<CookedOperation<'a>>, GraphOperationMeta>,
 }
 
 /// Precomputed metadata for an operation that references
@@ -634,7 +617,7 @@ pub struct GraphOperationMeta {
 #[derive(Default)]
 pub(super) struct GraphNodeMeta<'a> {
     /// Operations that use this type.
-    pub used_by: FxHashSet<ByAddress<&'a IrOperation<'a>>>,
+    pub used_by: FxHashSet<ByAddress<CookedOperation<'a>>>,
     /// Indices of other types that this type transitively depends on.
     pub dependencies: FixedBitSet,
     /// Indices of other types that transitively depend on this type.
@@ -683,8 +666,10 @@ impl<'a> Iterator for IrTypeVisitor<'a> {
                     itertools::chain!(
                         ty.fields
                             .iter()
-                            .map(|field| (EdgeKind::Reference, &field.ty)),
-                        ty.parents.iter().map(|parent| (EdgeKind::Inherits, parent)),
+                            .map(|field| (EdgeKind::Reference, field.ty)),
+                        ty.parents
+                            .iter()
+                            .map(|parent| (EdgeKind::Inherits, *parent)),
                     )
                     .map(|(kind, ty)| (Some(top), kind, ty))
                     .rev(),
@@ -697,7 +682,7 @@ impl<'a> Iterator for IrTypeVisitor<'a> {
                         .iter()
                         .filter_map(|variant| match variant {
                             IrUntaggedVariant::Some(_, ty) => {
-                                Some((Some(top), EdgeKind::Reference, ty))
+                                Some((Some(top), EdgeKind::Reference, *ty))
                             }
                             _ => None,
                         })
@@ -716,7 +701,7 @@ impl<'a> Iterator for IrTypeVisitor<'a> {
             IrType::Schema(SchemaIrType::Container(_, container))
             | IrType::Inline(InlineIrType::Container(_, container)) => {
                 self.stack
-                    .push((Some(top), EdgeKind::Reference, &container.inner().ty));
+                    .push((Some(top), EdgeKind::Reference, container.inner().ty));
             }
             IrType::Schema(
                 SchemaIrType::Enum(..) | SchemaIrType::Primitive(..) | SchemaIrType::Any(_),

--- a/ploidy-core/src/ir/mod.rs
+++ b/ploidy-core/src/ir/mod.rs
@@ -1,3 +1,4 @@
+mod cooker;
 mod error;
 mod graph;
 mod spec;

--- a/ploidy-core/src/ir/spec.rs
+++ b/ploidy-core/src/ir/spec.rs
@@ -63,72 +63,67 @@ impl<'a> IrSpec<'a> {
             .map_ok(|(method, path, op)| -> Result<_, IrError> {
                 let resource = op.extension("x-resource-name");
                 let id = op.operation_id.as_deref().ok_or(IrError::NoOperationId)?;
-                let params = op
-                    .parameters
-                    .iter()
-                    .filter_map(|param_or_ref| {
-                        let param = match param_or_ref {
-                            RefOrParameter::Other(p) => p,
-                            RefOrParameter::Ref(r) => doc
-                                .resolve(r.path.pointer().clone())
-                                .ok()
-                                .and_then(|p| p.downcast_ref::<Parameter>())?,
-                        };
-                        let ty = match &param.schema {
-                            Some(RefOrSchema::Ref(r)) => IrType::Ref(&r.path),
-                            Some(RefOrSchema::Other(schema)) => transform(
-                                arena,
-                                doc,
-                                InlineIrTypePath {
-                                    root: InlineIrTypePathRoot::Resource(resource),
-                                    segments: vec![
-                                        InlineIrTypePathSegment::Operation(id),
-                                        InlineIrTypePathSegment::Parameter(param.name.as_str()),
-                                    ],
-                                },
-                                schema,
-                            ),
-                            None => InlineIrType::Any(InlineIrTypePath {
+                let params = arena.alloc_slice(op.parameters.iter().filter_map(|param_or_ref| {
+                    let param = match param_or_ref {
+                        RefOrParameter::Other(p) => p,
+                        RefOrParameter::Ref(r) => doc
+                            .resolve(r.path.pointer().clone())
+                            .ok()
+                            .and_then(|p| p.downcast_ref::<Parameter>())?,
+                    };
+                    let ty = match &param.schema {
+                        Some(RefOrSchema::Ref(r)) => &*arena.alloc(IrType::Ref(&r.path)),
+                        Some(RefOrSchema::Other(schema)) => &*arena.alloc(transform(
+                            arena,
+                            doc,
+                            InlineIrTypePath {
                                 root: InlineIrTypePathRoot::Resource(resource),
-                                segments: vec![
+                                segments: arena.alloc_slice_copy(&[
                                     InlineIrTypePathSegment::Operation(id),
                                     InlineIrTypePathSegment::Parameter(param.name.as_str()),
-                                ],
-                            })
-                            .into(),
-                        };
-                        let style = match (param.style, param.explode) {
-                            (Some(ParameterStyle::DeepObject), Some(true) | None) => {
-                                Some(IrParameterStyle::DeepObject)
-                            }
-                            (Some(ParameterStyle::SpaceDelimited), Some(false) | None) => {
-                                Some(IrParameterStyle::SpaceDelimited)
-                            }
-                            (Some(ParameterStyle::PipeDelimited), Some(false) | None) => {
-                                Some(IrParameterStyle::PipeDelimited)
-                            }
-                            (Some(ParameterStyle::Form) | None, Some(true) | None) => {
-                                Some(IrParameterStyle::Form { exploded: true })
-                            }
-                            (Some(ParameterStyle::Form) | None, Some(false)) => {
-                                Some(IrParameterStyle::Form { exploded: false })
-                            }
-                            _ => None,
-                        };
-                        let info = IrParameterInfo {
-                            name: param.name.as_str(),
-                            ty,
-                            required: param.required,
-                            description: param.description.as_deref(),
-                            style,
-                        };
-                        Some(match param.location {
-                            ParameterLocation::Path => IrParameter::Path(info),
-                            ParameterLocation::Query => IrParameter::Query(info),
-                            _ => return None,
-                        })
+                                ]),
+                            },
+                            schema,
+                        )),
+                        None => &*arena.alloc(IrType::from(InlineIrType::Any(InlineIrTypePath {
+                            root: InlineIrTypePathRoot::Resource(resource),
+                            segments: arena.alloc_slice_copy(&[
+                                InlineIrTypePathSegment::Operation(id),
+                                InlineIrTypePathSegment::Parameter(param.name.as_str()),
+                            ]),
+                        }))),
+                    };
+                    let style = match (param.style, param.explode) {
+                        (Some(ParameterStyle::DeepObject), Some(true) | None) => {
+                            Some(IrParameterStyle::DeepObject)
+                        }
+                        (Some(ParameterStyle::SpaceDelimited), Some(false) | None) => {
+                            Some(IrParameterStyle::SpaceDelimited)
+                        }
+                        (Some(ParameterStyle::PipeDelimited), Some(false) | None) => {
+                            Some(IrParameterStyle::PipeDelimited)
+                        }
+                        (Some(ParameterStyle::Form) | None, Some(true) | None) => {
+                            Some(IrParameterStyle::Form { exploded: true })
+                        }
+                        (Some(ParameterStyle::Form) | None, Some(false)) => {
+                            Some(IrParameterStyle::Form { exploded: false })
+                        }
+                        _ => None,
+                    };
+                    let info = IrParameterInfo {
+                        name: param.name.as_str(),
+                        ty,
+                        required: param.required,
+                        description: param.description.as_deref(),
+                        style,
+                    };
+                    Some(match param.location {
+                        ParameterLocation::Path => IrParameter::Path(info),
+                        ParameterLocation::Query => IrParameter::Query(info),
+                        _ => return None,
                     })
-                    .collect_vec();
+                }));
 
                 let request = op
                     .request_body
@@ -159,32 +154,31 @@ impl<'a> IrSpec<'a> {
                     .map(|content| match content {
                         RequestContent::Multipart => IrRequest::Multipart,
                         RequestContent::Json(RefOrSchema::Ref(r)) => {
-                            IrRequest::Json(IrType::Ref(&r.path))
+                            IrRequest::Json(&*arena.alloc(IrType::Ref(&r.path)))
                         }
                         RequestContent::Json(RefOrSchema::Other(schema)) => {
-                            IrRequest::Json(transform(
+                            IrRequest::Json(&*arena.alloc(transform(
                                 arena,
                                 doc,
                                 InlineIrTypePath {
                                     root: InlineIrTypePathRoot::Resource(resource),
-                                    segments: vec![
+                                    segments: arena.alloc_slice_copy(&[
                                         InlineIrTypePathSegment::Operation(id),
                                         InlineIrTypePathSegment::Request,
-                                    ],
+                                    ]),
                                 },
                                 schema,
-                            ))
+                            )))
                         }
-                        RequestContent::Any => IrRequest::Json(
+                        RequestContent::Any => IrRequest::Json(&*arena.alloc(IrType::from(
                             InlineIrType::Any(InlineIrTypePath {
                                 root: InlineIrTypePathRoot::Resource(resource),
-                                segments: vec![
+                                segments: arena.alloc_slice_copy(&[
                                     InlineIrTypePathSegment::Operation(id),
                                     InlineIrTypePathSegment::Request,
-                                ],
-                            })
-                            .into(),
-                        ),
+                                ]),
+                            }),
+                        ))),
                     });
 
                 let response = {
@@ -227,32 +221,31 @@ impl<'a> IrSpec<'a> {
                         })
                         .map(|content| match content {
                             ResponseContent::Json(RefOrSchema::Ref(r)) => {
-                                IrResponse::Json(IrType::Ref(&r.path))
+                                IrResponse::Json(&*arena.alloc(IrType::Ref(&r.path)))
                             }
                             ResponseContent::Json(RefOrSchema::Other(schema)) => {
-                                IrResponse::Json(transform(
+                                IrResponse::Json(&*arena.alloc(transform(
                                     arena,
                                     doc,
                                     InlineIrTypePath {
                                         root: InlineIrTypePathRoot::Resource(resource),
-                                        segments: vec![
+                                        segments: arena.alloc_slice_copy(&[
                                             InlineIrTypePathSegment::Operation(id),
                                             InlineIrTypePathSegment::Response,
-                                        ],
+                                        ]),
                                     },
                                     schema,
-                                ))
+                                )))
                             }
-                            ResponseContent::Any => IrResponse::Json(
+                            ResponseContent::Any => IrResponse::Json(&*arena.alloc(IrType::from(
                                 InlineIrType::Any(InlineIrTypePath {
                                     root: InlineIrTypePathRoot::Resource(resource),
-                                    segments: vec![
+                                    segments: arena.alloc_slice_copy(&[
                                         InlineIrTypePathSegment::Operation(id),
                                         InlineIrTypePathSegment::Response,
-                                    ],
-                                })
-                                .into(),
-                            ),
+                                    ]),
+                                }),
+                            ))),
                         })
                 };
 
@@ -260,7 +253,7 @@ impl<'a> IrSpec<'a> {
                     resource,
                     id,
                     method,
-                    path,
+                    path: arena.alloc_slice_clone(&path),
                     description: op.description.as_deref(),
                     params,
                     request,

--- a/ploidy-core/src/ir/tests/transform.rs
+++ b/ploidy-core/src/ir/tests/transform.rs
@@ -39,7 +39,7 @@ fn test_enum_string_variants() {
         other => panic!("expected enum `Status`; got `{other:?}`"),
     };
     assert_matches!(
-        &*enum_.variants,
+        enum_.variants,
         [
             IrEnumVariant::String("active"),
             IrEnumVariant::String("inactive"),
@@ -76,7 +76,7 @@ fn test_enum_number_variants() {
         other => panic!("expected enum `Priority`; got `{other:?}`"),
     };
     assert_matches!(
-        &*enum_.variants,
+        enum_.variants,
         [
             IrEnumVariant::Number(n1),
             IrEnumVariant::Number(n2),
@@ -108,7 +108,7 @@ fn test_enum_bool_variants() {
         other => panic!("expected enum `Flag`; got `{other:?}`"),
     };
     assert_matches!(
-        &*enum_.variants,
+        enum_.variants,
         [IrEnumVariant::Bool(true), IrEnumVariant::Bool(false)],
     );
 }
@@ -136,7 +136,7 @@ fn test_enum_mixed_types() {
         other => panic!("expected enum `Mixed`; got `{other:?}`"),
     };
     assert_matches!(
-        &*enum_.variants,
+        enum_.variants,
         [
             IrEnumVariant::String("text"),
             IrEnumVariant::Number(n),
@@ -469,7 +469,7 @@ fn test_struct_with_own_properties() {
         other => panic!("expected struct `Person`; got `{other:?}`"),
     };
     assert_matches!(
-        &*struct_.fields,
+        struct_.fields,
         [
             IrStructField {
                 name: IrStructFieldName::Name("name"),
@@ -526,7 +526,7 @@ fn test_struct_with_additional_properties_ref() {
             ty,
             ..
         },
-    ] = &*struct_.fields
+    ] = struct_.fields
     else {
         panic!("expected two fields; got `{:?}`", struct_.fields);
     };
@@ -534,7 +534,7 @@ fn test_struct_with_additional_properties_ref() {
         ty,
         IrType::Inline(
             InlineIrType::Container(_, Container::Map(inner)),
-        ) if matches!(&*inner.ty, IrType::Ref(_)),
+        ) if matches!(inner.ty, IrType::Ref(_)),
     );
 }
 
@@ -584,7 +584,7 @@ fn test_struct_with_additional_properties_inline() {
             ty,
             ..
         },
-    ] = &*struct_.fields
+    ] = struct_.fields
     else {
         panic!("expected two fields; got `{:?}`", struct_.fields);
     };
@@ -595,19 +595,19 @@ fn test_struct_with_additional_properties_inline() {
     };
     assert_matches!(container_path.root, InlineIrTypePathRoot::Type("Config"));
     assert_matches!(
-        &*container_path.segments,
+        container_path.segments,
         [InlineIrTypePathSegment::Field(IrStructFieldName::Hint(
             IrStructFieldNameHint::AdditionalProperties,
         ))]
     );
 
     // The inline value type path should append `MapValue`.
-    let IrType::Inline(InlineIrType::Struct(value_path, _)) = &*inner.ty else {
+    let IrType::Inline(InlineIrType::Struct(value_path, _)) = inner.ty else {
         panic!("expected inline struct; got `{:?}`", inner.ty);
     };
     assert_matches!(value_path.root, InlineIrTypePathRoot::Type("Config"));
     assert_matches!(
-        &*value_path.segments,
+        value_path.segments,
         [
             InlineIrTypePathSegment::Field(IrStructFieldName::Hint(
                 IrStructFieldNameHint::AdditionalProperties,
@@ -648,14 +648,14 @@ fn test_struct_with_additional_properties_true() {
         other => panic!("expected struct `DynamicMap`; got `{other:?}`"),
     };
     assert_matches!(
-        &*struct_.fields,
+        struct_.fields,
         [IrStructField {
             name: IrStructFieldName::Hint(IrStructFieldNameHint::AdditionalProperties),
             flattened: true,
             required: true,
             ty: IrType::Inline(InlineIrType::Container(_, Container::Map(inner))),
             ..
-        }] if matches!(&*inner.ty, IrType::Inline(InlineIrType::Any(_)))
+        }] if matches!(inner.ty, IrType::Inline(InlineIrType::Any(_)))
     );
 }
 
@@ -723,7 +723,7 @@ fn test_struct_with_required_fields() {
         other => panic!("expected struct `User`; got `{other:?}`"),
     };
     assert_matches!(
-        &*struct_.fields,
+        struct_.fields,
         [
             IrStructField {
                 name: IrStructFieldName::Name("name"),
@@ -780,7 +780,7 @@ fn test_struct_with_nullable_field_ref() {
                 IrType::Inline(InlineIrType::Container(_, Container::Optional(Inner { ty: inner, .. }))),
             ..
         },
-    ] = &*struct_.fields
+    ] = struct_.fields
     else {
         panic!("expected single nullable field; got `{:?}`", struct_.fields);
     };
@@ -824,7 +824,7 @@ fn test_struct_with_nullable_field_inline() {
                 IrType::Inline(InlineIrType::Container(_, Container::Optional(Inner { ty: inner, .. }))),
             ..
         },
-    ] = &*struct_.fields
+    ] = struct_.fields
     else {
         panic!("expected single nullable field; got `{:?}`", struct_.fields);
     };
@@ -875,7 +875,7 @@ fn test_struct_with_nullable_field_openapi_31_syntax() {
             required: true,
             ..
         },
-    ] = &*struct_.fields
+    ] = struct_.fields
     else {
         panic!(
             "expected single required nullable field; got `{:?}`",
@@ -920,7 +920,7 @@ fn test_struct_ref_field_description() {
         other => panic!("expected struct `Entity`; got `{other:?}`"),
     };
     assert_matches!(
-        &*struct_.fields,
+        struct_.fields,
         [IrStructField {
             name: IrStructFieldName::Name("id"),
             description: Some("An identifier"),
@@ -957,7 +957,7 @@ fn test_struct_inline_field_description() {
         other => panic!("expected struct `User`; got `{other:?}`"),
     };
     assert_matches!(
-        &*struct_.fields,
+        struct_.fields,
         [IrStructField {
             name: IrStructFieldName::Name("name"),
             description: Some("A user's name"),
@@ -1003,7 +1003,7 @@ fn test_struct_inline_all_of_becomes_parent() {
 
     // The struct's own field is `email`; inherited fields come from parents.
     assert_matches!(
-        &*struct_.fields,
+        struct_.fields,
         [IrStructField {
             name: IrStructFieldName::Name("email"),
             ..
@@ -1012,16 +1012,16 @@ fn test_struct_inline_all_of_becomes_parent() {
 
     // The inline `allOf` schemas become inline parent types.
     assert_matches!(
-        &*struct_.parents,
+        struct_.parents,
         [
             IrType::Inline(InlineIrType::Struct(path1, parent1)),
             IrType::Inline(InlineIrType::Struct(path2, parent2)),
         ] if path1.root == InlineIrTypePathRoot::Type("Person")
-            && path1.segments == vec![InlineIrTypePathSegment::Parent(1)]
-            && matches!(&*parent1.fields, [IrStructField { name: IrStructFieldName::Name("name"), .. }])
+            && path1.segments == [InlineIrTypePathSegment::Parent(1)]
+            && matches!(parent1.fields, [IrStructField { name: IrStructFieldName::Name("name"), .. }])
             && path2.root == InlineIrTypePathRoot::Type("Person")
-            && path2.segments == vec![InlineIrTypePathSegment::Parent(2)]
-            && matches!(&*parent2.fields, [IrStructField { name: IrStructFieldName::Name("age"), .. }]),
+            && path2.segments == [InlineIrTypePathSegment::Parent(2)]
+            && matches!(parent2.fields, [IrStructField { name: IrStructFieldName::Name("age"), .. }]),
     );
 }
 
@@ -1066,14 +1066,14 @@ fn test_struct_mixed_all_of_ref_and_inline() {
 
     // Parents include both the named and inline schemas.
     assert_matches!(
-        &*struct_.parents,
+        struct_.parents,
         [
             IrType::Ref(r),
             IrType::Inline(InlineIrType::Struct(path, parent)),
         ] if r.name() == "Base"
             && path.root == InlineIrTypePathRoot::Type("Child")
-            && path.segments == vec![InlineIrTypePathSegment::Parent(2)]
-            && matches!(&*parent.fields, [IrStructField { name: IrStructFieldName::Name("name"), .. }])
+            && path.segments == [InlineIrTypePathSegment::Parent(2)]
+            && matches!(parent.fields, [IrStructField { name: IrStructFieldName::Name("name"), .. }])
     );
 }
 
@@ -1125,15 +1125,15 @@ fn test_tagged_with_mapping() {
     let [
         dog_variant @ IrTaggedVariant { name: "Dog", .. },
         cat_variant @ IrTaggedVariant { name: "Cat", .. },
-    ] = &*tagged.variants
+    ] = tagged.variants
     else {
         panic!(
             "expected and `Cat` variants `Dog`; got `{:?}`",
             tagged.variants,
         );
     };
-    assert_matches!(&*dog_variant.aliases, ["dog"]);
-    assert_eq!(&*cat_variant.aliases, ["cat"]);
+    assert_matches!(dog_variant.aliases, ["dog"]);
+    assert_eq!(cat_variant.aliases, ["cat"]);
 }
 
 #[test]
@@ -1179,7 +1179,7 @@ fn test_tagged_filters_non_refs() {
         other => panic!("expected untagged union `Animal`; got `{other:?}`"),
     };
     assert_matches!(
-        &*untagged.variants,
+        untagged.variants,
         [
             IrUntaggedVariant::Some(IrUntaggedVariantNameHint::Index(1), IrType::Ref(_)),
             IrUntaggedVariant::Some(IrUntaggedVariantNameHint::Index(2), IrType::Inline(_)),
@@ -1230,7 +1230,7 @@ fn test_tagged_multiple_aliases() {
             aliases,
             ..
         },
-    ] = &*tagged.variants
+    ] = tagged.variants
     else {
         panic!("expected variant `Success`; got `{:?}`", tagged.variants);
     };
@@ -1282,7 +1282,7 @@ fn test_tagged_missing_variant() {
         other => panic!("expected untagged union `Animal`; got `{other:?}`"),
     };
     assert_matches!(
-        &*untagged.variants,
+        untagged.variants,
         [
             IrUntaggedVariant::Some(IrUntaggedVariantNameHint::Index(1), IrType::Ref(_)),
             IrUntaggedVariant::Some(IrUntaggedVariantNameHint::Index(2), IrType::Ref(_)),
@@ -1328,7 +1328,7 @@ fn test_tagged_description() {
     };
     assert_eq!(tagged.description, Some("A tagged union of animals"));
     assert_matches!(
-        &*tagged.variants,
+        tagged.variants,
         [IrTaggedVariant { name: "Dog", aliases, .. }] if aliases == &["dog"],
     );
 }
@@ -1371,7 +1371,7 @@ fn test_untagged_basic() {
         other => panic!("expected untagged union `StringOrNumber`; got `{other:?}`"),
     };
     assert_matches!(
-        &*untagged.variants,
+        untagged.variants,
         [
             IrUntaggedVariant::Some(IrUntaggedVariantNameHint::Index(1), IrType::Ref(_)),
             IrUntaggedVariant::Some(IrUntaggedVariantNameHint::Index(2), IrType::Ref(_)),
@@ -1481,7 +1481,7 @@ fn test_untagged_variant_numbering() {
         other => panic!("expected untagged union `ABC`; got `{other:?}`"),
     };
     assert_matches!(
-        &*untagged.variants,
+        untagged.variants,
         [
             IrUntaggedVariant::Some(IrUntaggedVariantNameHint::Index(1), _),
             IrUntaggedVariant::Some(IrUntaggedVariantNameHint::Index(2), _),
@@ -1566,7 +1566,7 @@ fn test_any_of_fields_marked_flattened_not_required() {
         other => panic!("expected struct `Contact`; got `{other:?}`"),
     };
     assert_matches!(
-        &*struct_.fields,
+        struct_.fields,
         [
             IrStructField {
                 name: IrStructFieldName::Name("Address"),
@@ -1622,7 +1622,7 @@ fn test_any_of_ref_uses_type_name() {
         other => panic!("expected struct `Contact`; got `{other:?}`"),
     };
     assert_matches!(
-        &*struct_.fields,
+        struct_.fields,
         [
             IrStructField {
                 name: IrStructFieldName::Name("Address"),
@@ -1669,7 +1669,7 @@ fn test_any_of_inline_uses_index_hint() {
         other => panic!("expected struct `Mixed`; got `{other:?}`"),
     };
     assert_matches!(
-        &*struct_.fields,
+        struct_.fields,
         [
             IrStructField {
                 name: IrStructFieldName::Hint(IrStructFieldNameHint::Index(1)),
@@ -1731,7 +1731,7 @@ fn test_any_of_with_properties() {
         other => panic!("expected struct `Combined`; got `{other:?}`"),
     };
     assert_matches!(
-        &*struct_.fields,
+        struct_.fields,
         [
             IrStructField {
                 name: IrStructFieldName::Name("Extra2"),
@@ -1790,7 +1790,7 @@ fn test_any_of_nullable_refs() {
         other => panic!("expected struct `Container`; got `{other:?}`"),
     };
     assert_matches!(
-        &*struct_.fields,
+        struct_.fields,
         [
             IrStructField {
                 name: IrStructFieldName::Name("NullableString1"),
@@ -1857,7 +1857,7 @@ fn test_any_of_with_all_of() {
     // Only flattened `anyOf` fields should be stored directly; the inherited
     // `id` field is accessed via graph traversal through `parents()`.
     assert_matches!(
-        &*struct_.fields,
+        struct_.fields,
         [
             IrStructField {
                 name: IrStructFieldName::Name("Extra1"),
@@ -2007,7 +2007,7 @@ fn test_object_with_empty_properties_produces_struct() {
         )) => struct_,
         other => panic!("expected struct `EmptyObject`; got `{other:?}`"),
     };
-    assert_matches!(&*struct_.fields, []);
+    assert_matches!(struct_.fields, []);
 }
 
 #[test]
@@ -2192,7 +2192,7 @@ fn test_multiple_types_string_and_integer_untagged() {
         other => panic!("expected untagged union `StringOrInt`; got `{other:?}`"),
     };
     assert_matches!(
-        &*untagged.variants,
+        untagged.variants,
         [
             IrUntaggedVariant::Some(
                 IrUntaggedVariantNameHint::Primitive(PrimitiveIrType::String),
@@ -2246,7 +2246,7 @@ fn test_deeply_nested_inline_types() {
                 IrType::Inline(InlineIrType::Container(path, Container::Array(Inner { ty: items, .. }))),
             ..
         },
-    ] = &*struct_.fields
+    ] = struct_.fields
     else {
         panic!("expected named inline array; got `{:?}`", struct_.fields);
     };
@@ -2254,7 +2254,7 @@ fn test_deeply_nested_inline_types() {
     // Container type path should be correct.
     assert_matches!(path.root, InlineIrTypePathRoot::Type("Outer"));
     assert_matches!(
-        &*path.segments,
+        path.segments,
         [InlineIrTypePathSegment::Field(IrStructFieldName::Name(
             "items"
         ))],
@@ -2268,7 +2268,7 @@ fn test_deeply_nested_inline_types() {
     // Inner struct path should have correct segments.
     assert_matches!(path.root, InlineIrTypePathRoot::Type("Outer"));
     assert_matches!(
-        &*path.segments,
+        path.segments,
         [
             InlineIrTypePathSegment::Field(IrStructFieldName::Name("items")),
             InlineIrTypePathSegment::ArrayItem,
@@ -2277,7 +2277,7 @@ fn test_deeply_nested_inline_types() {
 
     // Inner struct should have correct fields.
     assert_matches!(
-        &*inner_struct.fields,
+        inner_struct.fields,
         [IrStructField {
             name: IrStructFieldName::Name("field"),
             ty: IrType::Inline(InlineIrType::Primitive(_, PrimitiveIrType::String)),
@@ -2315,7 +2315,7 @@ fn test_enum_with_only_null_json_values_produces_empty_enum() {
         )) => enum_,
         other => panic!("expected enum `NullEnum`; got `{other:?}`"),
     };
-    assert_matches!(&*enum_.variants, []);
+    assert_matches!(enum_.variants, []);
 }
 
 #[test]
@@ -2351,7 +2351,7 @@ fn test_additional_properties_false_creates_struct() {
         other => panic!("expected struct `StrictObject`; got `{other:?}`"),
     };
     assert_matches!(
-        &*struct_.fields,
+        struct_.fields,
         [IrStructField {
             name: IrStructFieldName::Name("name"),
             ty: IrType::Inline(InlineIrType::Primitive(_, PrimitiveIrType::String)),
@@ -2402,7 +2402,7 @@ fn test_array_inline_path_construction() {
         other => panic!("expected inline struct; got `{other:?}`"),
     };
     assert_matches!(path.root, InlineIrTypePathRoot::Type("Container"));
-    assert_matches!(&*path.segments, [InlineIrTypePathSegment::ArrayItem]);
+    assert_matches!(path.segments, [InlineIrTypePathSegment::ArrayItem]);
 }
 
 #[test]
@@ -2445,7 +2445,7 @@ fn test_map_inline_path_construction() {
         other => panic!("expected inline struct; got `{other:?}`"),
     };
     assert_matches!(path.root, InlineIrTypePathRoot::Type("Dictionary"));
-    assert_matches!(&*path.segments, [InlineIrTypePathSegment::MapValue]);
+    assert_matches!(path.segments, [InlineIrTypePathSegment::MapValue]);
 }
 
 #[test]
@@ -2484,7 +2484,7 @@ fn test_struct_inline_path_construction() {
             ty: IrType::Inline(InlineIrType::Struct(path, _)),
             ..
         },
-    ] = &*struct_.fields
+    ] = struct_.fields
     else {
         panic!(
             "expected single inline struct field; got `{:?}`",
@@ -2493,7 +2493,7 @@ fn test_struct_inline_path_construction() {
     };
     assert_matches!(path.root, InlineIrTypePathRoot::Type("Outer"));
     assert_matches!(
-        &*path.segments,
+        path.segments,
         [InlineIrTypePathSegment::Field(IrStructFieldName::Name(
             "nested"
         ))],
@@ -2558,7 +2558,7 @@ fn test_inline_tagged_union_in_struct_field() {
             ty: IrType::Inline(InlineIrType::Tagged(path, tagged)),
             ..
         },
-    ] = &*struct_.fields
+    ] = struct_.fields
     else {
         panic!(
             "expected single inline tagged union field; got `{:?}`",
@@ -2569,7 +2569,7 @@ fn test_inline_tagged_union_in_struct_field() {
     // Verify the path.
     assert_matches!(path.root, InlineIrTypePathRoot::Type("Container"));
     assert_matches!(
-        &*path.segments,
+        path.segments,
         [InlineIrTypePathSegment::Field(IrStructFieldName::Name(
             "animal"
         ))],
@@ -2582,15 +2582,15 @@ fn test_inline_tagged_union_in_struct_field() {
     let [
         cat_variant @ IrTaggedVariant { name: "Cat", .. },
         dog_variant @ IrTaggedVariant { name: "Dog", .. },
-    ] = &*tagged.variants
+    ] = tagged.variants
     else {
         panic!(
             "expected `Cat` and `Dog` variants; got `{:?}`",
             tagged.variants
         );
     };
-    assert_eq!(&*cat_variant.aliases, ["cat"]);
-    assert_eq!(&*dog_variant.aliases, ["dog"]);
+    assert_eq!(cat_variant.aliases, ["cat"]);
+    assert_eq!(dog_variant.aliases, ["dog"]);
 }
 
 // MARK: Recursive schemas
@@ -2636,7 +2636,7 @@ fn test_recursive_all_of_ref_nullable() {
 
     // Verify the struct has the expected fields.
     assert_matches!(
-        &*struct_.fields,
+        struct_.fields,
         [
             IrStructField {
                 name: IrStructFieldName::Name("value"),
@@ -2690,7 +2690,7 @@ fn test_recursive_all_of_ref() {
 
     // Verify the struct has the expected fields.
     assert_matches!(
-        &*struct_.fields,
+        struct_.fields,
         [
             IrStructField {
                 name: IrStructFieldName::Name("value"),
@@ -3065,7 +3065,7 @@ fn test_inline_array_produces_inline_container() {
         other => panic!("expected struct `Container`; got `{other:?}`"),
     };
     assert_matches!(
-        &*struct_.fields,
+        struct_.fields,
         [IrStructField {
             name: IrStructFieldName::Name("items"),
             ty: IrType::Inline(InlineIrType::Container(_, Container::Array(_))),
@@ -3114,7 +3114,7 @@ fn test_optional_field_container_description_is_not_parent_schema() {
                 )),
             ..
         },
-    ] = &*struct_.fields
+    ] = struct_.fields
     else {
         panic!(
             "expected optional field `nickname`; got `{:?}`",

--- a/ploidy-core/src/ir/tests/views.rs
+++ b/ploidy-core/src/ir/tests/views.rs
@@ -1612,7 +1612,7 @@ fn test_inline_view_path_method() {
     // `path()` should return a path with one segment.
     let path = nested_inline.path();
     assert_matches!(
-        &*path.segments,
+        path.segments,
         [InlineIrTypePathSegment::Field(IrStructFieldName::Name(
             "nested"
         ))]
@@ -2590,7 +2590,7 @@ fn test_operation_view_inlines_finds_inline_types() {
         .iter()
         .find(|inline| {
             matches!(inline, InlineIrTypeView::Struct(path, _) if matches!(
-                &*path.segments,
+                path.segments,
                 [
                     InlineIrTypePathSegment::Operation("createUser"),
                     InlineIrTypePathSegment::Request,
@@ -2605,7 +2605,7 @@ fn test_operation_view_inlines_finds_inline_types() {
         .iter()
         .find(|inline| {
             matches!(inline, InlineIrTypeView::Struct(path, _) if matches!(
-                &*path.segments,
+                path.segments,
                 [
                     InlineIrTypePathSegment::Operation("createUser"),
                     InlineIrTypePathSegment::Request,
@@ -2619,7 +2619,7 @@ fn test_operation_view_inlines_finds_inline_types() {
         .iter()
         .find(|inline| {
             matches!(inline, InlineIrTypeView::Struct(path, _) if matches!(
-                &*path.segments,
+                path.segments,
                 [
                     InlineIrTypePathSegment::Operation("createUser"),
                     InlineIrTypePathSegment::Response,
@@ -2676,7 +2676,7 @@ fn test_operation_request_and_response() {
     };
     assert_matches!(request.path().root, InlineIrTypePathRoot::Resource(None));
     assert_matches!(
-        &*request.path().segments,
+        request.path().segments,
         [
             InlineIrTypePathSegment::Operation("createUser"),
             InlineIrTypePathSegment::Request,
@@ -2691,7 +2691,7 @@ fn test_operation_request_and_response() {
     };
     assert_matches!(response.path().root, InlineIrTypePathRoot::Resource(None));
     assert_matches!(
-        &*response.path().segments,
+        response.path().segments,
         [
             InlineIrTypePathSegment::Operation("createUser"),
             InlineIrTypePathSegment::Response,
@@ -3425,7 +3425,7 @@ fn test_inlined_variant_inline_field_types_not_leaked() {
     };
     assert_matches!(path.root, InlineIrTypePathRoot::Type("Pet"));
     assert_matches!(
-        &*path.segments,
+        path.segments,
         [InlineIrTypePathSegment::TaggedVariant("Dog")]
     );
 
@@ -3587,7 +3587,7 @@ fn test_inlined_when_struct_field_references_tagged_variant() {
     };
     assert_matches!(path.root, InlineIrTypePathRoot::Type("Pet"));
     assert_matches!(
-        &*path.segments,
+        path.segments,
         [InlineIrTypePathSegment::TaggedVariant("Dog")]
     );
 

--- a/ploidy-core/src/ir/transform.rs
+++ b/ploidy-core/src/ir/transform.rs
@@ -68,6 +68,12 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
         }
     }
 
+    /// Returns a reference to the arena allocator.
+    #[inline]
+    fn arena(&self) -> &'a Arena {
+        self.context.arena
+    }
+
     fn transform(self) -> IrType<'a> {
         self.try_tagged()
             .or_else(Self::try_untagged)
@@ -100,8 +106,8 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
                         }
                         variants.push(IrTaggedVariant {
                             name: r.path.name(),
-                            ty: self.context.arena.inner().alloc(IrType::Ref(&r.path)),
-                            aliases: aliases.to_vec(),
+                            ty: &*self.arena().alloc(IrType::Ref(&r.path)),
+                            aliases: self.arena().alloc_slice_copy(aliases),
                         });
                     }
                     // An inline schema variant can't have a discriminator mapping;
@@ -115,7 +121,7 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
         let tagged = IrTagged {
             description: self.schema.description.as_deref(),
             tag: discriminator.property_name.as_str(),
-            variants,
+            variants: self.arena().alloc_slice_copy(&variants),
         };
 
         Ok(match self.name {
@@ -138,16 +144,13 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
                     RefOrSchema::Ref(r) => Some(IrType::Ref(&r.path)),
                     RefOrSchema::Other(s) if matches!(&*s.ty, [Ty::Null]) => None,
                     RefOrSchema::Other(schema) => {
-                        let path = match &self.name {
+                        let segment = InlineIrTypePathSegment::Variant(index);
+                        let path = match self.name {
                             IrTypeName::Schema(info) => InlineIrTypePath {
                                 root: InlineIrTypePathRoot::Type(info.name),
-                                segments: vec![InlineIrTypePathSegment::Variant(index)],
+                                segments: self.arena().alloc_slice_copy(&[segment]),
                             },
-                            IrTypeName::Inline(path) => {
-                                let mut path = path.clone();
-                                path.segments.push(InlineIrTypePathSegment::Variant(index));
-                                path
-                            }
+                            IrTypeName::Inline(path) => path.join(self.arena(), &[segment]),
                         };
                         Some(transform_with_context(self.context, path, schema))
                     }
@@ -168,24 +171,24 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
                         }
                         _ => IrUntaggedVariantNameHint::Index(index),
                     };
-                    IrUntaggedVariant::Some(hint, ty)
+                    IrUntaggedVariant::Some(hint, &*self.arena().alloc(ty))
                 })
                 .unwrap_or(IrUntaggedVariant::Null)
             })
             .collect_vec();
 
         Ok(match &*variants {
-            [] => match &self.name {
-                IrTypeName::Schema(info) => SchemaIrType::Any(*info).into(),
-                IrTypeName::Inline(path) => InlineIrType::Any(path.clone()).into(),
+            [] => match self.name {
+                IrTypeName::Schema(info) => SchemaIrType::Any(info).into(),
+                IrTypeName::Inline(path) => InlineIrType::Any(path).into(),
             },
 
             // Unwrap single-variant untagged unions.
-            [IrUntaggedVariant::Null] => match &self.name {
-                IrTypeName::Schema(info) => SchemaIrType::Any(*info).into(),
-                IrTypeName::Inline(path) => InlineIrType::Any(path.clone()).into(),
+            [IrUntaggedVariant::Null] => match self.name {
+                IrTypeName::Schema(info) => SchemaIrType::Any(info).into(),
+                IrTypeName::Inline(path) => InlineIrType::Any(path).into(),
             },
-            [IrUntaggedVariant::Some(_, ty)] => ty.clone(),
+            [IrUntaggedVariant::Some(_, ty)] => **ty,
 
             // Simplify two-variant untagged unions, where one is a type
             // and the other is `null`, into optionals.
@@ -193,26 +196,22 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
             | [IrUntaggedVariant::Null, IrUntaggedVariant::Some(_, ty)] => {
                 let container = Container::Optional(Inner {
                     description: self.schema.description.as_deref(),
-                    ty: ty.clone().into(),
+                    ty: *ty,
                 });
                 match self.name {
                     IrTypeName::Schema(info) => SchemaIrType::Container(info, container).into(),
-                    IrTypeName::Inline(path) => {
-                        InlineIrType::Container(path.clone(), container).into()
-                    }
+                    IrTypeName::Inline(path) => InlineIrType::Container(path, container).into(),
                 }
             }
 
-            _ => {
+            variants => {
                 let untagged = IrUntagged {
                     description: self.schema.description.as_deref(),
-                    variants,
+                    variants: self.arena().alloc_slice_copy(variants),
                 };
-                match &self.name {
-                    IrTypeName::Schema(info) => SchemaIrType::Untagged(*info, untagged).into(),
-                    IrTypeName::Inline(path) => {
-                        InlineIrType::Untagged(path.clone(), untagged).into()
-                    }
+                match self.name {
+                    IrTypeName::Schema(info) => SchemaIrType::Untagged(info, untagged).into(),
+                    IrTypeName::Inline(path) => InlineIrType::Untagged(path, untagged).into(),
                 }
             }
         })
@@ -231,9 +230,9 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
                     let path = match self.name {
                         IrTypeName::Schema(info) => InlineIrTypePath {
                             root: InlineIrTypePathRoot::Type(info.name),
-                            segments: vec![],
+                            segments: &[],
                         },
-                        IrTypeName::Inline(path) => path.clone(),
+                        IrTypeName::Inline(path) => path,
                     };
                     transform_with_context(self.context, path, schema)
                 }
@@ -250,7 +249,7 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
                         // as the field name. For example, a pointer like
                         // `#/components/schemas/Address` becomes `address`.
                         let name = IrStructFieldName::Name(r.path.name());
-                        let ty = IrType::Ref(&r.path);
+                        let ty: &_ = self.arena().alloc(IrType::Ref(&r.path));
                         let desc = self
                             .context
                             .doc
@@ -264,43 +263,34 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
                         // For inline schemas, we don't have a name that we can use,
                         // so use its index in `anyOf` as a naming hint.
                         let name = IrStructFieldName::Hint(IrStructFieldNameHint::Index(index + 1));
-                        let path = match &self.name {
+                        let segment = InlineIrTypePathSegment::Field(name);
+                        let path = match self.name {
                             IrTypeName::Schema(info) => InlineIrTypePath {
                                 root: InlineIrTypePathRoot::Type(info.name),
-                                segments: vec![InlineIrTypePathSegment::Field(name)],
+                                segments: self.arena().alloc_slice_copy(&[segment]),
                             },
-                            IrTypeName::Inline(path) => {
-                                let mut path = path.clone();
-                                path.segments.push(InlineIrTypePathSegment::Field(name));
-                                path
-                            }
+                            IrTypeName::Inline(path) => path.join(self.arena(), &[segment]),
                         };
-                        let ty = transform_with_context(self.context, path, schema);
+                        let ty: &_ =
+                            self.arena()
+                                .alloc(transform_with_context(self.context, path, schema));
                         let desc = schema.description.as_deref();
                         (name, ty, desc)
                     }
                 };
                 // Flattened `anyOf` fields are always optional.
-                let path = match &self.name {
+                let segment = InlineIrTypePathSegment::Field(field_name);
+                let path = match self.name {
                     IrTypeName::Schema(info) => InlineIrTypePath {
                         root: InlineIrTypePathRoot::Type(info.name),
-                        segments: vec![InlineIrTypePathSegment::Field(field_name)],
+                        segments: self.arena().alloc_slice_copy(&[segment]),
                     },
-                    IrTypeName::Inline(path) => {
-                        let mut path = path.clone();
-                        path.segments
-                            .push(InlineIrTypePathSegment::Field(field_name));
-                        path
-                    }
+                    IrTypeName::Inline(path) => path.join(self.arena(), &[segment]),
                 };
-                let ty = InlineIrType::Container(
+                let ty: &_ = self.arena().alloc(IrType::from(InlineIrType::Container(
                     path,
-                    Container::Optional(Inner {
-                        description,
-                        ty: ty.into(),
-                    }),
-                )
-                .into();
+                    Container::Optional(Inner { description, ty }),
+                )));
                 IrStructField {
                     name: field_name,
                     ty,
@@ -311,19 +301,16 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
             })
             .collect_vec();
 
-        let parents = self.parents().collect();
-        let regular_fields = self.properties();
-
-        // Combine all the fields: regular properties first,
-        // followed by the flattened `anyOf` fields. This ordering
-        // ensures that regular properties take precedence during
-        // (de)serialization.
-        let all_fields = itertools::chain!(regular_fields, any_of_fields).collect();
-
         let ty = IrStruct {
             description: self.schema.description.as_deref(),
-            fields: all_fields,
-            parents,
+            fields: self.arena().alloc_slice({
+                // Combine all the fields: regular properties first,
+                // followed by the flattened `anyOf` fields. This ordering
+                // ensures that regular properties take precedence during
+                // (de)serialization.
+                itertools::chain!(self.properties(), any_of_fields)
+            }),
+            parents: self.arena().alloc_slice(self.parents()),
         };
 
         Ok(match self.name {
@@ -336,18 +323,15 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
         let Some(values) = &self.schema.variants else {
             return Err(self);
         };
-        let variants = values
-            .iter()
-            .filter_map(|value| {
-                if let Some(s) = value.as_str() {
-                    Some(IrEnumVariant::String(s))
-                } else if let Some(n) = value.as_number() {
-                    Some(IrEnumVariant::Number(n.clone()))
-                } else {
-                    value.as_bool().map(IrEnumVariant::Bool)
-                }
-            })
-            .collect();
+        let variants = self.arena().alloc_slice(values.iter().filter_map(|value| {
+            if let Some(s) = value.as_str() {
+                Some(IrEnumVariant::String(s))
+            } else if let Some(n) = value.as_number() {
+                Some(IrEnumVariant::Number(n.clone()))
+            } else {
+                value.as_bool().map(IrEnumVariant::Bool)
+            }
+        }));
         let ty = IrEnum {
             description: self.schema.description.as_deref(),
             variants,
@@ -363,12 +347,13 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
             return Err(self);
         }
 
-        let parents = self.parents().collect();
-        let fields = itertools::chain!(self.properties(), self.additional_properties()).collect();
         let ty = IrStruct {
             description: self.schema.description.as_deref(),
-            fields,
-            parents,
+            fields: self.arena().alloc_slice(itertools::chain!(
+                self.properties(),
+                self.additional_properties()
+            )),
+            parents: self.arena().alloc_slice(self.parents()),
         };
         Ok(match self.name {
             IrTypeName::Schema(info) => SchemaIrType::Struct(info, ty).into(),
@@ -450,30 +435,24 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
                     let items = match &self.schema.items {
                         Some(RefOrSchema::Ref(r)) => IrType::Ref(&r.path),
                         Some(RefOrSchema::Other(schema)) => {
-                            let path = match &self.name {
+                            let segment = InlineIrTypePathSegment::ArrayItem;
+                            let path = match self.name {
                                 IrTypeName::Schema(info) => InlineIrTypePath {
                                     root: InlineIrTypePathRoot::Type(info.name),
-                                    segments: vec![InlineIrTypePathSegment::ArrayItem],
+                                    segments: self.arena().alloc_slice_copy(&[segment]),
                                 },
-                                IrTypeName::Inline(path) => {
-                                    let mut path = path.clone();
-                                    path.segments.push(InlineIrTypePathSegment::ArrayItem);
-                                    path
-                                }
+                                IrTypeName::Inline(path) => path.join(self.arena(), &[segment]),
                             };
                             transform_with_context(self.context, path, schema)
                         }
                         None => {
-                            let path = match &self.name {
+                            let segment = InlineIrTypePathSegment::ArrayItem;
+                            let path = match self.name {
                                 IrTypeName::Schema(info) => InlineIrTypePath {
                                     root: InlineIrTypePathRoot::Type(info.name),
-                                    segments: vec![InlineIrTypePathSegment::ArrayItem],
+                                    segments: self.arena().alloc_slice_copy(&[segment]),
                                 },
-                                IrTypeName::Inline(path) => {
-                                    let mut path = path.clone();
-                                    path.segments.push(InlineIrTypePathSegment::ArrayItem);
-                                    path
-                                }
+                                IrTypeName::Inline(path) => path.join(self.arena(), &[segment]),
                             };
                             InlineIrType::Any(path).into()
                         }
@@ -482,7 +461,7 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
                         &self.name,
                         Inner {
                             description: self.schema.description.as_deref(),
-                            ty: items.into(),
+                            ty: self.arena().alloc(items),
                         },
                     )
                 }
@@ -492,41 +471,39 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
                         Some(AdditionalProperties::RefOrSchema(RefOrSchema::Ref(r))) => {
                             Some(Inner {
                                 description: self.schema.description.as_deref(),
-                                ty: IrType::Ref(&r.path).into(),
+                                ty: &*self.arena().alloc(IrType::Ref(&r.path)),
                             })
                         }
                         Some(AdditionalProperties::RefOrSchema(RefOrSchema::Other(schema))) => {
-                            let path = match &self.name {
+                            let segment = InlineIrTypePathSegment::MapValue;
+                            let path = match self.name {
                                 IrTypeName::Schema(info) => InlineIrTypePath {
                                     root: InlineIrTypePathRoot::Type(info.name),
-                                    segments: vec![InlineIrTypePathSegment::MapValue],
+                                    segments: self.arena().alloc_slice_copy(&[segment]),
                                 },
-                                IrTypeName::Inline(path) => {
-                                    let mut path = path.clone();
-                                    path.segments.push(InlineIrTypePathSegment::MapValue);
-                                    path
-                                }
+                                IrTypeName::Inline(path) => path.join(self.arena(), &[segment]),
                             };
                             Some(Inner {
                                 description: self.schema.description.as_deref(),
-                                ty: transform_with_context(self.context, path, schema).into(),
+                                ty: &*self.arena().alloc(transform_with_context(
+                                    self.context,
+                                    path,
+                                    schema,
+                                )),
                             })
                         }
                         Some(AdditionalProperties::Bool(true)) => {
-                            let path = match &self.name {
+                            let segment = InlineIrTypePathSegment::MapValue;
+                            let path = match self.name {
                                 IrTypeName::Schema(info) => InlineIrTypePath {
                                     root: InlineIrTypePathRoot::Type(info.name),
-                                    segments: vec![InlineIrTypePathSegment::MapValue],
+                                    segments: self.arena().alloc_slice_copy(&[segment]),
                                 },
-                                IrTypeName::Inline(path) => {
-                                    let mut path = path.clone();
-                                    path.segments.push(InlineIrTypePathSegment::MapValue);
-                                    path
-                                }
+                                IrTypeName::Inline(path) => path.join(self.arena(), &[segment]),
                             };
                             Some(Inner {
                                 description: self.schema.description.as_deref(),
-                                ty: Box::new(IrType::Inline(InlineIrType::Any(path))),
+                                ty: &*self.arena().alloc(IrType::Inline(InlineIrType::Any(path))),
                             })
                         }
                         _ => None,
@@ -548,15 +525,15 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
         match (&*other.variants, other.nullable) {
             // An empty `type` array is invalid in JSON Schema,
             // but we treat it as "any type".
-            ([], false) => match &self.name {
-                IrTypeName::Schema(info) => SchemaIrType::Any(*info).into(),
-                IrTypeName::Inline(path) => InlineIrType::Any(path.clone()).into(),
+            ([], false) => match self.name {
+                IrTypeName::Schema(info) => SchemaIrType::Any(info).into(),
+                IrTypeName::Inline(path) => InlineIrType::Any(path).into(),
             },
 
             // A `null` variant becomes `Any`.
-            ([], true) => match &self.name {
-                IrTypeName::Schema(info) => SchemaIrType::Any(*info).into(),
-                IrTypeName::Inline(path) => InlineIrType::Any(path.clone()).into(),
+            ([], true) => match self.name {
+                IrTypeName::Schema(info) => SchemaIrType::Any(info).into(),
+                IrTypeName::Inline(path) => InlineIrType::Any(path).into(),
             },
 
             // A union with a single, non-`null` variant unwraps to
@@ -568,13 +545,11 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
             ([variant], true) => {
                 let container = Container::Optional(Inner {
                     description: self.schema.description.as_deref(),
-                    ty: variant.to_inline_type().into(),
+                    ty: &*self.arena().alloc(variant.to_inline_type()),
                 });
                 match self.name {
                     IrTypeName::Schema(info) => SchemaIrType::Container(info, container).into(),
-                    IrTypeName::Inline(path) => {
-                        InlineIrType::Container(path.clone(), container).into()
-                    }
+                    IrTypeName::Inline(path) => InlineIrType::Container(path, container).into(),
                 }
             }
 
@@ -589,7 +564,7 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
                             variant
                                 .hint()
                                 .unwrap_or(IrUntaggedVariantNameHint::Index(index)),
-                            variant.to_type(),
+                            &*self.arena().alloc(variant.to_type()),
                         )
                     })
                     .collect_vec();
@@ -598,13 +573,11 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
                 }
                 let untagged = IrUntagged {
                     description: self.schema.description.as_deref(),
-                    variants,
+                    variants: self.arena().alloc_slice_copy(&variants),
                 };
                 match self.name {
                     IrTypeName::Schema(info) => SchemaIrType::Untagged(info, untagged).into(),
-                    IrTypeName::Inline(path) => {
-                        InlineIrType::Untagged(path.clone(), untagged).into()
-                    }
+                    IrTypeName::Inline(path) => InlineIrType::Untagged(path, untagged).into(),
                 }
             }
         }
@@ -613,28 +586,27 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
     // MARK: Shared lowering
 
     /// Lowers immediate parents from `allOf` into a list of types.
-    fn parents(&self) -> impl Iterator<Item = IrType<'a>> {
+    fn parents(&self) -> impl Iterator<Item = &'a IrType<'a>> {
         self.schema
             .all_of
             .iter()
             .flatten()
             .enumerate()
             .map(|(index, parent)| (index + 1, parent))
-            .map(|(index, parent)| match parent {
-                RefOrSchema::Ref(r) => IrType::Ref(&r.path),
+            .map(move |(index, parent)| match parent {
+                RefOrSchema::Ref(r) => &*self.arena().alloc(IrType::Ref(&r.path)),
                 RefOrSchema::Other(schema) => {
-                    let path = match &self.name {
+                    let segment = InlineIrTypePathSegment::Parent(index);
+                    let path = match self.name {
                         IrTypeName::Schema(info) => InlineIrTypePath {
                             root: InlineIrTypePathRoot::Type(info.name),
-                            segments: vec![InlineIrTypePathSegment::Parent(index)],
+                            segments: self.arena().alloc_slice_copy(&[segment]),
                         },
-                        IrTypeName::Inline(path) => {
-                            let mut path = path.clone();
-                            path.segments.push(InlineIrTypePathSegment::Parent(index));
-                            path
-                        }
+                        IrTypeName::Inline(path) => path.join(self.arena(), &[segment]),
                     };
-                    transform_with_context(self.context, path, schema)
+                    &*self
+                        .arena()
+                        .alloc(transform_with_context(self.context, path, schema))
                 }
             })
     }
@@ -646,28 +618,24 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
             .properties
             .iter()
             .flatten()
-            .map(|(name, field_schema)| {
+            .map(move |(name, field_schema)| {
                 let field_name = name.as_str();
                 let required = self.schema.required.contains(name);
-                let ty = match field_schema {
-                    RefOrSchema::Ref(r) => IrType::Ref(&r.path),
+                let ty: &_ = match field_schema {
+                    RefOrSchema::Ref(r) => &*self.arena().alloc(IrType::Ref(&r.path)),
                     RefOrSchema::Other(schema) => {
-                        let path = match &self.name {
+                        let segment =
+                            InlineIrTypePathSegment::Field(IrStructFieldName::Name(field_name));
+                        let path = match self.name {
                             IrTypeName::Schema(info) => InlineIrTypePath {
                                 root: InlineIrTypePathRoot::Type(info.name),
-                                segments: vec![InlineIrTypePathSegment::Field(
-                                    IrStructFieldName::Name(field_name),
-                                )],
+                                segments: self.arena().alloc_slice_copy(&[segment]),
                             },
-                            IrTypeName::Inline(path) => {
-                                let mut path = path.clone();
-                                path.segments.push(InlineIrTypePathSegment::Field(
-                                    IrStructFieldName::Name(field_name),
-                                ));
-                                path
-                            }
+                            IrTypeName::Inline(path) => path.join(self.arena(), &[segment]),
                         };
-                        transform_with_context(self.context, path, schema)
+                        &*self
+                            .arena()
+                            .alloc(transform_with_context(self.context, path, schema))
                     }
                 };
                 let description = match field_schema {
@@ -697,30 +665,20 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
                 // Wrap the type in `Optional` if the field is either
                 // explicitly nullable, or implicitly optional. The `required`
                 // flag distinguishes between the two for codegen.
-                let ty = if nullable || !required {
-                    let path = match &self.name {
+                let ty: &_ = if nullable || !required {
+                    let segment =
+                        InlineIrTypePathSegment::Field(IrStructFieldName::Name(field_name));
+                    let path = match self.name {
                         IrTypeName::Schema(info) => InlineIrTypePath {
                             root: InlineIrTypePathRoot::Type(info.name),
-                            segments: vec![InlineIrTypePathSegment::Field(
-                                IrStructFieldName::Name(field_name),
-                            )],
+                            segments: self.arena().alloc_slice_copy(&[segment]),
                         },
-                        IrTypeName::Inline(path) => {
-                            let mut path = path.clone();
-                            path.segments.push(InlineIrTypePathSegment::Field(
-                                IrStructFieldName::Name(field_name),
-                            ));
-                            path
-                        }
+                        IrTypeName::Inline(path) => path.join(self.arena(), &[segment]),
                     };
-                    InlineIrType::Container(
+                    self.arena().alloc(IrType::from(InlineIrType::Container(
                         path,
-                        Container::Optional(Inner {
-                            description,
-                            ty: ty.into(),
-                        }),
-                    )
-                    .into()
+                        Container::Optional(Inner { description, ty }),
+                    )))
                 } else {
                     ty
                 };
@@ -738,47 +696,50 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
     /// if the schema specifies them.
     fn additional_properties(&self) -> Option<IrStructField<'a>> {
         let name = IrStructFieldName::Hint(IrStructFieldNameHint::AdditionalProperties);
-        let path = match &self.name {
+        let path = match self.name {
             IrTypeName::Schema(info) => InlineIrTypePath {
                 root: InlineIrTypePathRoot::Type(info.name),
-                segments: vec![InlineIrTypePathSegment::Field(name)],
+                segments: self
+                    .arena()
+                    .alloc_slice_copy(&[InlineIrTypePathSegment::Field(name)]),
             },
             IrTypeName::Inline(path) => {
-                let mut path = path.clone();
-                path.segments.push(InlineIrTypePathSegment::Field(name));
-                path
+                path.join(self.arena(), &[InlineIrTypePathSegment::Field(name)])
             }
         };
 
         let inner = match &self.schema.additional_properties {
             Some(AdditionalProperties::RefOrSchema(RefOrSchema::Ref(r))) => Inner {
                 description: self.schema.description.as_deref(),
-                ty: IrType::Ref(&r.path).into(),
+                ty: &*self.arena().alloc(IrType::Ref(&r.path)),
             },
             Some(AdditionalProperties::RefOrSchema(RefOrSchema::Other(schema))) => {
-                let mut path = path.clone();
-                path.segments.push(InlineIrTypePathSegment::MapValue);
+                let path = path.join(self.arena(), &[InlineIrTypePathSegment::MapValue]);
                 Inner {
                     description: self.schema.description.as_deref(),
-                    ty: transform_with_context(self.context, path, schema).into(),
+                    ty: &*self
+                        .arena()
+                        .alloc(transform_with_context(self.context, path, schema)),
                 }
             }
             Some(AdditionalProperties::Bool(true)) => {
-                let mut path = path.clone();
-                path.segments.push(InlineIrTypePathSegment::MapValue);
+                let path = path.join(self.arena(), &[InlineIrTypePathSegment::MapValue]);
                 Inner {
                     description: self.schema.description.as_deref(),
-                    ty: Box::new(IrType::Inline(InlineIrType::Any(path))),
+                    ty: &*self.arena().alloc(IrType::Inline(InlineIrType::Any(path))),
                 }
             }
             _ => return None,
         };
 
-        let ty = InlineIrType::Container(path, Container::Map(inner));
+        let ty: &_ = self.arena().alloc(IrType::from(InlineIrType::Container(
+            path,
+            Container::Map(inner),
+        )));
 
         Some(IrStructField {
             name,
-            ty: ty.into(),
+            ty,
             required: true,
             description: None,
             flattened: true,
@@ -820,29 +781,25 @@ impl<'name, 'a> OtherVariant<'name, 'a> {
         match self {
             &Self::Primitive(name, p) => match name {
                 IrTypeName::Schema(info) => SchemaIrType::Primitive(*info, p).into(),
-                IrTypeName::Inline(path) => InlineIrType::Primitive(path.clone(), p).into(),
+                IrTypeName::Inline(path) => InlineIrType::Primitive(*path, p).into(),
             },
             Self::Array(name, inner) => {
-                let container = Container::Array(inner.clone());
+                let container = Container::Array(*inner);
                 match name {
                     IrTypeName::Schema(info) => SchemaIrType::Container(*info, container).into(),
-                    IrTypeName::Inline(path) => {
-                        InlineIrType::Container(path.clone(), container).into()
-                    }
+                    IrTypeName::Inline(path) => InlineIrType::Container(*path, container).into(),
                 }
             }
             Self::Map(name, inner) => {
-                let container = Container::Map(inner.clone());
+                let container = Container::Map(*inner);
                 match name {
                     IrTypeName::Schema(info) => SchemaIrType::Container(*info, container).into(),
-                    IrTypeName::Inline(path) => {
-                        InlineIrType::Container(path.clone(), container).into()
-                    }
+                    IrTypeName::Inline(path) => InlineIrType::Container(*path, container).into(),
                 }
             }
             Self::Any(name) => match name {
                 IrTypeName::Schema(info) => SchemaIrType::Any(*info).into(),
-                IrTypeName::Inline(path) => InlineIrType::Any(path.clone()).into(),
+                IrTypeName::Inline(path) => InlineIrType::Any(*path).into(),
             },
         }
     }
@@ -856,31 +813,31 @@ impl<'name, 'a> OtherVariant<'name, 'a> {
                 let path = match name {
                     IrTypeName::Schema(info) => InlineIrTypePath {
                         root: InlineIrTypePathRoot::Type(info.name),
-                        segments: vec![],
+                        segments: &[],
                     },
-                    IrTypeName::Inline(path) => path.clone(),
+                    &IrTypeName::Inline(path) => path,
                 };
                 InlineIrType::Primitive(path, p).into()
             }
             Self::Array(name, inner) => {
-                let container = Container::Array(inner.clone());
+                let container = Container::Array(*inner);
                 let path = match name {
                     IrTypeName::Schema(info) => InlineIrTypePath {
                         root: InlineIrTypePathRoot::Type(info.name),
-                        segments: vec![],
+                        segments: &[],
                     },
-                    IrTypeName::Inline(path) => path.clone(),
+                    &&IrTypeName::Inline(path) => path,
                 };
                 InlineIrType::Container(path, container).into()
             }
             Self::Map(name, inner) => {
-                let container = Container::Map(inner.clone());
+                let container = Container::Map(*inner);
                 let path = match name {
                     IrTypeName::Schema(info) => InlineIrTypePath {
                         root: InlineIrTypePathRoot::Type(info.name),
-                        segments: vec![],
+                        segments: &[],
                     },
-                    IrTypeName::Inline(path) => path.clone(),
+                    &&IrTypeName::Inline(path) => path,
                 };
                 InlineIrType::Container(path, container).into()
             }
@@ -888,9 +845,9 @@ impl<'name, 'a> OtherVariant<'name, 'a> {
                 let path = match name {
                     IrTypeName::Schema(info) => InlineIrTypePath {
                         root: InlineIrTypePathRoot::Type(info.name),
-                        segments: vec![],
+                        segments: &[],
                     },
-                    IrTypeName::Inline(path) => path.clone(),
+                    &&IrTypeName::Inline(path) => path,
                 };
                 InlineIrType::Any(path).into()
             }

--- a/ploidy-core/src/ir/types.rs
+++ b/ploidy-core/src/ir/types.rs
@@ -2,10 +2,13 @@
 
 use serde_json::Number;
 
-use crate::parse::{ComponentRef, Method, path::PathSegment};
+use crate::{
+    arena::Arena,
+    parse::{ComponentRef, Method, path::PathSegment},
+};
 
 /// A schema type ready for code generation.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum IrType<'a> {
     /// A reference to another named schema type.
     Ref(&'a ComponentRef),
@@ -51,30 +54,30 @@ pub enum PrimitiveIrType {
 }
 
 /// A container type.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub enum Container<'a> {
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum Container<'a, Ty = &'a IrType<'a>> {
     /// An array of items.
-    Array(Inner<'a>),
+    Array(Inner<'a, Ty>),
     /// A map with string keys.
-    Map(Inner<'a>),
+    Map(Inner<'a, Ty>),
     /// A nullable value, or an optional struct field.
-    Optional(Inner<'a>),
+    Optional(Inner<'a, Ty>),
 }
 
-impl<'a> Container<'a> {
+impl<'a, Ty> Container<'a, Ty> {
     /// Returns a reference to the inner type of this container.
     #[inline]
-    pub fn inner(&self) -> &Inner<'a> {
+    pub fn inner(&self) -> &Inner<'a, Ty> {
         let (Self::Array(inner) | Self::Map(inner) | Self::Optional(inner)) = self;
         inner
     }
 }
 
 /// The inner type of a [`Container`].
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct Inner<'a> {
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct Inner<'a, Ty = &'a IrType<'a>> {
     pub description: Option<&'a str>,
-    pub ty: Box<IrType<'a>>,
+    pub ty: Ty,
 }
 
 /// Metadata for a named schema type.
@@ -87,25 +90,25 @@ pub struct SchemaTypeInfo<'a> {
 }
 
 /// A named schema type.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub enum SchemaIrType<'a> {
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum SchemaIrType<'a, Ty = &'a IrType<'a>> {
     /// An enum with named variants.
     Enum(SchemaTypeInfo<'a>, IrEnum<'a>),
     /// A struct with fields.
-    Struct(SchemaTypeInfo<'a>, IrStruct<'a>),
+    Struct(SchemaTypeInfo<'a>, IrStruct<'a, Ty>),
     /// A tagged union.
-    Tagged(SchemaTypeInfo<'a>, IrTagged<'a>),
+    Tagged(SchemaTypeInfo<'a>, IrTagged<'a, Ty>),
     /// An untagged union.
-    Untagged(SchemaTypeInfo<'a>, IrUntagged<'a>),
+    Untagged(SchemaTypeInfo<'a>, IrUntagged<'a, Ty>),
     /// A named container.
-    Container(SchemaTypeInfo<'a>, Container<'a>),
+    Container(SchemaTypeInfo<'a>, Container<'a, Ty>),
     /// A primitive type.
     Primitive(SchemaTypeInfo<'a>, PrimitiveIrType),
     /// Any JSON value.
     Any(SchemaTypeInfo<'a>),
 }
 
-impl<'a> SchemaIrType<'a> {
+impl<'a, Ty> SchemaIrType<'a, Ty> {
     #[inline]
     pub fn name(&self) -> &'a str {
         let (Self::Enum(info, ..)
@@ -132,18 +135,18 @@ impl<'a> SchemaIrType<'a> {
 }
 
 /// An inline schema type.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub enum InlineIrType<'a> {
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum InlineIrType<'a, Ty = &'a IrType<'a>> {
     Enum(InlineIrTypePath<'a>, IrEnum<'a>),
-    Struct(InlineIrTypePath<'a>, IrStruct<'a>),
-    Tagged(InlineIrTypePath<'a>, IrTagged<'a>),
-    Untagged(InlineIrTypePath<'a>, IrUntagged<'a>),
-    Container(InlineIrTypePath<'a>, Container<'a>),
+    Struct(InlineIrTypePath<'a>, IrStruct<'a, Ty>),
+    Tagged(InlineIrTypePath<'a>, IrTagged<'a, Ty>),
+    Untagged(InlineIrTypePath<'a>, IrUntagged<'a, Ty>),
+    Container(InlineIrTypePath<'a>, Container<'a, Ty>),
     Primitive(InlineIrTypePath<'a>, PrimitiveIrType),
     Any(InlineIrTypePath<'a>),
 }
 
-impl<'a> InlineIrType<'a> {
+impl<'a, Ty> InlineIrType<'a, Ty> {
     #[inline]
     pub fn path(&self) -> &InlineIrTypePath<'a> {
         let (Self::Enum(path, _)
@@ -158,10 +161,27 @@ impl<'a> InlineIrType<'a> {
 }
 
 /// A path to an inline type.
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct InlineIrTypePath<'a> {
     pub root: InlineIrTypePathRoot<'a>,
-    pub segments: Vec<InlineIrTypePathSegment<'a>>,
+    pub segments: &'a [InlineIrTypePathSegment<'a>],
+}
+
+impl<'a> InlineIrTypePath<'a> {
+    /// Returns a new path with the suffix appended to the segments.
+    pub fn join(
+        self,
+        arena: &'a Arena,
+        suffix: &[InlineIrTypePathSegment<'a>],
+    ) -> InlineIrTypePath<'a> {
+        match suffix {
+            [] => self,
+            suffix => InlineIrTypePath {
+                root: self.root,
+                segments: arena.alloc_slice(self.segments.iter().chain(suffix).copied()),
+            },
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -186,10 +206,10 @@ pub enum InlineIrTypePathSegment<'a> {
 }
 
 /// An enum type.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct IrEnum<'a> {
     pub description: Option<&'a str>,
-    pub variants: Vec<IrEnumVariant<'a>>,
+    pub variants: &'a [IrEnumVariant<'a>],
 }
 
 /// A variant of an enum.
@@ -201,19 +221,19 @@ pub enum IrEnumVariant<'a> {
 }
 
 /// A struct, created from a schema with named properties.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct IrStruct<'a> {
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct IrStruct<'a, Ty = &'a IrType<'a>> {
     pub description: Option<&'a str>,
-    pub fields: Vec<IrStructField<'a>>,
+    pub fields: &'a [IrStructField<'a, Ty>],
     /// Immediate parent types from `allOf`, in declaration order.
-    pub parents: Vec<IrType<'a>>,
+    pub parents: &'a [Ty],
 }
 
 /// A field in a struct.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct IrStructField<'a> {
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct IrStructField<'a, Ty = &'a IrType<'a>> {
     pub name: IrStructFieldName<'a>,
-    pub ty: IrType<'a>,
+    pub ty: Ty,
     pub required: bool,
     pub description: Option<&'a str>,
     pub flattened: bool,
@@ -221,28 +241,28 @@ pub struct IrStructField<'a> {
 
 /// A tagged union, created from a `oneOf` schema
 /// with an explicit `discriminator`.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct IrTagged<'a> {
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct IrTagged<'a, Ty = &'a IrType<'a>> {
     pub description: Option<&'a str>,
     pub tag: &'a str,
-    pub variants: Vec<IrTaggedVariant<'a>>,
+    pub variants: &'a [IrTaggedVariant<'a, Ty>],
 }
 
 /// A variant of a tagged union.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct IrTaggedVariant<'a> {
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct IrTaggedVariant<'a, Ty = &'a IrType<'a>> {
     pub name: &'a str,
-    pub aliases: Vec<&'a str>,
-    pub ty: &'a IrType<'a>,
+    pub aliases: &'a [&'a str],
+    pub ty: Ty,
 }
 
 /// An untagged union, created from a `oneOf` schema
 /// without a discriminator, or an OpenAPI 3.1 schema
 /// with multiple types in its `type` field.
-#[derive(Debug, Clone, Eq, Hash, PartialEq)]
-pub struct IrUntagged<'a> {
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct IrUntagged<'a, Ty = &'a IrType<'a>> {
     pub description: Option<&'a str>,
-    pub variants: Vec<IrUntaggedVariant<'a>>,
+    pub variants: &'a [IrUntaggedVariant<Ty>],
 }
 
 /// A hint that's used to generate a more descriptive name
@@ -275,13 +295,13 @@ pub enum IrStructFieldNameHint {
 }
 
 /// A variant of an untagged union.
-#[derive(Debug, Clone, Eq, Hash, PartialEq)]
-pub enum IrUntaggedVariant<'a> {
-    Some(IrUntaggedVariantNameHint, IrType<'a>),
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum IrUntaggedVariant<Ty> {
+    Some(IrUntaggedVariantNameHint, Ty),
     Null,
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum IrTypeName<'a> {
     Schema(SchemaTypeInfo<'a>),
     Inline(InlineIrTypePath<'a>),
@@ -308,22 +328,22 @@ impl<'a> From<InlineIrTypePath<'a>> for IrTypeName<'a> {
     }
 }
 
-#[derive(Clone, Debug)]
-pub struct IrOperation<'a> {
+#[derive(Clone, Copy, Debug)]
+pub struct IrOperation<'a, Ty = &'a IrType<'a>> {
     pub id: &'a str,
     pub method: Method,
-    pub path: Vec<PathSegment<'a>>,
+    pub path: &'a [PathSegment<'a>],
     pub resource: Option<&'a str>,
     pub description: Option<&'a str>,
-    pub params: Vec<IrParameter<'a>>,
-    pub request: Option<IrRequest<'a>>,
-    pub response: Option<IrResponse<'a>>,
+    pub params: &'a [IrParameter<'a, Ty>],
+    pub request: Option<IrRequest<Ty>>,
+    pub response: Option<IrResponse<Ty>>,
 }
 
-impl<'a> IrOperation<'a> {
+impl<'a, Ty> IrOperation<'a, Ty> {
     /// Returns an iterator over all the types that this operation
     /// references directly.
-    pub fn types(&self) -> impl Iterator<Item = &IrType<'a>> {
+    pub fn types(&self) -> impl Iterator<Item = &Ty> {
         itertools::chain!(
             self.params.iter().map(|param| match param {
                 IrParameter::Path(info) => &info.ty,
@@ -340,21 +360,21 @@ impl<'a> IrOperation<'a> {
     }
 }
 
-#[derive(Clone, Debug)]
-pub enum IrResponse<'a> {
-    Json(IrType<'a>),
+#[derive(Clone, Copy, Debug)]
+pub enum IrResponse<Ty> {
+    Json(Ty),
 }
 
-#[derive(Clone, Debug)]
-pub enum IrRequest<'a> {
-    Json(IrType<'a>),
+#[derive(Clone, Copy, Debug)]
+pub enum IrRequest<Ty> {
+    Json(Ty),
     Multipart,
 }
 
-#[derive(Clone, Debug)]
-pub enum IrParameter<'a> {
-    Path(IrParameterInfo<'a>),
-    Query(IrParameterInfo<'a>),
+#[derive(Clone, Copy, Debug)]
+pub enum IrParameter<'a, Ty = &'a IrType<'a>> {
+    Path(IrParameterInfo<'a, Ty>),
+    Query(IrParameterInfo<'a, Ty>),
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -365,10 +385,10 @@ pub enum IrParameterStyle {
     DeepObject,
 }
 
-#[derive(Clone, Debug)]
-pub struct IrParameterInfo<'a> {
+#[derive(Clone, Copy, Debug)]
+pub struct IrParameterInfo<'a, Ty = &'a IrType<'a>> {
     pub name: &'a str,
-    pub ty: IrType<'a>,
+    pub ty: Ty,
     pub required: bool,
     pub description: Option<&'a str>,
     pub style: Option<IrParameterStyle>,

--- a/ploidy-core/src/ir/views/container.rs
+++ b/ploidy-core/src/ir/views/container.rs
@@ -71,15 +71,12 @@ impl<'a> ContainerView<'a> {
     pub(in crate::ir) fn new(
         cooked: &'a CookedGraph<'a>,
         index: NodeIndex<usize>,
-        container: &'a Container<'a>,
+        container: &'a Container<'a, NodeIndex<usize>>,
     ) -> Self {
         let inner = InnerView {
             cooked,
             container: index,
-            inner: {
-                let node = cooked.resolve(&container.inner().ty);
-                cooked.indices[&node]
-            },
+            inner: container.inner().ty,
         };
         match container {
             Container::Array(_) => Self::Array(inner),

--- a/ploidy-core/src/ir/views/enum_.rs
+++ b/ploidy-core/src/ir/views/enum_.rs
@@ -32,7 +32,7 @@ impl<'a> IrEnumView<'a> {
 
     #[inline]
     pub fn variants(&self) -> &'a [IrEnumVariant<'a>] {
-        &self.ty.variants
+        self.ty.variants
     }
 }
 

--- a/ploidy-core/src/ir/views/inline.rs
+++ b/ploidy-core/src/ir/views/inline.rs
@@ -25,7 +25,7 @@ impl<'a> InlineIrTypeView<'a> {
     pub(in crate::ir) fn new(
         cooked: &'a CookedGraph<'a>,
         index: NodeIndex<usize>,
-        ty: &'a InlineIrType<'a>,
+        ty: &'a InlineIrType<'a, NodeIndex<usize>>,
     ) -> Self {
         match ty {
             InlineIrType::Enum(path, ty) => Self::Enum(path, IrEnumView::new(cooked, index, ty)),

--- a/ploidy-core/src/ir/views/operation.rs
+++ b/ploidy-core/src/ir/views/operation.rs
@@ -11,26 +11,24 @@ use petgraph::{
 
 use crate::{
     ir::{
-        graph::{CookedGraph, EdgeKind, GraphNode, Traversal, Traverse},
-        types::{
-            IrOperation, IrParameter, IrParameterInfo, IrParameterStyle, IrRequest, IrResponse,
-        },
+        graph::{CookedGraph, CookedOperation, EdgeKind, GraphNode, Traversal, Traverse},
+        types::{IrParameter, IrParameterInfo, IrParameterStyle, IrRequest, IrResponse},
     },
     parse::{Method, path::PathSegment},
 };
 
 use super::{Reach, View, inline::InlineIrTypeView, ir::IrTypeView};
 
-/// A graph-aware view of an [`IrOperation`].
+/// A graph-aware view of an [`IrOperation`][crate::ir::IrOperation].
 #[derive(Debug)]
 pub struct IrOperationView<'a> {
     cooked: &'a CookedGraph<'a>,
-    op: &'a IrOperation<'a>,
+    op: CookedOperation<'a>,
 }
 
 impl<'a> IrOperationView<'a> {
     #[inline]
-    pub(in crate::ir) fn new(cooked: &'a CookedGraph<'a>, op: &'a IrOperation<'a>) -> Self {
+    pub(in crate::ir) fn new(cooked: &'a CookedGraph<'a>, op: CookedOperation<'a>) -> Self {
         Self { cooked, op }
     }
 
@@ -67,10 +65,7 @@ impl<'a> IrOperationView<'a> {
     #[inline]
     pub fn request(&self) -> Option<IrRequestView<'a>> {
         self.op.request.as_ref().map(|ty| match ty {
-            IrRequest::Json(ty) => {
-                let node = self.cooked.resolve(ty);
-                IrRequestView::Json(IrTypeView::new(self.cooked, self.cooked.indices[&node]))
-            }
+            IrRequest::Json(index) => IrRequestView::Json(IrTypeView::new(self.cooked, *index)),
             IrRequest::Multipart => IrRequestView::Multipart,
         })
     }
@@ -79,10 +74,7 @@ impl<'a> IrOperationView<'a> {
     #[inline]
     pub fn response(&self) -> Option<IrResponseView<'a>> {
         self.op.response.as_ref().map(|ty| match ty {
-            IrResponse::Json(ty) => {
-                let node = self.cooked.resolve(ty);
-                IrResponseView::Json(IrTypeView::new(self.cooked, self.cooked.indices[&node]))
-            }
+            IrResponse::Json(index) => IrResponseView::Json(IrTypeView::new(self.cooked, *index)),
         })
     }
 
@@ -221,13 +213,16 @@ impl<'view, 'a> IrOperationViewPath<'view, 'a> {
 #[derive(Debug)]
 pub struct IrParameterView<'a, T> {
     cooked: &'a CookedGraph<'a>,
-    info: &'a IrParameterInfo<'a>,
+    info: &'a IrParameterInfo<'a, NodeIndex<usize>>,
     phantom: PhantomData<T>,
 }
 
 impl<'a, T> IrParameterView<'a, T> {
     #[inline]
-    pub(in crate::ir) fn new(cooked: &'a CookedGraph<'a>, info: &'a IrParameterInfo<'a>) -> Self {
+    pub(in crate::ir) fn new(
+        cooked: &'a CookedGraph<'a>,
+        info: &'a IrParameterInfo<'a, NodeIndex<usize>>,
+    ) -> Self {
         Self {
             cooked,
             info,
@@ -242,8 +237,7 @@ impl<'a, T> IrParameterView<'a, T> {
 
     #[inline]
     pub fn ty(&self) -> IrTypeView<'a> {
-        let node = self.cooked.resolve(&self.info.ty);
-        IrTypeView::new(self.cooked, self.cooked.indices[&node])
+        IrTypeView::new(self.cooked, self.info.ty)
     }
 
     #[inline]

--- a/ploidy-core/src/ir/views/schema.rs
+++ b/ploidy-core/src/ir/views/schema.rs
@@ -25,7 +25,7 @@ impl<'a> SchemaIrTypeView<'a> {
     pub(in crate::ir) fn new(
         cooked: &'a CookedGraph<'a>,
         index: NodeIndex<usize>,
-        ty: &'a SchemaIrType<'a>,
+        ty: &'a SchemaIrType<'a, NodeIndex<usize>>,
     ) -> Self {
         match ty {
             SchemaIrType::Enum(info, ty) => Self::Enum(*info, IrEnumView::new(cooked, index, ty)),

--- a/ploidy-core/src/ir/views/struct_.rs
+++ b/ploidy-core/src/ir/views/struct_.rs
@@ -17,7 +17,7 @@ use super::{ViewNode, ir::IrTypeView};
 pub struct IrStructView<'a> {
     cooked: &'a CookedGraph<'a>,
     index: NodeIndex<usize>,
-    ty: &'a IrStruct<'a>,
+    ty: &'a IrStruct<'a, NodeIndex<usize>>,
 }
 
 impl<'a> IrStructView<'a> {
@@ -25,7 +25,7 @@ impl<'a> IrStructView<'a> {
     pub(in crate::ir) fn new(
         cooked: &'a CookedGraph<'a>,
         index: NodeIndex<usize>,
-        ty: &'a IrStruct<'a>,
+        ty: &'a IrStruct<'a, NodeIndex<usize>>,
     ) -> Self {
         Self { cooked, index, ty }
     }
@@ -62,7 +62,7 @@ impl<'a> IrStructView<'a> {
         itertools::chain!(
             // Inherited fields first, in declaration order.
             ancestors
-                .flat_map(|ancestor| &ancestor.fields)
+                .flat_map(|ancestor| ancestor.fields)
                 .filter(move |field| seen.insert(field.name))
                 .map(|field| IrStructFieldView {
                     parent: self,
@@ -88,11 +88,11 @@ impl<'a> IrStructView<'a> {
     /// Returns an iterator over immediate parent types from `allOf`,
     /// including named and inline schemas.
     #[inline]
-    pub fn parents(&self) -> impl Iterator<Item = IrTypeView<'a>> + '_ {
-        self.ty.parents.iter().map(move |parent| {
-            let node = self.cooked.resolve(parent);
-            IrTypeView::new(self.cooked, self.cooked.indices[&node])
-        })
+    pub fn parents(&self) -> impl Iterator<Item = IrTypeView<'a>> {
+        self.ty
+            .parents
+            .iter()
+            .map(move |&parent| IrTypeView::new(self.cooked, parent))
     }
 }
 
@@ -112,7 +112,7 @@ impl<'a> ViewNode<'a> for IrStructView<'a> {
 #[derive(Debug)]
 pub struct IrStructFieldView<'view, 'a> {
     parent: &'view IrStructView<'a>,
-    field: &'a IrStructField<'a>,
+    field: &'a IrStructField<'a, NodeIndex<usize>>,
     inherited: bool,
 }
 
@@ -125,8 +125,7 @@ impl<'view, 'a> IrStructFieldView<'view, 'a> {
     /// Returns a view of the inner type that this type wraps.
     #[inline]
     pub fn ty(&self) -> IrTypeView<'a> {
-        let node = self.parent.cooked.resolve(&self.field.ty);
-        IrTypeView::new(self.parent.cooked, self.parent.cooked.indices[&node])
+        IrTypeView::new(self.parent.cooked, self.field.ty)
     }
 
     #[inline]
@@ -178,9 +177,7 @@ impl<'view, 'a> IrStructFieldView<'view, 'a> {
     #[inline]
     pub fn needs_indirection(&self) -> bool {
         let graph = self.parent.cooked;
-        let node = graph.resolve(&self.field.ty);
-        let target = graph.indices[&node];
         graph.metadata.scc_indices[self.parent.index.index()]
-            == graph.metadata.scc_indices[target.index()]
+            == graph.metadata.scc_indices[self.field.ty.index()]
     }
 }

--- a/ploidy-core/src/ir/views/tagged.rs
+++ b/ploidy-core/src/ir/views/tagged.rs
@@ -12,7 +12,7 @@ use super::{ViewNode, ir::IrTypeView};
 pub struct IrTaggedView<'a> {
     cooked: &'a CookedGraph<'a>,
     index: NodeIndex<usize>,
-    ty: &'a IrTagged<'a>,
+    ty: &'a IrTagged<'a, NodeIndex<usize>>,
 }
 
 impl<'a> IrTaggedView<'a> {
@@ -20,7 +20,7 @@ impl<'a> IrTaggedView<'a> {
     pub(in crate::ir) fn new(
         cooked: &'a CookedGraph<'a>,
         index: NodeIndex<usize>,
-        ty: &'a IrTagged<'a>,
+        ty: &'a IrTagged<'a, NodeIndex<usize>>,
     ) -> Self {
         Self { cooked, index, ty }
     }
@@ -38,10 +38,10 @@ impl<'a> IrTaggedView<'a> {
     /// Returns an iterator over this tagged union's variants.
     #[inline]
     pub fn variants(&self) -> impl Iterator<Item = IrTaggedVariantView<'a>> {
-        self.ty.variants.iter().map(move |variant| {
-            let node = self.cooked.resolve(variant.ty);
-            IrTaggedVariantView::new(self.cooked, self.cooked.indices[&node], variant)
-        })
+        self.ty
+            .variants
+            .iter()
+            .map(move |variant| IrTaggedVariantView::new(self.cooked, variant.ty, variant))
     }
 }
 
@@ -62,7 +62,7 @@ impl<'a> ViewNode<'a> for IrTaggedView<'a> {
 pub struct IrTaggedVariantView<'a> {
     cooked: &'a CookedGraph<'a>,
     index: NodeIndex<usize>,
-    variant: &'a IrTaggedVariant<'a>,
+    variant: &'a IrTaggedVariant<'a, NodeIndex<usize>>,
 }
 
 impl<'a> IrTaggedVariantView<'a> {
@@ -70,7 +70,7 @@ impl<'a> IrTaggedVariantView<'a> {
     fn new(
         cooked: &'a CookedGraph<'a>,
         index: NodeIndex<usize>,
-        variant: &'a IrTaggedVariant<'a>,
+        variant: &'a IrTaggedVariant<'a, NodeIndex<usize>>,
     ) -> Self {
         Self {
             cooked,
@@ -86,14 +86,13 @@ impl<'a> IrTaggedVariantView<'a> {
 
     #[inline]
     pub fn aliases(&self) -> &'a [&'a str] {
-        &self.variant.aliases
+        self.variant.aliases
     }
 
     /// Returns a view of this variant's type.
     #[inline]
     pub fn ty(&self) -> IrTypeView<'a> {
-        let node = self.cooked.resolve(self.variant.ty);
-        IrTypeView::new(self.cooked, self.cooked.indices[&node])
+        IrTypeView::new(self.cooked, self.variant.ty)
     }
 }
 

--- a/ploidy-core/src/ir/views/untagged.rs
+++ b/ploidy-core/src/ir/views/untagged.rs
@@ -13,7 +13,7 @@ use super::{ViewNode, ir::IrTypeView};
 pub struct IrUntaggedView<'a> {
     cooked: &'a CookedGraph<'a>,
     index: NodeIndex<usize>,
-    ty: &'a IrUntagged<'a>,
+    ty: &'a IrUntagged<'a, NodeIndex<usize>>,
 }
 
 impl<'a> IrUntaggedView<'a> {
@@ -21,7 +21,7 @@ impl<'a> IrUntaggedView<'a> {
     pub(in crate::ir) fn new(
         cooked: &'a CookedGraph<'a>,
         index: NodeIndex<usize>,
-        ty: &'a IrUntagged<'a>,
+        ty: &'a IrUntagged<'a, NodeIndex<usize>>,
     ) -> Self {
         Self { cooked, index, ty }
     }
@@ -60,7 +60,7 @@ impl<'a> ViewNode<'a> for IrUntaggedView<'a> {
 #[derive(Debug)]
 pub struct IrUntaggedVariantView<'view, 'a> {
     parent: &'view IrUntaggedView<'a>,
-    variant: &'a IrUntaggedVariant<'a>,
+    variant: &'a IrUntaggedVariant<NodeIndex<usize>>,
 }
 
 impl<'view, 'a> IrUntaggedVariantView<'view, 'a> {
@@ -68,13 +68,10 @@ impl<'view, 'a> IrUntaggedVariantView<'view, 'a> {
     #[inline]
     pub fn ty(&self) -> Option<SomeIrUntaggedVariant<'a>> {
         match self.variant {
-            IrUntaggedVariant::Some(hint, ty) => {
-                let node = self.parent.cooked.resolve(ty);
-                Some(SomeIrUntaggedVariant {
-                    hint: *hint,
-                    view: IrTypeView::new(self.parent.cooked, self.parent.cooked.indices[&node]),
-                })
-            }
+            &IrUntaggedVariant::Some(hint, index) => Some(SomeIrUntaggedVariant {
+                hint,
+                view: IrTypeView::new(self.parent.cooked, index),
+            }),
             IrUntaggedVariant::Null => None,
         }
     }


### PR DESCRIPTION
`IrType::Ref` is always resolved during raw graph construction, so it's an impossible state in the cooked graph that's not enforced at the type level. This commit fixes that mismatch by parameterizing all the IR types:

* Raw types use `&'a IrType<'a>`, and so include references.
* Cooked types use `NodeIndex<usize>`, where references are structurally impossible.

A new `Cooker` resolves all references during `CookedGraph` construction. This simplifies views; and lets `Vec` and `Box` fields on types become arena-allocated `&[T]` slices and `&T` references, making all IR types `Copy`.