### PR TITLE
feat(codegen): Preserve and round-trip `Other` enum variants.

### DIFF
--- a/ploidy-codegen-rust/src/enum_.rs
+++ b/ploidy-codegen-rust/src/enum_.rs
@@ -35,10 +35,10 @@ impl ToTokens for CodegenEnum<'_> {
                 pub type #type_name = ::std::string::String;
             });
         } else {
-            // Otherwise, emit a Rust unit enum.
-            let mut variants = Vec::new();
-            let mut display_arms = Vec::new();
-            let mut from_str_arms = Vec::new();
+            // Otherwise, emit a Rust enum.
+            let mut variants = vec![];
+            let mut display_arms = vec![];
+            let mut from_str_arms = vec![];
 
             for variant in self.ty.variants() {
                 match variant {
@@ -59,29 +59,24 @@ impl ToTokens for CodegenEnum<'_> {
                 parse_quote!(#name)
             };
             let other_name = format_ident!("Other{}", type_name);
-            variants.push(quote! {
-                #[default]
-                #other_name
-            });
-            display_arms.push(quote! { Self::#other_name => "(other)" });
-            from_str_arms.push(quote! { _ => Self::#other_name });
+            variants.push(quote! { #other_name(String) });
+            display_arms.push(quote! { Self::#other_name(s) => s.as_str() });
+            from_str_arms.push(quote! { _ => Self::#other_name(s.to_owned()) });
 
-            let other_serialize_error =
-                format!("can't serialize variant `{type_name}::{other_name}`");
             let expecting = format!("a variant of `{type_name}`");
 
             let doc_attrs = self.ty.description().map(doc_attrs);
 
             tokens.append_all(quote! {
                 #doc_attrs
-                #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+                #[derive(Clone, Debug, Eq, Hash, PartialEq)]
                 pub enum #type_name {
                     #(#variants),*
                 }
 
-                impl #type_name {
-                    pub fn is_other(&self) -> bool {
-                        matches!(self, Self::#other_name)
+                impl ::std::default::Default for #type_name {
+                    fn default() -> Self {
+                        Self::#other_name(::std::string::String::default())
                     }
                 }
 
@@ -132,10 +127,7 @@ impl ToTokens for CodegenEnum<'_> {
                         &self,
                         serializer: S,
                     ) -> ::std::result::Result<S::Ok, S::Error> {
-                        match self {
-                            Self::#other_name => Err(::ploidy_util::serde::ser::Error::custom(#other_serialize_error)),
-                            v => v.to_string().serialize(serializer),
-                        }
+                        serializer.collect_str(self)
                     }
                 }
             });
@@ -211,17 +203,16 @@ mod tests {
 
         let actual: syn::File = parse_quote!(#codegen);
         let expected: syn::File = parse_quote! {
-            #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+            #[derive(Clone, Debug, Eq, Hash, PartialEq)]
             pub enum Status {
                 Active,
                 Inactive,
                 Pending,
-                #[default]
-                OtherStatus
+                OtherStatus(String)
             }
-            impl Status {
-                pub fn is_other(&self) -> bool {
-                    matches!(self, Self::OtherStatus)
+            impl ::std::default::Default for Status {
+                fn default() -> Self {
+                    Self::OtherStatus(::std::string::String::default())
                 }
             }
             impl ::std::fmt::Display for Status {
@@ -231,7 +222,7 @@ mod tests {
                             Self::Active => "active",
                             Self::Inactive => "inactive",
                             Self::Pending => "pending",
-                            Self::OtherStatus => "(other)"
+                            Self::OtherStatus(s) => s.as_str()
                         }
                     )
                 }
@@ -244,7 +235,7 @@ mod tests {
                             "active" => Self::Active,
                             "inactive" => Self::Inactive,
                             "pending" => Self::Pending,
-                            _ => Self::OtherStatus
+                            _ => Self::OtherStatus(s.to_owned())
                         }
                     )
                 }
@@ -278,14 +269,7 @@ mod tests {
                     &self,
                     serializer: S,
                 ) -> ::std::result::Result<S::Ok, S::Error> {
-                    match self {
-                        Self::OtherStatus => Err(
-                            ::ploidy_util::serde::ser::Error::custom(
-                                "can't serialize variant `Status::OtherStatus`"
-                            )
-                        ),
-                        v => v.to_string().serialize(serializer),
-                    }
+                    serializer.collect_str(self)
                 }
             }
         };

--- a/ploidy-codegen-rust/src/struct_.rs
+++ b/ploidy-codegen-rust/src/struct_.rs
@@ -14,7 +14,6 @@ use syn::{Ident, parse_quote};
 use super::{
     derives::ExtraDerive,
     doc_attrs,
-    enum_::EnumViewExt,
     naming::{CodegenIdentScope, CodegenIdentUsage, CodegenStructFieldName, CodegenTypeName},
     ref_::CodegenRef,
 };
@@ -285,26 +284,7 @@ impl ToTokens for SerdeFieldAttr<'_, '_> {
             }
         }
 
-        if let ref ty @ TypeView::Schema(SchemaTypeView::Enum(_, ref view))
-        | ref ty @ TypeView::Inline(InlineTypeView::Enum(_, ref view)) = self.field.ty()
-            && view.representable()
-        {
-            // Enum fields default to the catch-all `Other` variant,
-            // which returns an error when serialized. Since this
-            // default isn't meaningful, skip serializing them.
-            // This only matches direct enum types; optional fields have
-            // `Container(Optional(Enum))` as their type, so they
-            // fall through to the `AbsentOr::is_absent` branch below.
-            attrs.push(quote! { default });
-            attrs.push({
-                let inner = CodegenRef::new(ty);
-                let path: syn::Path = parse_quote!(#inner::is_other);
-                // `.to_token_stream().to_string()` cuddles each `::` in spaces;
-                // manually stringify the path for cleaner output.
-                let joined = path.segments.iter().map(|s| &s.ident).join("::");
-                quote! { skip_serializing_if = #joined }
-            });
-        } else if !self.field.required() {
+        if !self.field.required() {
             // `CodegenField` always emits `AbsentOr` for optional fields.
             attrs.push(quote! { default });
             attrs.push(
@@ -1779,7 +1759,7 @@ mod tests {
     // MARK: Enum fields
 
     #[test]
-    fn test_struct_required_enum_field_skips_other() {
+    fn test_struct_required_enum_field() {
         let doc = Document::from_yaml(indoc::indoc! {"
             openapi: 3.0.0
             info:
@@ -1824,7 +1804,6 @@ mod tests {
             #[serde(crate = "::ploidy_util::serde")]
             pub struct Pet {
                 pub name: ::std::string::String,
-                #[serde(default, skip_serializing_if = "crate::types::Status::is_other",)]
                 pub status: crate::types::Status,
             }
         };
@@ -1884,7 +1863,7 @@ mod tests {
     }
 
     #[test]
-    fn test_struct_required_inline_enum_field_skips_other() {
+    fn test_struct_required_inline_enum_field() {
         let doc = Document::from_yaml(indoc::indoc! {"
             openapi: 3.0.0
             info:
@@ -1927,7 +1906,6 @@ mod tests {
             #[serde(crate = "::ploidy_util::serde")]
             pub struct Pet {
                 pub name: ::std::string::String,
-                #[serde(default, skip_serializing_if = "crate::types::pet::types::Status::is_other",)]
                 pub status: crate::types::pet::types::Status,
             }
         };


### PR DESCRIPTION
Follow-up to #49: instead of excluding `Other` variants from serialization, why don't we preserve the string? The generated enums can't derive `Copy` anymore, but since none of our other generated types derive it, that feels more than OK for the ergonomic improvement!

As a nice bonus, we can remove the complicated `skip_serializing_if` generation.

The other breaking change: enums no longer have an `is_other()` method. Since the `Other` variant now carries data, the predicate doesn't feel super useful now.