### PR TITLE
fix(ir): Support `properties` on `oneOf` schemas.

### DIFF
--- a/ploidy-codegen-rust/src/ext.rs
+++ b/ploidy-codegen-rust/src/ext.rs
@@ -36,29 +36,18 @@ impl<'a, T: View<'a>> ViewExt for T {
                     Traversal::Ignore
                 }
                 (
-                    EdgeKind::Reference | EdgeKind::Inherits,
-                    TypeView::Schema(SchemaTypeView::Struct(_, view))
-                    | TypeView::Inline(InlineTypeView::Struct(_, view)),
+                    EdgeKind::Reference,
+                    TypeView::Schema(SchemaTypeView::Struct(_, _))
+                    | TypeView::Inline(InlineTypeView::Struct(_, _)),
                 ) => {
-                    // Structs may or may not implement `Default`,
-                    // depending on their fields. If this struct
-                    // inherits fields from another struct,
-                    // we need to consider that struct's fields, too.
-                    if view.fields().filter(|f| !f.tag()).all(|f| !f.required()) {
-                        // If all non-tag fields of all reachable structs are optional,
-                        // then this struct can derive `Default`.
-                        Traversal::Ignore
-                    } else {
-                        // Otherwise, skip the struct itself, but visit all its fields
-                        // to determine which ones are defaultable.
-                        Traversal::Skip
-                    }
+                    // Structs may or may not implement `Default`, depending on
+                    // their fields. Skip the struct itself, but explore all
+                    // its fields to determine which ones are defaultable.
+                    Traversal::Skip
                 }
                 (EdgeKind::Inherits, _) => {
-                    // Inheriting from a non-struct type isn't semantically meaningful
-                    // because the parent doesn't contribute any fields, so we can
-                    // ignore it for the purposes of deriving `Default`.
-                    Traversal::Ignore
+                    // Explore parents to check their defaultability.
+                    Traversal::Skip
                 }
                 (EdgeKind::Reference, _) => {
                     // Any other type that this struct references must be defaultable

--- a/ploidy-codegen-rust/src/struct_.rs
+++ b/ploidy-codegen-rust/src/struct_.rs
@@ -81,10 +81,11 @@ impl ToTokens for CodegenStruct<'_> {
             extra_derives.push(ExtraDerive::Hash);
         }
 
