### PR TITLE
fix(ir): Use schema name for discriminators without explicit mappings.

### DIFF
--- a/ploidy-codegen-rust/src/tagged.rs
+++ b/ploidy-codegen-rust/src/tagged.rs
@@ -385,6 +385,70 @@ mod tests {
         assert_eq!(actual, expected);
     }
 
+    #[test]
+    fn test_tagged_union_without_mapping() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            components:
+              schemas:
+                Dog:
+                  type: object
+                  properties:
+                    bark:
+                      type: string
+                Cat:
+                  type: object
+                  properties:
+                    meow:
+                      type: string
+                Pet:
+                  oneOf:
+                    - $ref: '#/components/schemas/Dog'
+                    - $ref: '#/components/schemas/Cat'
+                  discriminator:
+                    propertyName: petType
+        "})
+        .unwrap();
+
+        let arena = Arena::new();
+        let spec = Spec::from_doc(&arena, &doc).unwrap();
+        let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
+
+        let schema = graph.schemas().find(|s| s.name() == "Pet");
+        let Some(schema @ SchemaTypeView::Tagged(_, tagged)) = &schema else {
+            panic!("expected tagged union `Pet`; got `{schema:?}`");
+        };
+
+        let name = CodegenTypeName::Schema(schema);
+        let codegen = CodegenTagged::new(name, tagged);
+
+        let actual: syn::File = parse_quote!(#codegen);
+        let expected: syn::File = parse_quote! {
+            #[derive(Debug, Clone, PartialEq, Eq, Hash, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+            #[serde(crate = "::ploidy_util::serde", tag = "petType")]
+            pub enum Pet {
+                #[serde(rename = "Dog")]
+                Dog(crate::types::Dog),
+                #[serde(rename = "Cat")]
+                Cat(crate::types::Cat),
+            }
+            impl ::std::convert::From<crate::types::Dog> for Pet {
+                fn from(value: crate::types::Dog) -> Self {
+                    Self::Dog(value)
+                }
+            }
+            impl ::std::convert::From<crate::types::Cat> for Pet {
+                fn from(value: crate::types::Cat) -> Self {
+                    Self::Cat(value)
+                }
+            }
+        };
+        assert_eq!(actual, expected);
+    }
+
     // MARK: Inlined variants
 
     #[test]

--- a/ploidy-core/src/ir/tests/transform.rs
+++ b/ploidy-core/src/ir/tests/transform.rs
@@ -1267,59 +1267,6 @@ fn test_tagged_multiple_aliases() {
 }
 
 #[test]
