### PR TITLE
Path parameter improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1101,6 +1101,7 @@ dependencies = [
  "percent-encoding",
  "petgraph",
  "ploidy-pointer",
+ "pretty_assertions",
  "prettyplease",
  "proc-macro2",
  "quote",

--- a/ploidy-codegen-rust/src/operation.rs
+++ b/ploidy-codegen-rust/src/operation.rs
@@ -626,4 +626,61 @@ mod tests {
         };
         assert_eq!(actual, expected);
     }
+
+    // MARK: Synthesized path params
+
+    #[test]
+    fn test_operation_with_synthesized_path_param() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths:
+              /items/{item_id}:
+                get:
+                  operationId: getItem
+                  responses:
+                    '200':
+                      description: OK
+        "})
+        .unwrap();
+
+        let arena = Arena::new();
+        let spec = Spec::from_doc(&arena, &doc).unwrap();
+        let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
+
+        let op = graph.operations().next().unwrap();
+        let codegen = CodegenOperation::new(&op);
+
+        let actual: syn::ImplItemFn = parse_quote!(#codegen);
+        let expected: syn::ImplItemFn = parse_quote! {
+            pub async fn get_item(
+                &self,
+                item_id: &str
+            ) -> Result<(), crate::error::Error> {
+                let url = {
+                    let mut url = self.base_url.clone();
+                    let _ = url
+                        .path_segments_mut()
+                        .map(|mut segments| {
+                            segments.pop_if_empty()
+                                .push("items")
+                                .push(item_id);
+                        });
+                    url
+                };
+                let response = self
+                    .client
+                    .get(url)
+                    .headers(self.headers.clone())
+                    .send()
+                    .await?
+                    .error_for_status()?;
+                let _ = response;
+                Ok(())
+            }
+        };
+        assert_eq!(actual, expected);
+    }
 }

--- a/ploidy-core/Cargo.toml
+++ b/ploidy-core/Cargo.toml
@@ -36,6 +36,7 @@ winnow = "1.0"
 
 [dev-dependencies]
 indoc = "2"
+pretty_assertions = { workspace = true }
 
 [features]
 default = []

--- a/ploidy-core/src/ir/spec.rs
+++ b/ploidy-core/src/ir/spec.rs
@@ -1,11 +1,13 @@
 use indexmap::IndexMap;
 use itertools::Itertools;
+use rustc_hash::FxHashSet;
 
 use crate::{
     arena::Arena,
     parse::{
-        self, Document, Info, Parameter, ParameterLocation, ParameterStyle as ParsedParameterStyle,
-        RefOrParameter, RefOrRequestBody, RefOrResponse, RefOrSchema, RequestBody, Response,
+        self, Document, Info, Method, Operation, Parameter, ParameterLocation,
+        ParameterStyle as ParsedParameterStyle, RefOrParameter, RefOrRequestBody, RefOrResponse,
+        RefOrSchema, RequestBody, Response, path::PathSegment,
     },
 };
 