-        // Derive `Default` if all transitively referenced types
-        // are defaultable.
-        let all_defaultable = self.ty.defaultable();
-        if all_defaultable {
+        // Derive `Default` if all non-tag fields are optional
+        // (they become `AbsentOr<T>`, which is unconditionally `Default`),
+        // or if all transitively referenced types are defaultable.
+        let all_optional = self.ty.fields().filter(|f| !f.tag()).all(|f| !f.required());
+        if all_optional || self.ty.defaultable() {
             extra_derives.push(ExtraDerive::Default);
         }
 
@@ -1173,6 +1174,55 @@ mod tests {
     }
 
     #[test]
+    fn test_struct_derives_default_with_optional_url_field() {
+        // Even though `Url` doesn't implement `Default`, an optional `Url`
+        // field becomes `AbsentOr<Url>`, which is unconditionally `Default`.
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Resource:
+                  type: object
+                  properties:
+                    link:
+                      type: string
+                      format: uri
+                    name:
+                      type: string
+        "})
+        .unwrap();
+
+        let arena = Arena::new();
+        let spec = Spec::from_doc(&arena, &doc).unwrap();
+        let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
+
+        let schema = graph.schemas().find(|s| s.name() == "Resource");
+        let Some(schema @ SchemaTypeView::Struct(_, struct_view)) = &schema else {
+            panic!("expected struct `Resource`; got `{schema:?}`");
+        };
+
+        let name = CodegenTypeName::Schema(schema);
+        let codegen = CodegenStruct::new(name, struct_view);
+
+        let actual: syn::ItemStruct = parse_quote!(#codegen);
+        let expected: syn::ItemStruct = parse_quote! {
+            #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+            #[serde(crate = "::ploidy_util::serde")]
+            pub struct Resource {
+                #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent")]
+                pub link: ::ploidy_util::absent::AbsentOr<::ploidy_util::url::Url>,
+                #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent")]
+                pub name: ::ploidy_util::absent::AbsentOr<::std::string::String>,
+            }
+        };
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
     fn test_struct_derives_default_with_required_container_schema_field() {
         // A required field that references a container schema should still allow
         // the struct to derive `Default`, since `Vec<T>` implements `Default`.
@@ -1281,13 +1331,94 @@ mod tests {
 
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         // `Corgi` inherits from the tagged union `Animal` via `allOf`.
-        // Inheriting from a tagged union isn't structurally meaningful;
-        // the union's variants aren't fields. Since `Corgi`'s own field
-        // (`name`) is optional, it should derive `Default`.
+        // `Animal` has `type` as a required common field alongside its
+        // `oneOf` discriminator; `Corgi` inherits it. Both `String` and
+        // `AbsentOr` implement `Default`, so `Default` is still derived.
         let expected: syn::ItemStruct = parse_quote! {
             #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
             #[serde(crate = "::ploidy_util::serde")]
             pub struct Corgi {
+                pub r#type: ::std::string::String,
+                #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent")]
+                pub name: ::ploidy_util::absent::AbsentOr<::std::string::String>,
+            }
+        };
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_struct_excludes_default_when_inheriting_non_defaultable_from_tagged_union() {
+        // `Base` is a tagged union with a non-defaultable `source` field.
+        // `Child` inherits from `Base` and has only optional own fields,
+        // but can't derive `Default` thanks to the inherited `source`.
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                TypeA:
+                  type: object
+                  properties:
+                    value:
+                      type: string
+                TypeB:
+                  type: object
+                  properties:
+                    count:
+                      type: integer
+                Base:
+                  oneOf:
+                    - $ref: '#/components/schemas/TypeA'
+                    - $ref: '#/components/schemas/TypeB'
+                  discriminator:
+                    propertyName: kind
+                    mapping:
+                      a: '#/components/schemas/TypeA'
+                      b: '#/components/schemas/TypeB'
+                  properties:
+                    kind:
+                      type: string
+                    source:
+                      type: string
+                      format: uri
+                  required:
+                    - kind
+                    - source
+                Child:
+                  allOf:
+                    - $ref: '#/components/schemas/Base'
+                    - type: object
+                      properties:
+                        name:
+                          type: string
+        "})
+        .unwrap();
+
+        let arena = Arena::new();
+        let spec = Spec::from_doc(&arena, &doc).unwrap();
+        let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
+
+        let schema = graph.schemas().find(|s| s.name() == "Child");
+        let Some(schema @ SchemaTypeView::Struct(_, struct_view)) = &schema else {
+            panic!("expected struct `Child`; got `{schema:?}`");
+        };
+
+        let name = CodegenTypeName::Schema(schema);
+        let codegen = CodegenStruct::new(name, struct_view);
+
+        let actual: syn::ItemStruct = parse_quote!(#codegen);
+        // `Child` inherits non-defaultable `source` from `Base`.
+        // `Url` doesn't implement `Default`, so `Child` can't derive it,
+        // even though `Child`'s own `name` field is optional.
+        let expected: syn::ItemStruct = parse_quote! {
+            #[derive(Debug, Clone, PartialEq, Eq, Hash, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize)]
+            #[serde(crate = "::ploidy_util::serde")]
+            pub struct Child {
+                pub kind: ::std::string::String,
+                pub source: ::ploidy_util::url::Url,
                 #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent")]
                 pub name: ::ploidy_util::absent::AbsentOr<::std::string::String>,
             }

--- a/ploidy-core/src/ir/graph.rs
+++ b/ploidy-core/src/ir/graph.rs
@@ -164,7 +164,6 @@ impl<'a> RawGraph<'a> {
             inlines: Vec<VariantInline<'a>>,
         }
         struct VariantInline<'a> {
-            at: usize,
             node: GraphType<'a>,
             variant_index: NodeIndex<usize>,
             parent_indices: &'a [NodeIndex<usize>],
@@ -197,7 +196,7 @@ impl<'a> RawGraph<'a> {
                 };
                 let mut inlines = vec![];
 
-                for (at, variant) in tagged.variants.iter().enumerate() {
+                for variant in tagged.variants {
                     let variant_index = variant.ty;
                     let GraphType::Schema(GraphSchemaType::Struct(variant_info, variant_struct)) =
                         self.graph[variant_index]
@@ -208,8 +207,8 @@ impl<'a> RawGraph<'a> {
                     // A struct variant only needs inlining if it has multiple
                     // distinct uses. Skip if (1) no operation uses the struct,
                     // _and_ (2) every incoming edge is from a tagged union with
-                    // the same tag. If both hold, all uses agree, so the
-                    // struct can be used directly without inlining.
+                    // the same tag and fields. If both hold, all uses agree, so
+                    // the struct can be used directly without inlining.
                     if !used_by_ops.contains(variant_index.index()) {
                         let Some(first) = ({
                             self.graph
@@ -222,49 +221,69 @@ impl<'a> RawGraph<'a> {
                             continue;
                         };
                         // Check that all the variant's inbound edges are from
-                        // tagged unions, and that all their tags match the tag
-                        // of the first union we found.
-                        let all_tags_match = self
+                        // tagged unions, and that all their tags and fields
+                        // match the first union we found.
+                        let all_agree = self
                             .graph
                             .neighbors_directed(variant_index, Direction::Incoming)
                             .all(|neighbor| {
                                 matches!(
                                     self.graph[neighbor],
                                     GraphType::Schema(GraphSchemaType::Tagged(_, t))
-                                        if t.tag == first.tag,
+                                        if t.tag == first.tag && t.fields == first.fields,
                                 )
                             });
-                        if all_tags_match {
+                        if all_agree {
                             continue;
                         }
                     }
 
-                    // Skip inlining the struct variant if it doesn't declare
-                    // the tag as a field. Inlining these struct variants
-                    // would just produce identical inline structs.
-                    let has_tag_field = {
-                        let inherits = EdgeFiltered::from_fn(&self.graph, |edge| {
-                            matches!(edge.weight(), EdgeKind::Inherits)
+                    // Skip inlining when the inline copy would be
+                    // identical to the original. This happens when
+                    // the variant doesn't declare the tag as a field _and_
+                    // either (a) the union has no own fields, or
+                    // (b) the variant already inherits from this union,
+                    // so its fields are already reachable.
+                    let (has_tag_field, already_inherits) = {
+                        let inherits = EdgeFiltered::from_fn(&self.graph, |e| {
+                            matches!(e.weight(), EdgeKind::Inherits)
                         });
                         let mut dfs = DfsPostOrder::new(&inherits, variant_index);
-                        std::iter::from_fn(|| dfs.next(&inherits))
-                            .flat_map(|ancestor| match self.graph[ancestor] {
+                        let mut has_tag_field = false;
+                        let mut already_inherits = false;
+                        while let Some(ancestor) = dfs.next(&inherits)
+                            && !(has_tag_field && already_inherits)
+                        {
+                            already_inherits |= ancestor == index;
+                            has_tag_field |= match self.graph[ancestor] {
                                 GraphType::Schema(GraphSchemaType::Struct(_, s))
-                                | GraphType::Inline(GraphInlineType::Struct(_, s)) => s.fields,
-                                _ => &[],
-                            })
-                            .any(|f| {
-                                // Check own and inherited fields; OpenAPI 3.2
-                                // clarifies that the tag can be inherited.
-                                matches!(f.name, StructFieldName::Name(n) if n == tagged.tag)
-                            })
+                                | GraphType::Inline(GraphInlineType::Struct(_, s)) => {
+                                    // Check own and inherited fields; OpenAPI 3.2
+                                    // clarifies that the tag can be inherited.
+                                    s.fields.iter().any(|f| {
+                                        matches!(
+                                            f.name,
+                                            StructFieldName::Name(n) if n == tagged.tag,
+                                        )
+                                    })
+                                }
+                                _ => false,
+                            };
+                        }
+                        (has_tag_field, already_inherits)
                     };
-                    if !has_tag_field {
+                    if !has_tag_field && (tagged.fields.is_empty() || already_inherits) {
                         continue;
                     }
 
                     // Build our new inline type, with the same attributes
                     // as the schema type, but a distinct inline type path.
+                    // The inline struct is a clone of the original, plus
+                    // an inheritance edge to the tagged union for its fields.
+                    let parents = self.arena.alloc_slice(itertools::chain!(
+                        variant_struct.parents.iter().copied(),
+                        std::iter::once(index),
+                    ));
                     let node = GraphType::Inline(GraphInlineType::Struct(
                         InlineTypePath {
                             root: InlineTypePathRoot::Type(info.name),
@@ -275,15 +294,14 @@ impl<'a> RawGraph<'a> {
                         GraphStruct {
                             description: variant_struct.description,
                             fields: variant_struct.fields,
-                            parents: variant_struct.parents,
+                            parents,
                         },
                     ));
 
                     inlines.push(VariantInline {
-                        at,
                         node,
                         variant_index,
-                        parent_indices: variant_struct.parents,
+                        parent_indices: parents,
                         name: variant.name,
                         aliases: variant.aliases,
                     });
@@ -303,48 +321,63 @@ impl<'a> RawGraph<'a> {
 
         // Apply the plans to the graph.
         for plan in plans {
-            let mut new_variants = plan.tagged.variants.to_vec();
+            let mut new_variants = FxHashMap::default();
 
-            // Add nodes for the inlined types, and connect them to
-            // the original schema variants, so that they'll inherit
-            // the same transitive dependencies and SCC membership.
+            // Add nodes and edges for the inline types.
             for entry in &plan.inlines {
                 let node_index = self.graph.add_node(entry.node);
+
+                // Reference the original variant so that the inline
+                // inherits the original's transitive dependencies and
+                // SCC membership, but not its inline subtree.
                 self.graph
                     .add_edge(node_index, entry.variant_index, EdgeKind::Reference);
+
+                // Add inheritance edges back to the inline's parents.
                 for &parent_index in entry.parent_indices {
                     self.graph
                         .add_edge(node_index, parent_index, EdgeKind::Inherits);
                 }
 
-                new_variants[entry.at] = GraphTaggedVariant {
-                    name: entry.name,
-                    aliases: entry.aliases,
-                    ty: node_index,
-                };
+                new_variants.insert(
+                    entry.variant_index,
+                    GraphTaggedVariant {
+                        name: entry.name,
+                        aliases: entry.aliases,
+                        ty: node_index,
+                    },
+                );
             }
 
-            // Rewrite reference edges from the tagged union
-            // to point to its new variants.
-            let edges_to_remove = self
+            // Retarget reference edges from the tagged union to point to
+            // the new inline variants. We only update edges targeting a
+            // replaced variant; other edges stay.
+            let edges_to_retarget = self
                 .graph
                 .edges_directed(plan.tagged_index, Direction::Outgoing)
-                .filter(|e| matches!(e.weight(), EdgeKind::Reference))
-                .map(|e| e.id())
+                .filter(|e| {
+                    matches!(e.weight(), EdgeKind::Reference)
+                        && new_variants.contains_key(&e.target())
+                })
+                .map(|e| (e.id(), new_variants[&e.target()].ty))
                 .collect_vec();
-            for edge_id in edges_to_remove {
+            for (edge_id, new_target) in edges_to_retarget {
                 self.graph.remove_edge(edge_id);
-            }
-            for variant in &new_variants {
                 self.graph
-                    .add_edge(plan.tagged_index, variant.ty, EdgeKind::Reference);
+                    .add_edge(plan.tagged_index, new_target, EdgeKind::Reference);
             }
 
             // Replace the node for the tagged union itself.
             let modified_tagged = GraphTagged {
                 description: plan.tagged.description,
                 tag: plan.tagged.tag,
-                variants: self.arena.alloc_slice_copy(&new_variants),
+                variants: self.arena.alloc_slice_exact(
+                    plan.tagged
+                        .variants
+                        .iter()
+                        .map(|&v| new_variants.get(&v.ty).copied().unwrap_or(v)),
+                ),
+                fields: plan.tagged.fields,
             };
             self.graph[plan.tagged_index] =
                 GraphType::Schema(GraphSchemaType::Tagged(plan.info, modified_tagged));
@@ -653,24 +686,34 @@ impl<'a> Iterator for SpecTypeVisitor<'a> {
             SpecType::Schema(SpecSchemaType::Untagged(_, ty))
             | SpecType::Inline(SpecInlineType::Untagged(_, ty)) => {
                 self.stack.extend(
-                    ty.variants
-                        .iter()
-                        .filter_map(|variant| match variant {
+                    itertools::chain!(
+                        ty.fields
+                            .iter()
+                            .map(|field| (EdgeKind::Reference, field.ty)),
+                        ty.variants.iter().filter_map(|variant| match variant {
                             SpecUntaggedVariant::Some(_, ty) => {
-                                Some((Some(top), EdgeKind::Reference, *ty))
+                                Some((EdgeKind::Reference, *ty))
                             }
                             _ => None,
-                        })
-                        .rev(),
+                        }),
+                    )
+                    .map(|(kind, ty)| (Some(top), kind, ty))
+                    .rev(),
                 );
             }
             SpecType::Schema(SpecSchemaType::Tagged(_, ty))
             | SpecType::Inline(SpecInlineType::Tagged(_, ty)) => {
                 self.stack.extend(
-                    ty.variants
-                        .iter()
-                        .map(|variant| (Some(top), EdgeKind::Reference, variant.ty))
-                        .rev(),
+                    itertools::chain!(
+                        ty.fields
+                            .iter()
+                            .map(|field| (EdgeKind::Reference, field.ty)),
+                        ty.variants
+                            .iter()
+                            .map(|variant| (EdgeKind::Reference, variant.ty)),
+                    )
+                    .map(|(kind, ty)| (Some(top), kind, ty))
+                    .rev(),
                 );
             }
             SpecType::Schema(SpecSchemaType::Container(_, container))

--- a/ploidy-core/src/ir/tests/graph.rs
+++ b/ploidy-core/src/ir/tests/graph.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 
 use crate::{
     arena::Arena,
-    ir::{RawGraph, SchemaTypeView, Spec, StructFieldName, View},
+    ir::{InlineTypeView, RawGraph, SchemaTypeView, Spec, StructFieldName, TypeView, View},
     parse::Document,
     tests::assert_matches,
 };
@@ -1994,4 +1994,260 @@ fn test_circular_all_of_terminates() {
         .find(|f| matches!(f.name(), StructFieldName::Name("a_field")))
         .unwrap();
     assert!(!a_field.tag());
+}
+
+#[test]
+fn test_all_of_parent_with_one_of_and_properties() {
+    // When a parent has `oneOf` (with a `discriminator`) and `properties`,
+    // children inheriting from that parent via `allOf` should still receive
+    // the `oneOf` parent's `properties` as inherited fields.
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test
+          version: 1.0.0
+        components:
+          schemas:
+            Column:
+              type: object
+              properties:
+                name:
+                  type: string
+            Base:
+              oneOf:
+                - $ref: '#/components/schemas/VariantA'
+                - $ref: '#/components/schemas/VariantB'
+              discriminator:
+                propertyName: kind
+                mapping:
+                  a: '#/components/schemas/VariantA'
+                  b: '#/components/schemas/VariantB'
+              properties:
+                schema:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/Column'
+                kind:
+                  type: string
+            VariantA:
+              allOf:
+                - $ref: '#/components/schemas/Base'
+              properties:
+                a_field:
+                  type: string
+            VariantB:
+              allOf:
+                - $ref: '#/components/schemas/Base'
+              properties:
+                b_field:
+                  type: string
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let spec = Spec::from_doc(&arena, &doc).unwrap();
+    let graph = RawGraph::new(&arena, &spec).cook();
+
+    // `VariantA` inherits from `Base`, which has properties
+    // `schema` and `kind` alongside its discriminator field.
+    let variant_a = graph.schemas().find(|s| s.name() == "VariantA").unwrap();
+    let variant_a_struct = match variant_a {
+        SchemaTypeView::Struct(_, view) => view,
+        other => panic!("expected struct `VariantA`; got {other:?}"),
+    };
+
+    let all_field_names = variant_a_struct
+        .fields()
+        .map(|f| match f.name() {
+            StructFieldName::Name(n) => n,
+            other => panic!("expected named field; got {other:?}"),
+        })
+        .collect_vec();
+
+    // Should include inherited `schema` and `kind` from `Base`,
+    // plus `VariantA`'s own `a_field`.
+    assert_matches!(&*all_field_names, ["schema", "kind", "a_field"]);
+}
+
+#[test]
+fn test_untagged_union_with_properties() {
+    // When a parent has `oneOf` (without a `discriminator`) and `properties`,
+    // the `Untagged` union should retain those properties as `fields`, and
+    // children inheriting from the union via `allOf` should receive its
+    // properties as inherited fields.
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test
+          version: 1.0.0
+        components:
+          schemas:
+            Base:
+              oneOf:
+                - $ref: '#/components/schemas/VariantA'
+                - $ref: '#/components/schemas/VariantB'
+              properties:
+                shared_field:
+                  type: string
+                count:
+                  type: integer
+            VariantA:
+              allOf:
+                - $ref: '#/components/schemas/Base'
+              properties:
+                a_field:
+                  type: string
+            VariantB:
+              allOf:
+                - $ref: '#/components/schemas/Base'
+              properties:
+                b_field:
+                  type: string
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let spec = Spec::from_doc(&arena, &doc).unwrap();
+    let graph = RawGraph::new(&arena, &spec).cook();
+
+    // `Base` has no `discriminator`, so it must be `Untagged`.
+    let base = graph.schemas().find(|s| s.name() == "Base").unwrap();
+    let base_untagged = match base {
+        SchemaTypeView::Untagged(_, view) => view,
+        other => panic!("expected untagged `Base`; got `{other:?}`"),
+    };
+
+    // The untagged union should store its own `properties` directly.
+    let base_field_names = base_untagged
+        .fields()
+        .iter()
+        .map(|f| match f.name {
+            StructFieldName::Name(n) => n,
+            other => panic!("expected named field; got `{other:?}`"),
+        })
+        .collect_vec();
+    assert_matches!(&*base_field_names, ["shared_field", "count"]);
+
+    // `VariantA` inherits from `Base` via `allOf`, so should receive
+    // `Base`'s fields alongside its own `a_field`.
+    let variant_a = graph.schemas().find(|s| s.name() == "VariantA").unwrap();
+    let variant_a_struct = match variant_a {
+        SchemaTypeView::Struct(_, view) => view,
+        other => panic!("expected struct `VariantA`; got `{other:?}`"),
+    };
+
+    let variant_a_field_names = variant_a_struct
+        .fields()
+        .map(|f| match f.name() {
+            StructFieldName::Name(n) => n,
+            other => panic!("expected named field; got `{other:?}`"),
+        })
+        .collect_vec();
+
+    // Inherited fields come first, then the own field.
+    assert_matches!(
+        &*variant_a_field_names,
+        ["shared_field", "count", "a_field"]
+    );
+}
+
+#[test]
+fn test_tagged_union_inlines_include_field_types() {
+    // A tagged union with an own inline enum property should
+    // include that enum in its `inlines()`.
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test
+          version: 1.0.0
+        components:
+          schemas:
+            Dog:
+              type: object
+              properties:
+                kind:
+                  type: string
+            Pet:
+              oneOf:
+                - $ref: '#/components/schemas/Dog'
+              discriminator:
+                propertyName: kind
+                mapping:
+                  dog: '#/components/schemas/Dog'
+              properties:
+                kind:
+                  type: string
+                severity:
+                  type: string
+                  enum: [low, high]
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let spec = Spec::from_doc(&arena, &doc).unwrap();
+    let graph = RawGraph::new(&arena, &spec).cook();
+
+    let pet = graph.schemas().find(|s| s.name() == "Pet").unwrap();
+    let has_inline_enum = pet.inlines().any(|i| matches!(i, InlineTypeView::Enum(..)));
+    assert!(has_inline_enum);
+}
+
+#[test]
+fn test_needs_indirection_through_inlined_tagged_variant() {
+    // When a tagged union has own fields, its variants are inlined.
+    // The inlined variant must retain a reference edge to the original,
+    // so that SCC membership (and thus `needs_indirection()`) is preserved.
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test
+          version: 1.0.0
+        components:
+          schemas:
+            Pet:
+              oneOf:
+                - $ref: '#/components/schemas/Dog'
+              discriminator:
+                propertyName: kind
+              properties:
+                kind:
+                  type: string
+                name:
+                  type: string
+            Dog:
+              type: object
+              properties:
+                parent:
+                  $ref: '#/components/schemas/Pet'
+            Kennel:
+              type: object
+              properties:
+                resident:
+                  $ref: '#/components/schemas/Dog'
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let spec = Spec::from_doc(&arena, &doc).unwrap();
+    let mut raw = RawGraph::new(&arena, &spec);
+    raw.inline_tagged_variants();
+    let graph = raw.cook();
+
+    // The inlined variant `Pet/Dog` should have `parent` marked as
+    // needing indirection, since it points back to `Pet`.
+    let pet = graph.schemas().find(|s| s.name() == "Pet").unwrap();
+    let tagged = match pet {
+        SchemaTypeView::Tagged(_, view) => view,
+        other => panic!("expected tagged `Pet`; got {other:?}"),
+    };
+    let variant = tagged.variants().next().unwrap();
+    let variant_struct = match variant.ty() {
+        TypeView::Inline(InlineTypeView::Struct(_, view)) => view,
+        other => panic!("expected inline struct variant; got {other:?}"),
+    };
+    let parent_field = variant_struct
+        .own_fields()
+        .find(|f| matches!(f.name(), StructFieldName::Name("parent")))
+        .unwrap();
+    assert!(parent_field.needs_indirection());
 }

--- a/ploidy-core/src/ir/tests/transform.rs
+++ b/ploidy-core/src/ir/tests/transform.rs
@@ -1308,6 +1308,7 @@ fn test_tagged_description() {
                     aliases: ["dog"],
                     ..
                 }],
+                ..
             },
         )),
     );

--- a/ploidy-core/src/ir/tests/views.rs
+++ b/ploidy-core/src/ir/tests/views.rs
@@ -3361,6 +3361,242 @@ fn test_inlined_when_tagged_unions_disagree_on_tag() {
 }
 
 #[test]
+fn test_inlined_when_tagged_unions_disagree_on_fields() {
+    // When a variant struct appears in multiple tagged unions that
+    // share the same tag but have different common fields, the variant
+    // must be inlined so that each inline copy inherits just its
+    // parent union's fields.
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test
+          version: 1.0.0
+        components:
+          schemas:
+            Dog:
+              type: object
+              properties:
+                kind:
+                  type: string
+                bark:
+                  type: string
+            UnionA:
+              oneOf:
+                - $ref: '#/components/schemas/Dog'
+              discriminator:
+                propertyName: kind
+                mapping:
+                  dog: '#/components/schemas/Dog'
+              properties:
+                kind:
+                  type: string
+                name:
+                  type: string
+            UnionB:
+              oneOf:
+                - $ref: '#/components/schemas/Dog'
+              discriminator:
+                propertyName: kind
+                mapping:
+                  dog: '#/components/schemas/Dog'
+              properties:
+                kind:
+                  type: string
+                habitat:
+                  type: string
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let spec = Spec::from_doc(&arena, &doc).unwrap();
+    let mut raw = RawGraph::new(&arena, &spec);
+    raw.inline_tagged_variants();
+    let graph = raw.cook();
+
+    // The original `Dog` keeps all its own fields.
+    let dog = graph.schemas().find(|s| s.name() == "Dog").unwrap();
+    let SchemaTypeView::Struct(_, dog_struct) = dog else {
+        panic!("expected struct `Dog`; got `{dog:?}`");
+    };
+    let field_names = dog_struct.fields().map(|f| f.name()).collect_vec();
+    assert_matches!(
+        &*field_names,
+        [StructFieldName::Name("kind"), StructFieldName::Name("bark")]
+    );
+
+    // Each inlined `Dog` has an inheritance edge back to its
+    // parent tagged union. `Dog`'s own fields come first, then
+    // the union's own fields; minus duplicates like `kind`.
+    let union_a = graph.schemas().find(|s| s.name() == "UnionA").unwrap();
+    let SchemaTypeView::Tagged(_, union_a_tagged) = union_a else {
+        panic!("expected tagged `UnionA`; got `{union_a:?}`");
+    };
+    let variant = union_a_tagged.variants().next().unwrap();
+    let TypeView::Inline(InlineTypeView::Struct(_, inline_struct)) = variant.ty() else {
+        panic!("expected inline struct variant; got `{:?}`", variant.ty());
+    };
+    let inline_fields = inline_struct.fields().map(|f| f.name()).collect_vec();
+    assert_matches!(
+        &*inline_fields,
+        [
+            // Inherited from `UnionA` (minus `kind` because it's shadowed by own).
+            StructFieldName::Name("name"),
+            // `Dog`'s own fields.
+            StructFieldName::Name("kind"),
+            StructFieldName::Name("bark"),
+        ]
+    );
+
+    let union_b = graph.schemas().find(|s| s.name() == "UnionB").unwrap();
+    let SchemaTypeView::Tagged(_, union_b_tagged) = union_b else {
+        panic!("expected tagged `UnionB`; got `{union_b:?}`");
+    };
+    let variant = union_b_tagged.variants().next().unwrap();
+    let TypeView::Inline(InlineTypeView::Struct(_, inline_struct)) = variant.ty() else {
+        panic!("expected inline struct variant; got `{:?}`", variant.ty());
+    };
+    let inline_fields = inline_struct.fields().map(|f| f.name()).collect_vec();
+    assert_matches!(
+        &*inline_fields,
+        [
+            // Inherited from `UnionB` (minus `kind` because it's shadowed by own).
+            StructFieldName::Name("habitat"),
+            // `Dog`'s own fields.
+            StructFieldName::Name("kind"),
+            StructFieldName::Name("bark"),
+        ]
+    );
+}
+
+#[test]
+fn test_not_inlined_when_variant_already_inherits_union_fields() {
+    // When a variant struct already inherits from the tagged union
+    // via `allOf`, the union's fields are already reachable through
+    // the existing inheritance edge. Inlining would produce a
+    // structurally identical copy, so it should be skipped.
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test
+          version: 1.0.0
+        components:
+          schemas:
+            Dog:
+              allOf:
+                - $ref: '#/components/schemas/Pet'
+              properties:
+                bark:
+                  type: string
+            Pet:
+              oneOf:
+                - $ref: '#/components/schemas/Dog'
+              discriminator:
+                propertyName: kind
+                mapping:
+                  dog: '#/components/schemas/Dog'
+              properties:
+                kind:
+                  type: string
+                name:
+                  type: string
+            Owner:
+              type: object
+              properties:
+                dog:
+                  $ref: '#/components/schemas/Dog'
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let spec = Spec::from_doc(&arena, &doc).unwrap();
+    let mut raw = RawGraph::new(&arena, &spec);
+    raw.inline_tagged_variants();
+    let graph = raw.cook();
+
+    // `Dog` is referenced by `Owner.dog` and inherits from `Pet` via `allOf`,
+    // so the inline would be identical. The variant should remain
+    // a direct reference to `Dog`, not an inline copy.
+    let pet = graph.schemas().find(|s| s.name() == "Pet").unwrap();
+    let tagged = match pet {
+        SchemaTypeView::Tagged(_, view) => view,
+        other => panic!("expected tagged `Pet`; got {other:?}"),
+    };
+    let variant = tagged.variants().next().unwrap();
+    assert_matches!(variant.ty(), TypeView::Schema(SchemaTypeView::Struct(..)));
+
+    // `Dog` should still have the inherited fields from `Pet`.
+    let dog = graph.schemas().find(|s| s.name() == "Dog").unwrap();
+    let SchemaTypeView::Struct(_, dog_struct) = dog else {
+        panic!("expected struct `Dog`; got `{dog:?}`");
+    };
+    let field_names = dog_struct.fields().map(|f| f.name()).collect_vec();
+    assert_matches!(
+        &*field_names,
+        [
+            StructFieldName::Name("kind"),
+            StructFieldName::Name("name"),
+            StructFieldName::Name("bark"),
+        ]
+    );
+}
+
+#[test]
+fn test_inlining_preserves_field_type_edges() {
+    // `Pet` is a tagged union with an inline enum property (`severity`).
+    // `Dog` is both a variant of `Pet` and a property of `Owner`, so it's
+    // inlined. After inlining, `Pet`'s inlines must still include the
+    // `severity` inline enum; only its edge to `Dog` should have been updated.
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test
+          version: 1.0.0
+        paths: {}
+        components:
+          schemas:
+            Dog:
+              type: object
+              properties:
+                kind:
+                  type: string
+                bark:
+                  type: string
+            Pet:
+              oneOf:
+                - $ref: '#/components/schemas/Dog'
+              discriminator:
+                propertyName: kind
+                mapping:
+                  dog: '#/components/schemas/Dog'
+              properties:
+                severity:
+                  type: string
+                  enum:
+                    - low
+                    - high
+            Owner:
+              type: object
+              properties:
+                dog:
+                  $ref: '#/components/schemas/Dog'
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let spec = Spec::from_doc(&arena, &doc).unwrap();
+    let mut raw = RawGraph::new(&arena, &spec);
+    raw.inline_tagged_variants();
+    let graph = raw.cook();
+
+    // `Dog` is inlined because `Owner.dog` gives it a non-tagged incoming edge.
+    // After inlining, `pet.inlines()` must still include the inline enum from
+    // `Pet.severity`.
+    let pet = graph.schemas().find(|s| s.name() == "Pet").unwrap();
+    let has_inline_enum = pet.inlines().any(|i| matches!(i, InlineTypeView::Enum(..)));
+    assert!(has_inline_enum);
+}
+
+#[test]
 fn test_inlined_variant_inline_field_types_not_leaked() {
     // `Dog` is inlined (referenced by `Owner.dog`) and has an
     // inline field type (`details`). After inlining, `Pet`'s

--- a/ploidy-core/src/ir/transform.rs
+++ b/ploidy-core/src/ir/transform.rs
@@ -124,6 +124,7 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
             description: self.schema.description.as_deref(),
             tag: discriminator.property_name.as_str(),
             variants: self.arena().alloc_slice_copy(&variants),
+            fields: self.arena().alloc_slice(self.properties()),
         };
 
         Ok(match self.name {
@@ -218,6 +219,7 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
                 let untagged = SpecUntagged {
                     description: self.schema.description.as_deref(),
                     variants: self.arena().alloc_slice_copy(variants),
+                    fields: self.arena().alloc_slice(self.properties()),
                 };
                 match self.name {
                     TypeInfo::Schema(info) => SpecSchemaType::Untagged(info, untagged).into(),
@@ -595,6 +597,7 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
                 let untagged = SpecUntagged {
                     description: self.schema.description.as_deref(),
                     variants: self.arena().alloc_slice_copy(&variants),
+                    fields: &[],
                 };
                 match self.name {
                     TypeInfo::Schema(info) => SpecSchemaType::Untagged(info, untagged).into(),

--- a/ploidy-core/src/ir/types/mapper.rs
+++ b/ploidy-core/src/ir/types/mapper.rs
@@ -111,6 +111,7 @@ where
                     aliases: v.aliases,
                     ty: self.map(v.ty),
                 })),
+            fields: self.fields(raw.fields),
         }
     }
 
@@ -123,7 +124,19 @@ where
                     &UntaggedVariant::Some(hint, ty) => UntaggedVariant::Some(hint, self.map(ty)),
                     UntaggedVariant::Null => UntaggedVariant::Null,
                 })),
+            fields: self.fields(raw.fields),
         }
+    }
+
+    fn fields(&self, raw: &[StructField<'a, T>]) -> &'a [StructField<'a, U>] {
+        self.arena
+            .alloc_slice_exact(raw.iter().map(|f| StructField {
+                name: f.name,
+                ty: self.map(f.ty),
+                required: f.required,
+                description: f.description,
+                flattened: f.flattened,
+            }))
     }
 
     fn container(&self, raw: &Container<'a, T>) -> Container<'a, U> {

--- a/ploidy-core/src/ir/types/shape.rs
+++ b/ploidy-core/src/ir/types/shape.rs
@@ -135,6 +135,8 @@ pub struct Tagged<'a, Ty> {
     pub description: Option<&'a str>,
     pub tag: &'a str,
     pub variants: &'a [TaggedVariant<'a, Ty>],
+    // Own fields that the union declares as `properties`.
+    pub fields: &'a [StructField<'a, Ty>],
 }
 
 /// A variant of a tagged union.
@@ -152,6 +154,8 @@ pub struct TaggedVariant<'a, Ty> {
 pub struct Untagged<'a, Ty> {
     pub description: Option<&'a str>,
     pub variants: &'a [UntaggedVariant<Ty>],
+    // Own fields that the union declares as `properties`.
+    pub fields: &'a [StructField<'a, Ty>],
 }
 
 /// A variant of an untagged union.

--- a/ploidy-core/src/ir/views/struct_.rs
+++ b/ploidy-core/src/ir/views/struct_.rs
@@ -98,7 +98,11 @@ impl<'a> StructView<'a> {
             .filter(move |&index| index != self.index)
             .filter_map(|index| match self.cooked.graph[index] {
                 GraphType::Schema(GraphSchemaType::Struct(_, s))
-                | GraphType::Inline(GraphInlineType::Struct(_, s)) => Some(s),
+                | GraphType::Inline(GraphInlineType::Struct(_, s)) => Some(s.fields),
+                GraphType::Schema(GraphSchemaType::Tagged(_, t))
+                | GraphType::Inline(GraphInlineType::Tagged(_, t)) => Some(t.fields),
+                GraphType::Schema(GraphSchemaType::Untagged(_, u))
+                | GraphType::Inline(GraphInlineType::Untagged(_, u)) => Some(u.fields),
                 _ => None,
             });
 
@@ -109,7 +113,7 @@ impl<'a> StructView<'a> {
         itertools::chain!(
             // Inherited fields first, in declaration order.
             ancestors
-                .flat_map(|ancestor| ancestor.fields)
+                .flatten()
                 .filter(move |field| seen.insert(field.name))
                 .map(|field| StructFieldView {
                     parent: self,

--- a/ploidy-core/src/ir/views/tagged.rs
+++ b/ploidy-core/src/ir/views/tagged.rs
@@ -37,7 +37,7 @@ use petgraph::graph::NodeIndex;
 
 use crate::ir::{
     graph::CookedGraph,
-    types::{GraphTagged, GraphTaggedVariant},
+    types::{GraphStructField, GraphTagged, GraphTaggedVariant},
 };
 
 use super::{ViewNode, ir::TypeView};
@@ -70,6 +70,13 @@ impl<'a> TaggedView<'a> {
     #[inline]
     pub fn tag(&self) -> &'a str {
         self.ty.tag
+    }
+
+    /// Returns the common fields declared alongside `oneOf`,
+    /// shared across all variants.
+    #[inline]
+    pub fn fields(&self) -> &'a [GraphStructField<'a>] {
+        self.ty.fields
     }
 
     /// Returns an iterator over this tagged union's variants.

--- a/ploidy-core/src/ir/views/untagged.rs
+++ b/ploidy-core/src/ir/views/untagged.rs
@@ -30,7 +30,7 @@ use petgraph::graph::NodeIndex;
 use crate::ir::{
     UntaggedVariantNameHint,
     graph::CookedGraph,
-    types::{GraphUntagged, GraphUntaggedVariant},
+    types::{GraphStructField, GraphUntagged, GraphUntaggedVariant},
 };
 
 use super::{ViewNode, ir::TypeView};
@@ -57,6 +57,13 @@ impl<'a> UntaggedView<'a> {
     #[inline]
     pub fn description(&self) -> Option<&'a str> {
         self.ty.description
+    }
+
+    /// Returns the common fields declared alongside `oneOf`,
+    /// shared across all variants.
+    #[inline]
+    pub fn fields(&self) -> &'a [GraphStructField<'a>] {
+        self.ty.fields
     }
 
     /// Returns an iterator over this untagged union's variants.


### PR DESCRIPTION
OpenAPI lets `oneOf` schemas (and I think `anyOf` and `allOf`, too; though we handle those already, because we represent them as structs!) define their own `properties`, and we have _one_ case in our spec that does that.

To fix that, `Tagged` and `Untagged` unions can carry those extra properties as fields (let's not think too hard about how we're stretching the definition of "tagged union" a bit far here 😅), and the Rust generator can inline them into each variant struct, just like it does for `allOf` inheritance.