### PR TITLE
fix(pointer): Treat `AbsentOr` and `Option` as transparent.

### DIFF
--- a/ploidy-pointer/src/lib.rs
+++ b/ploidy-pointer/src/lib.rs
@@ -344,19 +344,15 @@ impl<T: JsonPointee> JsonPointee for Option<T> {
     }
 
     fn resolve(&self, pointer: &JsonPointer) -> Result<&dyn JsonPointee, JsonPointerResolveError> {
-        if let Some(value) = self {
-            value.resolve(pointer)
-        } else {
-            let Some(key) = pointer.head() else {
-                return Ok(&None::<T>);
-            };
-            Err({
+        match self {
+            Some(value) => value.resolve(pointer),
+            None => Err({
                 #[cfg(feature = "did-you-mean")]
-                let err = JsonPointerKeyError::with_ty(key, JsonPointeeType::name_of(self));
+                let err = JsonPointerTypeError::with_ty(pointer, JsonPointeeType::name_of(self));
                 #[cfg(not(feature = "did-you-mean"))]
-                let err = JsonPointerKeyError::new(key);
+                let err = JsonPointerTypeError::new(pointer);
                 err
-            })?
+            })?,
         }
     }
 }
@@ -364,12 +360,7 @@ impl<T: JsonPointee> JsonPointee for Option<T> {
 impl<T: JsonPointee> JsonPointee for Box<T> {
     #[inline]
     fn as_any(&self) -> &dyn Any {
-        &**self
-    }
-
-    #[inline]
-    fn name(&self) -> &'static str {
-        (**self).name()
+        self
     }
 
     fn resolve(&self, pointer: &JsonPointer) -> Result<&dyn JsonPointee, JsonPointerResolveError> {
@@ -380,12 +371,7 @@ impl<T: JsonPointee> JsonPointee for Box<T> {
 impl<T: JsonPointee> JsonPointee for Arc<T> {
     #[inline]
     fn as_any(&self) -> &dyn Any {
-        &**self
-    }
-
-    #[inline]
-    fn name(&self) -> &'static str {
-        (**self).name()
+        self
     }
 
     fn resolve(&self, pointer: &JsonPointer) -> Result<&dyn JsonPointee, JsonPointerResolveError> {
@@ -396,12 +382,7 @@ impl<T: JsonPointee> JsonPointee for Arc<T> {
 impl<T: JsonPointee> JsonPointee for Rc<T> {
     #[inline]
     fn as_any(&self) -> &dyn Any {
-        &**self
-    }
-
-    #[inline]
-    fn name(&self) -> &'static str {
-        (**self).name()
+        self
     }
 
     fn resolve(&self, pointer: &JsonPointer) -> Result<&dyn JsonPointee, JsonPointerResolveError> {

--- a/ploidy-pointer/tests/pointee.rs
+++ b/ploidy-pointer/tests/pointee.rs
@@ -1005,9 +1005,9 @@ fn test_downcast_box() {
     let boxed = Box::new(Inner {
         value: "hello".to_owned(),
     });
-    let pointee: &dyn JsonPointee = &boxed;
+    let pointee = boxed.resolve(JsonPointer::empty()).unwrap();
 
-    // `downcast_ref` should see `Inner`, not `Box<Inner>`.
+    // `resolve` should return `Inner`, not `Box<Inner>`.
     assert!(pointee.downcast_ref::<Inner>().is_some());
     assert!(pointee.downcast_ref::<Box<Inner>>().is_none());
 }
@@ -1022,9 +1022,9 @@ fn test_downcast_arc() {
     let arced = Arc::new(Inner {
         value: "hello".to_owned(),
     });
-    let pointee: &dyn JsonPointee = &arced;
+    let pointee = arced.resolve(JsonPointer::empty()).unwrap();
 
-    // `downcast_ref` should see `Inner`, not `Arc<Inner>`.
+    // `resolve` should return `Inner`, not `Arc<Inner>`.
     assert!(pointee.downcast_ref::<Inner>().is_some());
     assert!(pointee.downcast_ref::<Arc<Inner>>().is_none());
 }
@@ -1039,9 +1039,9 @@ fn test_downcast_rc() {
     let rced = Rc::new(Inner {
         value: "hello".to_owned(),
     });
-    let pointee: &dyn JsonPointee = &rced;
+    let pointee = rced.resolve(JsonPointer::empty()).unwrap();
 
-    // `downcast_ref` should see `Inner`, not `Rc<Inner>`.
+    // `resolve` should return `Inner`, not `Rc<Inner>`.
     assert!(pointee.downcast_ref::<Inner>().is_some());
     assert!(pointee.downcast_ref::<Rc<Inner>>().is_none());
 }
@@ -1056,10 +1056,29 @@ fn test_box_resolve_is_transparent() {
     let boxed: Box<Inner> = Box::new(Inner {
         value: "hello".to_owned(),
     });
-
-    // Resolving through a `Box` should reach the inner struct's fields.
     let result = boxed
         .resolve(JsonPointer::parse("/value").unwrap())
         .unwrap();
+
+    // Resolving through a `Box` should reach the inner struct's fields.
     assert_eq!(result.downcast_ref::<String>(), Some(&"hello".to_owned()));
+}
+
+#[test]
+fn test_option_resolve_is_transparent() {
+    #[derive(Debug, Eq, JsonPointee, PartialEq)]
+    struct Inner {
+        value: String,
+    }
+
+    let some = Some(Inner {
+        value: "hello".to_owned(),
+    });
+    let inner = some.resolve(JsonPointer::empty()).unwrap();
+    assert_eq!(inner.downcast_ref::<Inner>(), some.as_ref());
+    let value = some.resolve(JsonPointer::parse("/value").unwrap()).unwrap();
+    assert_eq!(value.downcast_ref::<String>(), Some(&"hello".to_owned()));
+
+    let none = None::<Inner>;
+    assert!(none.resolve(JsonPointer::empty()).is_err());
 }

--- a/ploidy-util/Cargo.toml
+++ b/ploidy-util/Cargo.toml
@@ -15,7 +15,12 @@ chrono = { version = "0.4", features = ["serde"] }
 http = "1"
 itertools = "0.14"
 percent-encoding = "2.3"
-ploidy-pointer = { workspace = true, features = ["chrono", "derive", "serde_json", "url"] }
+ploidy-pointer = { workspace = true, features = [
+    "chrono",
+    "derive",
+    "serde_json",
+    "url",
+] }
 reqwest = { version = "0.13", default-features = false, features = [
     "form",
     "http2",
@@ -31,3 +36,6 @@ serde_path_to_error = "0.1"
 thiserror = "2"
 url = { version = "2", features = ["serde"] }
 uuid = { version = "1", features = ["serde", "v4"] }
+
+[features]
+did-you-mean = ["ploidy-pointer/did-you-mean"]

--- a/ploidy-util/src/absent.rs
+++ b/ploidy-util/src/absent.rs
@@ -1,6 +1,8 @@
 use std::{any::Any, marker::PhantomData, ops::Deref};
 
-use ploidy_pointer::{JsonPointee, JsonPointer, JsonPointerResolveError, JsonPointerTypeError};
+use ploidy_pointer::{
+    JsonPointee, JsonPointeeType, JsonPointer, JsonPointerResolveError, JsonPointerTypeError,
+};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// An [`Option`]-like type that distinguishes between
@@ -22,13 +24,13 @@ impl<T: JsonPointee> JsonPointee for AbsentOr<T> {
     fn resolve(&self, pointer: &JsonPointer) -> Result<&dyn JsonPointee, JsonPointerResolveError> {
         match self {
             Self::Present(value) => value.resolve(pointer),
-            _ => {
-                if pointer.is_empty() {
-                    Ok(self as &dyn JsonPointee)
-                } else {
-                    Err(JsonPointerTypeError::new(pointer).into())
-                }
-            }
+            _ => Err({
+                #[cfg(feature = "did-you-mean")]
+                let err = JsonPointerTypeError::with_ty(pointer, JsonPointeeType::name_of(self));
+                #[cfg(not(feature = "did-you-mean"))]
+                let err = JsonPointerTypeError::new(pointer);
+                err
+            })?,
         }
     }
 }
@@ -293,4 +295,82 @@ pub enum FieldAbsentError {
     Absent(&'static str),
     #[error("field `{0}` is `null`")]
     Null(&'static str),
+}
+
+#[cfg(test)]
+mod tests {
+    use ploidy_pointer::{JsonPointee, JsonPointeeExt};
+
+    use super::*;
+
+    #[derive(JsonPointee)]
+    #[ploidy(pointer(untagged))]
+    enum Response {
+        One(ResponseOne),
+        Two(ResponseTwo),
+    }
+
+    #[derive(JsonPointee)]
+    struct ResponseOne {
+        data: AbsentOr<String>,
+        error: AbsentOr<ResponseError>,
+    }
+
+    #[derive(JsonPointee)]
+    struct ResponseTwo {
+        data: AbsentOr<i32>,
+        error: AbsentOr<ResponseError>,
+    }
+
+    #[derive(JsonPointee)]
+    struct ResponseError {
+        message: String,
+    }
+
+    #[test]
+    fn test_absent_or_present_pointer_succeeds() {
+        let response = Response::One(ResponseOne {
+            error: AbsentOr::Present(ResponseError {
+                message: "oops".to_owned(),
+            }),
+            data: AbsentOr::Null,
+        });
+
+        // `error` is present, so the pointer should resolve.
+        let err = response.pointer::<ResponseError>("/error").unwrap();
+        assert_eq!(err.message, "oops");
+
+        // The `AbsentOr` wrapper itself is transparent;
+        // there's no way to access it via the pointer.
+        assert!(
+            response
+                .pointer::<AbsentOr<ResponseError>>("/error")
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn test_absent_or_null_errors() {
+        let response = Response::Two(ResponseTwo {
+            data: AbsentOr::Present(2),
+            error: AbsentOr::Null,
+        });
+
+        // The `AbsentOr` wrapper is transparent, and `Null` has no value,
+        // so resolving the pointer always errors.
+        let result = response.pointer::<ResponseError>("/error");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_absent_or_absent_errors() {
+        let response = Response::Two(ResponseTwo {
+            data: AbsentOr::Present(2),
+            error: AbsentOr::Absent,
+        });
+
+        // `AbsentOr::Absent` behaves the same as `Null`.
+        let result = response.pointer::<ResponseError>("/error");
+        assert!(result.is_err());
+    }
 }


### PR DESCRIPTION
Previously, we'd treat these as transparent only if they held a value. This was inconsistent, and led to surprising errors when downcasting.