@@ -68,81 +70,104 @@ impl<'a> Spec<'a> {
             .paths
             .iter()
             .map(|(path, item)| {
-                let segments = parse::path::parse(arena, path.as_str())?;
-                Ok(item
-                    .operations()
-                    .map(move |(method, op)| (method, segments.clone(), op)))
+                let segments: &_ =
+                    arena.alloc_slice_copy(&parse::path::parse(arena, path.as_str())?);
+                Ok(item.operations().map(move |(method, op)| PathOperation {
+                    path: segments,
+                    method,
+                    params: &item.parameters,
+                    op,
+                }))
             })
             .flatten_ok()
-            .map_ok(|(method, path, op)| -> Result<_, IrError> {
-                let resource = op.extension("x-resource-name");
-                let id = op.operation_id.as_deref().ok_or(IrError::NoOperationId)?;
-                let params = arena.alloc_slice(op.parameters.iter().filter_map(|param_or_ref| {
-                    let param = match param_or_ref {
-                        RefOrParameter::Other(p) => p,
-                        RefOrParameter::Ref(r) => {
-                            r.path.pointer().follow::<&Parameter>(doc).ok()?
-                        }
-                    };
-                    let ty: &_ = match &param.schema {
-                        Some(RefOrSchema::Ref(r)) => arena.alloc(SpecType::Ref(&r.path)),
-                        Some(RefOrSchema::Other(schema)) => arena.alloc(transform(
-                            arena,
-                            doc,
-                            InlineTypePath {
-                                root: InlineTypePathRoot::Resource(resource),
-                                segments: arena.alloc_slice_copy(&[
-                                    InlineTypePathSegment::Operation(id),
-                                    InlineTypePathSegment::Parameter(param.name.as_str()),
-                                ]),
-                            },
-                            schema,
-                        )),
-                        None => arena.alloc(
-                            SpecInlineType::Any(InlineTypePath {
-                                root: InlineTypePathRoot::Resource(resource),
-                                segments: arena.alloc_slice_copy(&[
-                                    InlineTypePathSegment::Operation(id),
-                                    InlineTypePathSegment::Parameter(param.name.as_str()),
-                                ]),
-                            })
-                            .into(),
-                        ),
-                    };
-                    let style = match (param.style, param.explode) {
-                        (Some(ParsedParameterStyle::DeepObject), Some(true) | None) => {
-                            Some(IrParameterStyle::DeepObject)
-                        }
-                        (Some(ParsedParameterStyle::SpaceDelimited), Some(false) | None) => {
-                            Some(IrParameterStyle::SpaceDelimited)
-                        }
-                        (Some(ParsedParameterStyle::PipeDelimited), Some(false) | None) => {
-                            Some(IrParameterStyle::PipeDelimited)
-                        }
-                        (None, None) => None,
-                        (Some(ParsedParameterStyle::Form) | None, Some(true) | None) => {
-                            Some(IrParameterStyle::Form { exploded: true })
-                        }
-                        (Some(ParsedParameterStyle::Form) | None, Some(false)) => {
-                            Some(IrParameterStyle::Form { exploded: false })
-                        }
-                        _ => None,
-                    };
-                    let info = SpecParameterInfo {
-                        name: param.name.as_str(),
-                        ty,
-                        required: param.required,
-                        description: param.description.as_deref(),
-                        style,
-                    };
-                    Some(match param.location {
-                        ParameterLocation::Path => SpecParameter::Path(info),
-                        ParameterLocation::Query => SpecParameter::Query(info),
-                        _ => return None,
-                    })
-                }));
+            .map_ok(|item| -> Result<_, IrError> {
+                let resource = item.op.extension("x-resource-name");
+                let id = item
+                    .op
+                    .operation_id
+                    .as_deref()
+                    .ok_or(IrError::NoOperationId)?;
 
-                let request = op
+                let params = {
+                    // Merge path item and operation parameters. Operation
+                    // params override path item params with the same
+                    // `(name, location)` pair.
+                    let mut seen = FxHashSet::default();
+                    let all = item
+                        .params
+                        .iter()
+                        .chain(item.op.parameters.iter())
+                        .filter_map(|p| match p {
+                            RefOrParameter::Other(p) => Some(p),
+                            RefOrParameter::Ref(r) => {
+                                r.path.pointer().follow::<&Parameter>(doc).ok()
+                            }
+                        })
+                        .rev()
+                        .filter(|s| seen.insert((s.name.as_str(), s.location)))
+                        .collect_vec();
+                    arena.alloc_slice(all.into_iter().rev().filter_map(|param| {
+                        let ty: &_ = match &param.schema {
+                            Some(RefOrSchema::Ref(r)) => arena.alloc(SpecType::Ref(&r.path)),
+                            Some(RefOrSchema::Other(schema)) => arena.alloc(transform(
+                                arena,
+                                doc,
+                                InlineTypePath {
+                                    root: InlineTypePathRoot::Resource(resource),
+                                    segments: arena.alloc_slice_copy(&[
+                                        InlineTypePathSegment::Operation(id),
+                                        InlineTypePathSegment::Parameter(param.name.as_str()),
+                                    ]),
+                                },
+                                schema,
+                            )),
+                            None => arena.alloc(
+                                SpecInlineType::Any(InlineTypePath {
+                                    root: InlineTypePathRoot::Resource(resource),
+                                    segments: arena.alloc_slice_copy(&[
+                                        InlineTypePathSegment::Operation(id),
+                                        InlineTypePathSegment::Parameter(param.name.as_str()),
+                                    ]),
+                                })
+                                .into(),
+                            ),
+                        };
+                        let style = match (param.style, param.explode) {
+                            (Some(ParsedParameterStyle::DeepObject), Some(true) | None) => {
+                                Some(IrParameterStyle::DeepObject)
+                            }
+                            (Some(ParsedParameterStyle::SpaceDelimited), Some(false) | None) => {
+                                Some(IrParameterStyle::SpaceDelimited)
+                            }
+                            (Some(ParsedParameterStyle::PipeDelimited), Some(false) | None) => {
+                                Some(IrParameterStyle::PipeDelimited)
+                            }
+                            (None, None) => None,
+                            (Some(ParsedParameterStyle::Form) | None, Some(true) | None) => {
+                                Some(IrParameterStyle::Form { exploded: true })
+                            }
+                            (Some(ParsedParameterStyle::Form) | None, Some(false)) => {
+                                Some(IrParameterStyle::Form { exploded: false })
+                            }
+                            _ => None,
+                        };
+                        let info = SpecParameterInfo {
+                            name: param.name.as_str(),
+                            ty,
+                            required: param.required,
+                            description: param.description.as_deref(),
+                            style,
+                        };
+                        Some(match param.location {
+                            ParameterLocation::Path => SpecParameter::Path(info),
+                            ParameterLocation::Query => SpecParameter::Query(info),
+                            _ => return None,
+                        })
+                    }))
+                };
+
+                let request = item
+                    .op
                     .request_body
                     .as_ref()
                     .and_then(|request_or_ref| {
@@ -201,7 +226,8 @@ impl<'a> Spec<'a> {
                     });
 
                 let response = {
-                    let mut statuses = op
+                    let mut statuses = item
+                        .op
                         .responses
                         .keys()
                         .filter_map(|status| Some((status.as_str(), status.parse::<u16>().ok()?)))
@@ -213,7 +239,8 @@ impl<'a> Spec<'a> {
                         .map(|&(key, _)| key)
                         .unwrap_or("default");
 
-                    op.responses
+                    item.op
+                        .responses
                         .get(key)
                         .and_then(|response_or_ref| {
                             let response = match response_or_ref {
@@ -273,9 +300,9 @@ impl<'a> Spec<'a> {
                 Ok(SpecOperation {
                     resource,
                     id,
-                    method,
-                    path: arena.alloc_slice_copy(&path),
-                    description: op.description.as_deref(),
+                    method: item.method,
+                    path: item.path,
+                    description: item.op.description.as_deref(),
                     params,
                     request,
                     response,
@@ -327,4 +354,12 @@ enum RequestContent<'a> {
 enum ResponseContent<'a> {
     Json(&'a RefOrSchema),
     Any,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct PathOperation<'a> {
+    path: &'a [PathSegment<'a>],
+    method: Method,
+    params: &'a [RefOrParameter],
+    op: &'a Operation,
 }

--- a/ploidy-core/src/ir/spec.rs
+++ b/ploidy-core/src/ir/spec.rs
@@ -17,9 +17,9 @@ use super::{
     transform::transform,
     types::{
         InlineTypePath, InlineTypePathRoot, InlineTypePathSegment,
-        ParameterStyle as IrParameterStyle, PrimitiveType, SchemaTypeInfo, SpecInlineType,
-        SpecOperation, SpecParameter, SpecParameterInfo, SpecRequest, SpecResponse, SpecSchemaType,
-        SpecType, TypeInfo,
+        ParameterStyle as IrParameterStyle, SchemaTypeInfo, SpecInlineType, SpecOperation,
+        SpecParameter, SpecParameterInfo, SpecRequest, SpecResponse, SpecSchemaType, SpecType,
+        TypeInfo,
     },
 };
 
@@ -208,16 +208,13 @@ impl<'a> Spec<'a> {
                         }
                         Source::Synthesized(name) => {
                             let ty: &_ = arena.alloc(
-                                SpecInlineType::Primitive(
-                                    InlineTypePath {
-                                        root: InlineTypePathRoot::Resource(resource),
-                                        segments: arena.alloc_slice_copy(&[
-                                            InlineTypePathSegment::Operation(id),
-                                            InlineTypePathSegment::Parameter(name),
-                                        ]),
-                                    },
-                                    PrimitiveType::String,
-                                )
+                                SpecInlineType::Any(InlineTypePath {
+                                    root: InlineTypePathRoot::Resource(resource),
+                                    segments: arena.alloc_slice_copy(&[
+                                        InlineTypePathSegment::Operation(id),
+                                        InlineTypePathSegment::Parameter(name),
+                                    ]),
+                                })
                                 .into(),
                             );
                             Some(SpecParameter::Path(SpecParameterInfo {

--- a/ploidy-core/src/ir/spec.rs
+++ b/ploidy-core/src/ir/spec.rs
@@ -7,7 +7,8 @@ use crate::{
     parse::{
         self, Document, Info, Method, Operation, Parameter, ParameterLocation,
         ParameterStyle as ParsedParameterStyle, RefOrParameter, RefOrRequestBody, RefOrResponse,
-        RefOrSchema, RequestBody, Response, path::PathSegment,
+        RefOrSchema, RequestBody, Response,
+        path::{PathFragment, PathSegment},
     },
 };
 
@@ -16,9 +17,9 @@ use super::{
     transform::transform,
     types::{
         InlineTypePath, InlineTypePathRoot, InlineTypePathSegment,
-        ParameterStyle as IrParameterStyle, SchemaTypeInfo, SpecInlineType, SpecOperation,
-        SpecParameter, SpecParameterInfo, SpecRequest, SpecResponse, SpecSchemaType, SpecType,
-        TypeInfo,
+        ParameterStyle as IrParameterStyle, PrimitiveType, SchemaTypeInfo, SpecInlineType,
+        SpecOperation, SpecParameter, SpecParameterInfo, SpecRequest, SpecResponse, SpecSchemaType,
+        SpecType, TypeInfo,
     },
 };
 
@@ -106,64 +107,107 @@ impl<'a> Spec<'a> {
                         .rev()
                         .filter(|s| seen.insert((s.name.as_str(), s.location)))
                         .collect_vec();
-                    arena.alloc_slice(all.into_iter().rev().filter_map(|param| {
-                        let ty: &_ = match &param.schema {
-                            Some(RefOrSchema::Ref(r)) => arena.alloc(SpecType::Ref(&r.path)),
-                            Some(RefOrSchema::Other(schema)) => arena.alloc(transform(
-                                arena,
-                                doc,
-                                InlineTypePath {
-                                    root: InlineTypePathRoot::Resource(resource),
-                                    segments: arena.alloc_slice_copy(&[
-                                        InlineTypePathSegment::Operation(id),
-                                        InlineTypePathSegment::Parameter(param.name.as_str()),
-                                    ]),
-                                },
-                                schema,
-                            )),
-                            None => arena.alloc(
-                                SpecInlineType::Any(InlineTypePath {
-                                    root: InlineTypePathRoot::Resource(resource),
-                                    segments: arena.alloc_slice_copy(&[
-                                        InlineTypePathSegment::Operation(id),
-                                        InlineTypePathSegment::Parameter(param.name.as_str()),
-                                    ]),
-                                })
-                                .into(),
-                            ),
-                        };
-                        let style = match (param.style, param.explode) {
-                            (Some(ParsedParameterStyle::DeepObject), Some(true) | None) => {
-                                Some(IrParameterStyle::DeepObject)
-                            }
-                            (Some(ParsedParameterStyle::SpaceDelimited), Some(false) | None) => {
-                                Some(IrParameterStyle::SpaceDelimited)
-                            }
-                            (Some(ParsedParameterStyle::PipeDelimited), Some(false) | None) => {
-                                Some(IrParameterStyle::PipeDelimited)
-                            }
-                            (None, None) => None,
-                            (Some(ParsedParameterStyle::Form) | None, Some(true) | None) => {
-                                Some(IrParameterStyle::Form { exploded: true })
-                            }
-                            (Some(ParsedParameterStyle::Form) | None, Some(false)) => {
-                                Some(IrParameterStyle::Form { exploded: false })
-                            }
-                            _ => None,
-                        };
-                        let info = SpecParameterInfo {
-                            name: param.name.as_str(),
-                            ty,
-                            required: param.required,
-                            description: param.description.as_deref(),
-                            style,
-                        };
-                        Some(match param.location {
-                            ParameterLocation::Path => SpecParameter::Path(info),
-                            ParameterLocation::Query => SpecParameter::Query(info),
-                            _ => return None,
+
+                    let mut params = all
+                        .into_iter()
+                        .rev()
+                        .filter_map(|param| {
+                            let ty: &_ = match &param.schema {
+                                Some(RefOrSchema::Ref(r)) => arena.alloc(SpecType::Ref(&r.path)),
+                                Some(RefOrSchema::Other(schema)) => arena.alloc(transform(
+                                    arena,
+                                    doc,
+                                    InlineTypePath {
+                                        root: InlineTypePathRoot::Resource(resource),
+                                        segments: arena.alloc_slice_copy(&[
+                                            InlineTypePathSegment::Operation(id),
+                                            InlineTypePathSegment::Parameter(param.name.as_str()),
+                                        ]),
+                                    },
+                                    schema,
+                                )),
+                                None => arena.alloc(
+                                    SpecInlineType::Any(InlineTypePath {
+                                        root: InlineTypePathRoot::Resource(resource),
+                                        segments: arena.alloc_slice_copy(&[
+                                            InlineTypePathSegment::Operation(id),
+                                            InlineTypePathSegment::Parameter(param.name.as_str()),
+                                        ]),
+                                    })
+                                    .into(),
+                                ),
+                            };
+                            let style = match (param.style, param.explode) {
+                                (Some(ParsedParameterStyle::DeepObject), Some(true) | None) => {
+                                    Some(IrParameterStyle::DeepObject)
+                                }
+                                (
+                                    Some(ParsedParameterStyle::SpaceDelimited),
+                                    Some(false) | None,
+                                ) => Some(IrParameterStyle::SpaceDelimited),
+                                (Some(ParsedParameterStyle::PipeDelimited), Some(false) | None) => {
+                                    Some(IrParameterStyle::PipeDelimited)
+                                }
+                                (None, None) => None,
+                                (Some(ParsedParameterStyle::Form) | None, Some(true) | None) => {
+                                    Some(IrParameterStyle::Form { exploded: true })
+                                }
+                                (Some(ParsedParameterStyle::Form) | None, Some(false)) => {
+                                    Some(IrParameterStyle::Form { exploded: false })
+                                }
+                                _ => None,
+                            };
+                            let info = SpecParameterInfo {
+                                name: param.name.as_str(),
+                                ty,
+                                required: param.required,
+                                description: param.description.as_deref(),
+                                style,
+                            };
+                            Some(match param.location {
+                                ParameterLocation::Path => SpecParameter::Path(info),
+                                ParameterLocation::Query => SpecParameter::Query(info),
+                                _ => return None,
+                            })
                         })
-                    }))
+                        .collect_vec();
+
+                    // Synthesize missing path parameters. If a `{param}` in
+                    // the path template has no matching declaration, add a
+                    // string placeholder.
+                    params.extend(
+                        item.path
+                            .iter()
+                            .flat_map(|segment| segment.fragments())
+                            .filter_map(|fragment| match fragment {
+                                &PathFragment::Param(name) => Some(name),
+                                _ => None,
+                            })
+                            .filter(|name| seen.insert((name, ParameterLocation::Path)))
+                            .map(|name| {
+                                SpecParameter::Path(SpecParameterInfo {
+                                    name,
+                                    ty: arena.alloc(
+                                        SpecInlineType::Primitive(
+                                            InlineTypePath {
+                                                root: InlineTypePathRoot::Resource(resource),
+                                                segments: arena.alloc_slice_copy(&[
+                                                    InlineTypePathSegment::Operation(id),
+                                                    InlineTypePathSegment::Parameter(name),
+                                                ]),
+                                            },
+                                            PrimitiveType::String,
+                                        )
+                                        .into(),
+                                    ),
+                                    required: true,
+                                    description: None,
+                                    style: None,
+                                })
+                            }),
+                    );
+
+                    arena.alloc_slice_copy(&params)
                 };
 
                 let request = item

--- a/ploidy-core/src/ir/spec.rs
+++ b/ploidy-core/src/ir/spec.rs
@@ -90,11 +90,15 @@ impl<'a> Spec<'a> {
                     .ok_or(IrError::NoOperationId)?;
 
                 let params = {
-                    // Merge path item and operation parameters. Operation
-                    // params override path item params with the same
-                    // `(name, location)` pair.
-                    let mut seen = FxHashSet::default();
-                    let all = item
+                    enum Source<'a> {
+                        Declared(&'a Parameter),
+                        Synthesized(&'a str),
+                    }
+
+                    // Merge path item and operation parameters.
+                    // Operation parameters override path item ones.
+                    let mut declared = IndexMap::new();
+                    for param in item
                         .params
                         .iter()
                         .chain(item.op.parameters.iter())
@@ -104,14 +108,46 @@ impl<'a> Spec<'a> {
                                 r.path.pointer().follow::<&Parameter>(doc).ok()
                             }
                         })
-                        .rev()
-                        .filter(|s| seen.insert((s.name.as_str(), s.location)))
-                        .collect_vec();
+                    {
+                        declared.insert((param.name.as_str(), param.location), param);
+                    }
 
-                    let mut params = all
-                        .into_iter()
-                        .rev()
-                        .filter_map(|param| {
+                    // Walk the path template to produce path parameters in
+                    // template order. Each template parameter name pulls its
+                    // declaration from the merged map; undeclared names get
+                    // a synthesized string parameter.
+                    let mut sources = {
+                        let mut seen = FxHashSet::default();
+                        item.path
+                            .iter()
+                            .flat_map(|segment| segment.fragments())
+                            .filter_map(|fragment| match fragment {
+                                &PathFragment::Param(name) => Some(name),
+                                _ => None,
+                            })
+                            .filter(|&name| seen.insert(name))
+                            .map(|name| {
+                                match declared.shift_remove(&(name, ParameterLocation::Path)) {
+                                    Some(param) => Source::Declared(param),
+                                    None => Source::Synthesized(name),
+                                }
+                            })
+                            .collect_vec()
+                    };
+
+                    // Append remaining parameters in declaration order.
+                    sources.extend(declared.into_iter().filter_map(|((_, location), param)| {
+                        match location {
+                            // Drop declared path parameters that are
+                            // absent from the template.
+                            ParameterLocation::Path => None,
+                            _ => Some(Source::Declared(param)),
+                        }
+                    }));
+
+                    // Lower all sources to spec parameters.
+                    let params = sources.into_iter().filter_map(|source| match source {
+                        Source::Declared(param) => {
                             let ty: &_ = match &param.schema {
                                 Some(RefOrSchema::Ref(r)) => arena.alloc(SpecType::Ref(&r.path)),
                                 Some(RefOrSchema::Other(schema)) => arena.alloc(transform(
@@ -169,45 +205,32 @@ impl<'a> Spec<'a> {
                                 ParameterLocation::Query => SpecParameter::Query(info),
                                 _ => return None,
                             })
-                        })
-                        .collect_vec();
+                        }
+                        Source::Synthesized(name) => {
+                            let ty: &_ = arena.alloc(
+                                SpecInlineType::Primitive(
+                                    InlineTypePath {
+                                        root: InlineTypePathRoot::Resource(resource),
+                                        segments: arena.alloc_slice_copy(&[
+                                            InlineTypePathSegment::Operation(id),
+                                            InlineTypePathSegment::Parameter(name),
+                                        ]),
+                                    },
+                                    PrimitiveType::String,
+                                )
+                                .into(),
+                            );
+                            Some(SpecParameter::Path(SpecParameterInfo {
+                                name,
+                                ty,
+                                required: true,
+                                description: None,
+                                style: None,
+                            }))
+                        }
+                    });
 
-                    // Synthesize missing path parameters. If a `{param}` in
-                    // the path template has no matching declaration, add a
-                    // string placeholder.
-                    params.extend(
-                        item.path
-                            .iter()
-                            .flat_map(|segment| segment.fragments())
-                            .filter_map(|fragment| match fragment {
-                                &PathFragment::Param(name) => Some(name),
-                                _ => None,
-                            })
-                            .filter(|name| seen.insert((name, ParameterLocation::Path)))
-                            .map(|name| {
-                                SpecParameter::Path(SpecParameterInfo {
-                                    name,
-                                    ty: arena.alloc(
-                                        SpecInlineType::Primitive(
-                                            InlineTypePath {
-                                                root: InlineTypePathRoot::Resource(resource),
-                                                segments: arena.alloc_slice_copy(&[
-                                                    InlineTypePathSegment::Operation(id),
-                                                    InlineTypePathSegment::Parameter(name),
-                                                ]),
-                                            },
-                                            PrimitiveType::String,
-                                        )
-                                        .into(),
-                                    ),
-                                    required: true,
-                                    description: None,
-                                    style: None,
-                                })
-                            }),
-                    );
-
-                    arena.alloc_slice_copy(&params)
+                    arena.alloc_slice(params)
                 };
 
                 let request = item

--- a/ploidy-core/src/ir/tests/spec.rs
+++ b/ploidy-core/src/ir/tests/spec.rs
@@ -1931,3 +1931,87 @@ fn test_path_item_ignores_header_and_cookie_parameters() {
 
     assert_matches!(&*ir.operations, [SpecOperation { params: [], .. }]);
 }
+
+// MARK: Synthesized path parameters
+
+#[test]
+fn test_synthesizes_missing_path_parameter() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test API
+          version: 1.0
+        paths:
+          /items/{item_id}:
+            get:
+              operationId: getItem
+              responses:
+                '200':
+                  description: Success
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let ir = Spec::from_doc(&arena, &doc).unwrap();
+
+    assert_matches!(
+        &*ir.operations,
+        [SpecOperation {
+            params: [SpecParameter::Path(SpecParameterInfo {
+                name: "item_id",
+                required: true,
+                ty: SpecType::Inline(SpecInlineType::Primitive(_, PrimitiveType::String)),
+                ..
+            })],
+            ..
+        }],
+    );
+}
+
+#[test]
+fn test_synthesized_path_parameters_appear_after_declared() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test API
+          version: 1.0
+        paths:
+          /orgs/{org_id}/items/{item_id}:
+            get:
+              operationId: getOrgItem
+              parameters:
+                - name: org_id
+                  in: path
+                  required: true
+                  schema:
+                    type: integer
+                    format: int64
+              responses:
+                '200':
+                  description: Success
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let ir = Spec::from_doc(&arena, &doc).unwrap();
+
+    assert_matches!(
+        &*ir.operations,
+        [SpecOperation {
+            params: [
+                SpecParameter::Path(SpecParameterInfo {
+                    name: "org_id",
+                    ty: SpecType::Inline(SpecInlineType::Primitive(_, PrimitiveType::I64)),
+                    ..
+                }),
+                SpecParameter::Path(SpecParameterInfo {
+                    name: "item_id",
+                    required: true,
+                    ty: SpecType::Inline(SpecInlineType::Primitive(_, PrimitiveType::String)),
+                    ..
+                }),
+            ],
+            ..
+        }],
+    );
+}

--- a/ploidy-core/src/ir/tests/spec.rs
+++ b/ploidy-core/src/ir/tests/spec.rs
@@ -1932,6 +1932,58 @@ fn test_path_item_ignores_header_and_cookie_parameters() {
     assert_matches!(&*ir.operations, [SpecOperation { params: [], .. }]);
 }
 
+#[test]
+fn test_declared_path_parameter_not_in_template_is_dropped() {
+    // `phantom` is declared as `in: path` but absent from the template.
+    // It should be silently dropped.
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test API
+          version: 1.0
+        paths:
+          /users/{id}:
+            get:
+              operationId: getUser
+              parameters:
+                - name: id
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+                - name: phantom
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+                - name: include
+                  in: query
+                  schema:
+                    type: string
+              responses:
+                '200':
+                  description: Success
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let ir = Spec::from_doc(&arena, &doc).unwrap();
+
+    assert_matches!(
+        &*ir.operations,
+        [SpecOperation {
+            params: [
+                SpecParameter::Path(SpecParameterInfo { name: "id", .. }),
+                SpecParameter::Query(SpecParameterInfo {
+                    name: "include",
+                    ..
+                }),
+            ],
+            ..
+        }],
+    );
+}
+
 // MARK: Synthesized path parameters
 
 #[test]
@@ -1968,8 +2020,12 @@ fn test_synthesizes_missing_path_parameter() {
     );
 }
 
+// MARK: Path parameter ordering
+
 #[test]
-fn test_synthesized_path_parameters_appear_after_declared() {
+fn test_path_parameters_sort_in_template_order() {
+    // Parameters are declared in reverse template order.
+    // The output should match the template, not the declaration.
     let doc = Document::from_yaml(indoc::indoc! {"
         openapi: 3.0.0
         info:
@@ -1980,7 +2036,30 @@ fn test_synthesized_path_parameters_appear_after_declared() {
             get:
               operationId: getOrgItem
               parameters:
+                - name: item_id
+                  in: path
+                  required: true
+                  schema:
+                    type: string
                 - name: org_id
+                  in: path
+                  required: true
+                  schema:
+                    type: integer
+                    format: int64
+              responses:
+                '200':
+                  description: Success
+          /teams/{team_id}/projects/{project_id}/leads/{team_id}:
+            get:
+              operationId: getTeamProjectLead
+              parameters:
+                - name: project_id
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+                - name: team_id
                   in: path
                   required: true
                   schema:
@@ -1997,19 +2076,178 @@ fn test_synthesized_path_parameters_appear_after_declared() {
 
     assert_matches!(
         &*ir.operations,
+        [
+            SpecOperation {
+                params: [
+                    SpecParameter::Path(SpecParameterInfo {
+                        name: "org_id",
+                        ty: SpecType::Inline(SpecInlineType::Primitive(_, PrimitiveType::I64)),
+                        ..
+                    }),
+                    SpecParameter::Path(SpecParameterInfo {
+                        name: "item_id",
+                        ty: SpecType::Inline(SpecInlineType::Primitive(_, PrimitiveType::String)),
+                        ..
+                    }),
+                ],
+                ..
+            },
+            // `team_id` appears at two template positions;
+            // the first occurrence determines its sort position.
+            SpecOperation {
+                params: [
+                    SpecParameter::Path(SpecParameterInfo {
+                        name: "team_id",
+                        ty: SpecType::Inline(SpecInlineType::Primitive(_, PrimitiveType::I64)),
+                        ..
+                    }),
+                    SpecParameter::Path(SpecParameterInfo {
+                        name: "project_id",
+                        ty: SpecType::Inline(SpecInlineType::Primitive(_, PrimitiveType::String)),
+                        ..
+                    }),
+                ],
+                ..
+            },
+        ],
+    );
+}
+
+#[test]
+fn test_synthesized_path_parameters_intersperse_in_template_order() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test API
+          version: 1.0
+        paths:
+          /orgs/{org_id}/users/{user_id}/items/{item_id}:
+            get:
+              operationId: getOrgUserItem
+              parameters:
+                - name: org_id
+                  in: path
+                  required: true
+                  schema:
+                    type: integer
+                    format: int64
+                - name: item_id
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+              responses:
+                '200':
+                  description: Success
+          /teams/{team_id}/projects/{project_id}/leads/{team_id}:
+            get:
+              operationId: getTeamProjectLead
+              parameters:
+                - name: team_id
+                  in: path
+                  required: true
+                  schema:
+                    type: integer
+                    format: int64
+              responses:
+                '200':
+                  description: Success
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let ir = Spec::from_doc(&arena, &doc).unwrap();
+
+    assert_matches!(
+        &*ir.operations,
+        [
+            SpecOperation {
+                params: [
+                    SpecParameter::Path(SpecParameterInfo {
+                        name: "org_id",
+                        required: true,
+                        ty: SpecType::Inline(SpecInlineType::Primitive(_, PrimitiveType::I64)),
+                        ..
+                    }),
+                    SpecParameter::Path(SpecParameterInfo {
+                        name: "user_id",
+                        required: true,
+                        ty: SpecType::Inline(SpecInlineType::Primitive(_, PrimitiveType::String)),
+                        ..
+                    }),
+                    SpecParameter::Path(SpecParameterInfo {
+                        name: "item_id",
+                        required: true,
+                        ty: SpecType::Inline(SpecInlineType::Primitive(_, PrimitiveType::String)),
+                        ..
+                    }),
+                ],
+                ..
+            },
+            // `team_id` appears at two template positions; only `project_id` is
+            // synthesized. First `team_id` occurrence determines sort position.
+            SpecOperation {
+                params: [
+                    SpecParameter::Path(SpecParameterInfo {
+                        name: "team_id",
+                        required: true,
+                        ty: SpecType::Inline(SpecInlineType::Primitive(_, PrimitiveType::I64)),
+                        ..
+                    }),
+                    SpecParameter::Path(SpecParameterInfo {
+                        name: "project_id",
+                        required: true,
+                        ty: SpecType::Inline(SpecInlineType::Primitive(_, PrimitiveType::String)),
+                        ..
+                    }),
+                ],
+                ..
+            },
+        ],
+    );
+}
+
+#[test]
+fn test_path_parameters_precede_query_parameters() {
+    // The source spec declares query parameters before path, but
+    // the path parameters should appear first in the lowered spec.
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test API
+          version: 1.0
+        paths:
+          /items/{item_id}:
+            get:
+              operationId: getItem
+              parameters:
+                - name: limit
+                  in: query
+                  schema:
+                    type: integer
+                - name: item_id
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+              responses:
+                '200':
+                  description: Success
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let ir = Spec::from_doc(&arena, &doc).unwrap();
+
+    assert_matches!(
+        &*ir.operations,
         [SpecOperation {
             params: [
                 SpecParameter::Path(SpecParameterInfo {
-                    name: "org_id",
-                    ty: SpecType::Inline(SpecInlineType::Primitive(_, PrimitiveType::I64)),
-                    ..
-                }),
-                SpecParameter::Path(SpecParameterInfo {
                     name: "item_id",
-                    required: true,
-                    ty: SpecType::Inline(SpecInlineType::Primitive(_, PrimitiveType::String)),
                     ..
                 }),
+                SpecParameter::Query(SpecParameterInfo { name: "limit", .. }),
             ],
             ..
         }],

--- a/ploidy-core/src/ir/tests/spec.rs
+++ b/ploidy-core/src/ir/tests/spec.rs
@@ -277,6 +277,60 @@ fn test_parses_multiple_path_parameters() {
     );
 }
 
+#[test]
+fn test_path_and_query_parameters_with_same_name_coexist() {
+    // A query and a path parameter both named `id` are distinct.
+    // Both should appear in the output.
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test API
+          version: 1.0
+        paths:
+          /items/{id}:
+            get:
+              operationId: getItem
+              parameters:
+                - name: id
+                  in: path
+                  required: true
+                  schema:
+                    type: integer
+                    format: int64
+                - name: id
+                  in: query
+                  required: false
+                  schema:
+                    type: string
+              responses:
+                '200':
+                  description: Success
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let ir = Spec::from_doc(&arena, &doc).unwrap();
+
+    assert_matches!(
+        &*ir.operations,
+        [SpecOperation {
+            params: [
+                SpecParameter::Path(SpecParameterInfo {
+                    name: "id",
+                    ty: SpecType::Inline(SpecInlineType::Primitive(_, PrimitiveType::I64)),
+                    ..
+                }),
+                SpecParameter::Query(SpecParameterInfo {
+                    name: "id",
+                    ty: SpecType::Inline(SpecInlineType::Primitive(_, PrimitiveType::String)),
+                    ..
+                }),
+            ],
+            ..
+        }],
+    );
+}
+
 // MARK: Query parameters
 
 #[test]
@@ -1547,5 +1601,333 @@ fn test_ignores_header_and_cookie_parameters() {
     let ir = Spec::from_doc(&arena, &doc).unwrap();
 
     // Header and cookie parameters are ignored for now.
+    assert_matches!(&*ir.operations, [SpecOperation { params: [], .. }]);
+}
+
+// MARK: Path item parameters
+
+#[test]
+fn test_path_item_parameter_inherited_by_operation() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test API
+          version: 1.0
+        paths:
+          /users/{id}:
+            parameters:
+              - name: id
+                in: path
+                required: true
+                schema:
+                  type: string
+            get:
+              operationId: getUser
+              responses:
+                '200':
+                  description: Success
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let ir = Spec::from_doc(&arena, &doc).unwrap();
+
+    assert_matches!(
+        &*ir.operations,
+        [SpecOperation {
+            id: "getUser",
+            params: [SpecParameter::Path(SpecParameterInfo {
+                name: "id",
+                required: true,
+                ..
+            })],
+            ..
+        }],
+    );
+}
+
+#[test]
+fn test_path_item_parameter_inherited_by_multiple_operations() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test API
+          version: 1.0
+        paths:
+          /users/{id}:
+            parameters:
+              - name: id
+                in: path
+                required: true
+                schema:
+                  type: string
+            get:
+              operationId: getUser
+              responses:
+                '200':
+                  description: Success
+            delete:
+              operationId: deleteUser
+              responses:
+                '204':
+                  description: Deleted
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let ir = Spec::from_doc(&arena, &doc).unwrap();
+
+    assert_matches!(
+        &*ir.operations,
+        [
+            SpecOperation {
+                id: "getUser",
+                params: [SpecParameter::Path(SpecParameterInfo { name: "id", .. })],
+                ..
+            },
+            SpecOperation {
+                id: "deleteUser",
+                params: [SpecParameter::Path(SpecParameterInfo { name: "id", .. })],
+                ..
+            },
+        ],
+    );
+}
+
+#[test]
+fn test_operation_parameter_overrides_path_item_parameter() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test API
+          version: 1.0
+        paths:
+          /users/{id}:
+            parameters:
+              - name: id
+                in: path
+                required: true
+                schema:
+                  type: string
+            get:
+              operationId: getUser
+              parameters:
+                - name: id
+                  in: path
+                  required: true
+                  description: The user ID (overridden)
+                  schema:
+                    type: integer
+                    format: int64
+              responses:
+                '200':
+                  description: Success
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let ir = Spec::from_doc(&arena, &doc).unwrap();
+
+    // The operation-level parameter should win, giving us
+    // an integer instead of the path item's string.
+    assert_matches!(
+        &*ir.operations,
+        [SpecOperation {
+            params: [SpecParameter::Path(SpecParameterInfo {
+                name: "id",
+                ty: SpecType::Inline(SpecInlineType::Primitive(_, PrimitiveType::I64)),
+                description: Some("The user ID (overridden)"),
+                ..
+            })],
+            ..
+        }],
+    );
+}
+
+#[test]
+fn test_path_item_parameter_coexists_with_operation_parameter() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test API
+          version: 1.0
+        paths:
+          /users/{id}:
+            parameters:
+              - name: id
+                in: path
+                required: true
+                schema:
+                  type: string
+            get:
+              operationId: getUser
+              parameters:
+                - name: include
+                  in: query
+                  schema:
+                    type: string
+              responses:
+                '200':
+                  description: Success
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let ir = Spec::from_doc(&arena, &doc).unwrap();
+
+    // The `id` path param from the path item, and the `include` query param
+    // from the operation, should both be present.
+    assert_matches!(
+        &*ir.operations,
+        [SpecOperation {
+            params: [
+                SpecParameter::Path(SpecParameterInfo { name: "id", .. }),
+                SpecParameter::Query(SpecParameterInfo {
+                    name: "include",
+                    ..
+                }),
+            ],
+            ..
+        }],
+    );
+}
+
+#[test]
+fn test_path_item_parameter_override_only_affects_matching_operation() {
+    // One operation overrides the path item param, the other inherits it.
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test API
+          version: 1.0
+        paths:
+          /users/{id}:
+            parameters:
+              - name: id
+                in: path
+                required: true
+                schema:
+                  type: string
+            get:
+              operationId: getUser
+              parameters:
+                - name: id
+                  in: path
+                  required: true
+                  description: overridden
+                  schema:
+                    type: integer
+              responses:
+                '200':
+                  description: Success
+            delete:
+              operationId: deleteUser
+              responses:
+                '204':
+                  description: Deleted
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let ir = Spec::from_doc(&arena, &doc).unwrap();
+
+    assert_matches!(
+        &*ir.operations,
+        [
+            SpecOperation {
+                id: "getUser",
+                params: [SpecParameter::Path(SpecParameterInfo {
+                    description: Some("overridden"),
+                    ..
+                })],
+                ..
+            },
+            SpecOperation {
+                id: "deleteUser",
+                params: [SpecParameter::Path(SpecParameterInfo {
+                    description: None,
+                    ..
+                })],
+                ..
+            },
+        ],
+    );
+}
+
+#[test]
+fn test_path_item_ref_parameter_inherited_by_operation() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test API
+          version: 1.0
+        paths:
+          /users/{id}:
+            parameters:
+              - $ref: '#/components/parameters/UserId'
+            get:
+              operationId: getUser
+              responses:
+                '200':
+                  description: Success
+        components:
+          parameters:
+            UserId:
+              name: id
+              in: path
+              required: true
+              schema:
+                type: integer
+                format: int64
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let ir = Spec::from_doc(&arena, &doc).unwrap();
+
+    assert_matches!(
+        &*ir.operations,
+        [SpecOperation {
+            params: [SpecParameter::Path(SpecParameterInfo {
+                name: "id",
+                ty: SpecType::Inline(SpecInlineType::Primitive(_, PrimitiveType::I64)),
+                ..
+            })],
+            ..
+        }],
+    );
+}
+
+#[test]
+fn test_path_item_ignores_header_and_cookie_parameters() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test API
+          version: 1.0
+        paths:
+          /users:
+            parameters:
+              - name: X-API-Key
+                in: header
+                required: true
+                schema:
+                  type: string
+              - name: sessionId
+                in: cookie
+                required: true
+                schema:
+                  type: string
+            get:
+              operationId: listUsers
+              responses:
+                '200':
+                  description: Success
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let ir = Spec::from_doc(&arena, &doc).unwrap();
+
     assert_matches!(&*ir.operations, [SpecOperation { params: [], .. }]);
 }

--- a/ploidy-core/src/ir/tests/spec.rs
+++ b/ploidy-core/src/ir/tests/spec.rs
@@ -2012,7 +2012,7 @@ fn test_synthesizes_missing_path_parameter() {
             params: [SpecParameter::Path(SpecParameterInfo {
                 name: "item_id",
                 required: true,
-                ty: SpecType::Inline(SpecInlineType::Primitive(_, PrimitiveType::String)),
+                ty: SpecType::Inline(SpecInlineType::Any(_)),
                 ..
             })],
             ..
@@ -2172,7 +2172,7 @@ fn test_synthesized_path_parameters_intersperse_in_template_order() {
                     SpecParameter::Path(SpecParameterInfo {
                         name: "user_id",
                         required: true,
-                        ty: SpecType::Inline(SpecInlineType::Primitive(_, PrimitiveType::String)),
+                        ty: SpecType::Inline(SpecInlineType::Any(_)),
                         ..
                     }),
                     SpecParameter::Path(SpecParameterInfo {
@@ -2197,7 +2197,7 @@ fn test_synthesized_path_parameters_intersperse_in_template_order() {
                     SpecParameter::Path(SpecParameterInfo {
                         name: "project_id",
                         required: true,
-                        ty: SpecType::Inline(SpecInlineType::Primitive(_, PrimitiveType::String)),
+                        ty: SpecType::Inline(SpecInlineType::Any(_)),
                         ..
                     }),
                 ],

--- a/ploidy-core/src/parse/types.rs
+++ b/ploidy-core/src/parse/types.rs
@@ -38,6 +38,8 @@ pub struct Info {
 #[derive(Debug, Deserialize, JsonPointee, JsonPointerTarget)]
 pub struct PathItem {
     #[serde(default)]
+    pub parameters: Vec<RefOrParameter>,
+    #[serde(default)]
     pub get: Option<Operation>,
     #[serde(default)]
     pub post: Option<Operation>,
@@ -116,7 +118,7 @@ pub struct Parameter {
     pub explode: Option<bool>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, JsonPointee, JsonPointerTarget)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize, JsonPointee, JsonPointerTarget)]
 #[serde(rename_all = "lowercase")]
 #[ploidy(pointer(untagged, rename_all = "lowercase"))]
 pub enum ParameterLocation {

--- a/ploidy-core/src/tests.rs
+++ b/ploidy-core/src/tests.rs
@@ -1,6 +1,8 @@
 //! Shared test-only helpers.
 
-use std::fmt::{Arguments, Debug};
+use std::fmt::{Arguments, Debug, Display};
+
+use pretty_assertions::Comparison;
 
 /// Asserts that an expression matches the given pattern.
 ///
@@ -38,22 +40,33 @@ pub(crate) use assert_matches;
 
 #[track_caller]
 pub(crate) fn assert_matches_failed(left: impl Debug, right: &str, message: Option<Arguments<'_>>) {
+    struct Pattern<'a>(&'a str);
+    impl Debug for Pattern<'_> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            // Force `panic!()` to use the right side's `Display`
+            // representation, not the default `Debug`.
+            Display::fmt(self.0, f)
+        }
+    }
+
     match message {
         Some(message) => panic!(
             "{}",
             indoc::formatdoc! {"
                 assertion `left matches right` failed: {message}
-                  left: {left:?}
-                 right: {right:?}
-            "},
+                {}
+                ",
+                Comparison::new(&left, &Pattern(right)),
+            },
         ),
         None => panic!(
             "{}",
             indoc::formatdoc! {"
                 assertion `left matches right` failed
-                  left: {left:?}
-                 right: {right:?}
-            "},
+                {}
+                ",
+                Comparison::new(&left, &Pattern(right)),
+            },
         ),
     }
 }


### PR DESCRIPTION
Two commits inspired by #86, that are still super valuable even if that did turn out to be a bug in the spec generator!

* Support path item-level `parameters` that apply to all operations. This tackles one of our OpenAPI compliance points!
* Synthesize string parameters for `{params}` that appear in the path template without a corresponding `in: path` definition in a path item or operation `parameters` section. This _teeeechnically_ goes against the OpenAPI spec, but still feels like a nice and low-effort quality-of-life improvement in line with Postel's law.