-fn test_tagged_missing_variant() {
-    let doc = Document::from_yaml(indoc::indoc! {"
-        openapi: 3.0.0
-        info:
-          title: Test API
-          version: 1.0.0
-        components:
-          schemas:
-            Dog:
-              type: object
-              properties:
-                bark:
-                  type: string
-            Cat:
-              type: object
-              properties:
-                meow:
-                  type: string
-    "})
-    .unwrap();
-    // Only `Dog` is in the mapping; `Cat` isn't.
-    let schema: Schema = serde_yaml::from_str(indoc::indoc! {"
-        oneOf:
-          - $ref: '#/components/schemas/Dog'
-          - $ref: '#/components/schemas/Cat'
-        discriminator:
-          propertyName: type
-          mapping:
-            dog: '#/components/schemas/Dog'
-    "})
-    .unwrap();
-
-    let arena = Arena::new();
-    let result = transform(&arena, &doc, "Animal", &schema);
-
-    // `Cat` has no discriminator tag, so `Animal` should lower to
-    // an untagged union with two variants.
-    assert_matches!(
-        result,
-        SpecType::Schema(SpecSchemaType::Untagged(
-            SchemaTypeInfo { name: "Animal", .. },
-            Untagged {
-                variants: [
-                    SpecUntaggedVariant::Some(UntaggedVariantNameHint::Index(1), SpecType::Ref(_)),
-                    SpecUntaggedVariant::Some(UntaggedVariantNameHint::Index(2), SpecType::Ref(_)),
-                ],
-                ..
-            },
-        )),
-    );
-}
-
-#[test]
 fn test_tagged_description() {
     let doc = Document::from_yaml(indoc::indoc! {"
         openapi: 3.0.0
@@ -1361,6 +1308,126 @@ fn test_tagged_description() {
                     aliases: ["dog"],
                     ..
                 }],
+            },
+        )),
+    );
+}
+
+#[test]
+fn test_tagged_without_mapping() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test API
+          version: 1.0.0
+        components:
+          schemas:
+            Dog:
+              type: object
+              properties:
+                bark:
+                  type: string
+            Cat:
+              type: object
+              properties:
+                meow:
+                  type: string
+    "})
+    .unwrap();
+    // A discriminator without an explicit `mapping` should default to
+    // the schema name.
+    let schema: Schema = serde_yaml::from_str(indoc::indoc! {"
+        oneOf:
+          - $ref: '#/components/schemas/Dog'
+          - $ref: '#/components/schemas/Cat'
+        discriminator:
+          propertyName: petType
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let result = transform(&arena, &doc, "Pet", &schema);
+
+    assert_matches!(
+        result,
+        SpecType::Schema(SpecSchemaType::Tagged(
+            SchemaTypeInfo { name: "Pet", .. },
+            Tagged {
+                tag: "petType",
+                variants: [
+                    SpecTaggedVariant {
+                        name: "Dog",
+                        aliases: ["Dog"],
+                        ..
+                    },
+                    SpecTaggedVariant {
+                        name: "Cat",
+                        aliases: ["Cat"],
+                        ..
+                    },
+                ],
+                ..
+            },
+        )),
+    );
+}
+
+#[test]
+fn test_tagged_with_partial_mapping() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test API
+          version: 1.0.0
+        components:
+          schemas:
+            Dog:
+              type: object
+              properties:
+                bark:
+                  type: string
+            Cat:
+              type: object
+              properties:
+                meow:
+                  type: string
+    "})
+    .unwrap();
+    // Only `Dog` has an explicit mapping; `Cat` should default to
+    // its schema name.
+    let schema: Schema = serde_yaml::from_str(indoc::indoc! {"
+        oneOf:
+          - $ref: '#/components/schemas/Dog'
+          - $ref: '#/components/schemas/Cat'
+        discriminator:
+          propertyName: type
+          mapping:
+            dog: '#/components/schemas/Dog'
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let result = transform(&arena, &doc, "Animal", &schema);
+
+    assert_matches!(
+        result,
+        SpecType::Schema(SpecSchemaType::Tagged(
+            SchemaTypeInfo { name: "Animal", .. },
+            Tagged {
+                tag: "type",
+                variants: [
+                    SpecTaggedVariant {
+                        name: "Dog",
+                        aliases: ["dog"],
+                        ..
+                    },
+                    SpecTaggedVariant {
+                        name: "Cat",
+                        aliases: ["Cat"],
+                        ..
+                    },
+                ],
+                ..
             },
         )),
     );

--- a/ploidy-core/src/ir/transform.rs
+++ b/ploidy-core/src/ir/transform.rs
@@ -99,12 +99,13 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
             for schema in one_of {
                 match schema {
                     RefOrSchema::Ref(r) => {
-                        let aliases = inverted.get(&r.path).map(|s| s.as_slice()).unwrap_or(&[]);
-                        if aliases.is_empty() {
-                            // Variant missing from discriminator mapping;
-                            // fall through to `try_untagged`.
-                            return Err(self);
-                        }
+                        let aliases =
+                            match inverted.get(&r.path).map(|s| s.as_slice()).unwrap_or(&[]) {
+                                // When a discriminator value doesn't have
+                                // an explicit `mapping`, use the schema name.
+                                [] => &[&*self.arena().alloc_str(r.path.name())],
+                                aliases => aliases,
+                            };
                         variants.push(SpecTaggedVariant {
                             name: r.path.name(),
                             ty: self.arena().alloc(SpecType::Ref(&r.path)),


### PR DESCRIPTION
Per OpenAPI 3.2 section 4.25.2, when a schema doesn't have an explicit discriminator `mapping`, the schema name should be used instead. `try_tagged()` no longer falls through to an untagged union if a `oneOf` variant schema doesn't appear in the mapping.

Closes #47.