### PR TITLE
Propagate `Hash`, `Eq`, and `Default` through inherited fields in cycles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,7 +183,7 @@ if f.discriminator() { continue; }
 ## Crate-Specific Rules
 
 - **ploidy-core:** Language-agnostic IR, but Rust-flavored concepts are fine when they simplify codegen (e.g., `Required`, `needs_box()`). The boundary is: core must not depend on codegen types (`syn`, `quote`, token streams). Use view types for graph queries. Tests in `src/**/tests/*.rs`.
-- **ploidy-codegen-rust:** All types implement `ToTokens`. Use `quote!` for tokens, never string-format. Tests compare AST with `parse_quote!`, never strings.
+- **ploidy-codegen-rust:** All types implement `ToTokens`. Use `quote!` for tokens, never string-format. Tests must compare AST nodes using `parse_quote!`, never string matching (e.g., `tokens.contains("...")`).
 - **ploidy-pointer:** Follows RFC 6901. Tests in `src/lib.rs` and `tests/`. Simpler assertions OK.
 - **ploidy-pointer-derive:** Proc-macro constraints apply. Test via `ploidy-pointer/tests/`.
 - **ploidy-util:** Keep minimal. All data types must impl `Serialize`/`Deserialize`. Key types: `AbsentOr<T>`, `QuerySerializer`, `UnixSeconds`.

--- a/ploidy-codegen-rust/src/struct_.rs
+++ b/ploidy-codegen-rust/src/struct_.rs
@@ -1004,7 +1004,309 @@ mod tests {
         assert_eq!(actual, expected);
     }
 
+    #[test]
+    fn test_struct_omits_hash_eq_when_inheriting_unhashable_field_through_cycle() {
+        // Struct `N` inherits from struct `A`, which declares field `t: T`.
+        // `T` has `val: f64` (unhashable) and `ns: Vec<N>`, closing the cycle.
+        //
+        //   N --Inherits--> A --Field--> T --Field--> [N] --Contains--> N
+        //                                 \--Field--> f64
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                A:
+                  type: object
+                  properties:
+                    t:
+                      $ref: '#/components/schemas/T'
+                  required:
+                    - t
+                N:
+                  type: object
+                  allOf:
+                    - $ref: '#/components/schemas/A'
+                  properties:
+                    name:
+                      type: string
+                  required:
+                    - name
+                T:
+                  type: object
+                  properties:
+                    ns:
+                      type: array
+                      items:
+                        $ref: '#/components/schemas/N'
+                    val:
+                      type: number
+                      format: double
+                  required:
+                    - ns
+                    - val
+        "})
+        .unwrap();
+
+        let arena = Arena::new();
+        let spec = Spec::from_doc(&arena, &doc).unwrap();
+        let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
+
+        let schema = graph.schemas().find(|s| s.name() == "N");
+        let Some(schema @ SchemaTypeView::Struct(_, struct_view)) = &schema else {
+            panic!("expected struct `N`; got `{schema:?}`");
+        };
+
+        let name = CodegenTypeName::Schema(schema);
+        let codegen = CodegenStruct::new(name, struct_view);
+
+        let actual: syn::ItemStruct = parse_quote!(#codegen);
+        let expected: syn::ItemStruct = parse_quote! {
+            #[derive(Debug, Clone, PartialEq, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
+            #[serde(crate = "::ploidy_util::serde")]
+            #[ploidy(pointer(crate = "::ploidy_util::pointer"))]
+            pub struct N {
+                pub t: crate::types::T,
+                pub name: ::std::string::String,
+            }
+        };
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_struct_omits_hash_eq_for_scc_sibling_of_inherited_unhashable() {
+        // `X` has field `y: Y`. `Y` inherits `P`, which has fields
+        // `v: f64`. Two SCCs: `{X, Y}` and `{P}`.
+        //
+        //   X --Field--> Y --Inherits--> P --Field--> f64
+        //   Y --Field--> X
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                X:
+                  type: object
+                  properties:
+                    y:
+                      $ref: '#/components/schemas/Y'
+                  required:
+                    - y
+                Y:
+                  type: object
+                  allOf:
+                    - $ref: '#/components/schemas/P'
+                  properties:
+                    x:
+                      $ref: '#/components/schemas/X'
+                  required:
+                    - x
+                P:
+                  type: object
+                  properties:
+                    v:
+                      type: number
+                      format: double
+                  required:
+                    - v
+        "})
+        .unwrap();
+
+        let arena = Arena::new();
+        let spec = Spec::from_doc(&arena, &doc).unwrap();
+        let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
+
+        let schema = graph.schemas().find(|s| s.name() == "X");
+        let Some(schema @ SchemaTypeView::Struct(_, struct_view)) = &schema else {
+            panic!("expected struct `X`; got `{schema:?}`");
+        };
+
+        let name = CodegenTypeName::Schema(schema);
+        let codegen = CodegenStruct::new(name, struct_view);
+
+        let actual: syn::ItemStruct = parse_quote!(#codegen);
+        let expected: syn::ItemStruct = parse_quote! {
+            #[derive(Debug, Clone, PartialEq, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
+            #[serde(crate = "::ploidy_util::serde")]
+            #[ploidy(pointer(crate = "::ploidy_util::pointer"))]
+            pub struct X {
+                pub y: ::std::boxed::Box<crate::types::Y>,
+            }
+        };
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_struct_omits_hash_eq_for_non_inheriting_scc_member() {
+        // `A` inherits `B`. `B` has field `d: D`. `D` inherits `E`
+        // with fields `f: f64` and `as: [A]`. One SCC: `{A, B, D}`.
+        //
+        //   A --Inherits--> B --Field--> D --Inherits--> E --Field--> f64
+        //                                D --Field--> [A]
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                A:
+                  type: object
+                  allOf:
+                    - $ref: '#/components/schemas/B'
+                B:
+                  type: object
+                  properties:
+                    d:
+                      $ref: '#/components/schemas/D'
+                  required:
+                    - d
+                D:
+                  type: object
+                  allOf:
+                    - $ref: '#/components/schemas/E'
+                  properties:
+                    as:
+                      type: array
+                      items:
+                        $ref: '#/components/schemas/A'
+                  required:
+                    - as
+                E:
+                  type: object
+                  properties:
+                    f:
+                      type: number
+                      format: double
+                  required:
+                    - f
+        "})
+        .unwrap();
+
+        let arena = Arena::new();
+        let spec = Spec::from_doc(&arena, &doc).unwrap();
+        let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
+
+        let schema = graph.schemas().find(|s| s.name() == "B");
+        let Some(schema @ SchemaTypeView::Struct(_, struct_view)) = &schema else {
+            panic!("expected struct `B`; got `{schema:?}`");
+        };
+
+        let name = CodegenTypeName::Schema(schema);
+        let codegen = CodegenStruct::new(name, struct_view);
+
+        let actual: syn::ItemStruct = parse_quote!(#codegen);
+        let expected: syn::ItemStruct = parse_quote! {
+            #[derive(Debug, Clone, PartialEq, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
+            #[serde(crate = "::ploidy_util::serde")]
+            #[ploidy(pointer(crate = "::ploidy_util::pointer"))]
+            pub struct B {
+                pub d: crate::types::D,
+            }
+        };
+        assert_eq!(actual, expected);
+    }
+
     // MARK: `Default`
+
+    #[test]
+    fn test_struct_omits_default_when_inheriting_undefaultable_field_through_cycle() {
+        // `N` inherits `A`, which has required field `link: Url`
+        // (undefaultable). `N` has required field `t: T`, and `T` has
+        // required field `n: N`, closing the cycle. Two SCCs:
+        // `{N, T}` and `{A}`.
+        //
+        //   N --Inherits--> A --Field--> Url
+        //   N --Field--> T --Field--> N
+        //
+        // None of `A`, `N`, `T` should derive `Default`.
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                A:
+                  type: object
+                  properties:
+                    link:
+                      type: string
+                      format: uri
+                  required:
+                    - link
+                N:
+                  type: object
+                  allOf:
+                    - $ref: '#/components/schemas/A'
+                  properties:
+                    t:
+                      $ref: '#/components/schemas/T'
+                  required:
+                    - t
+                T:
+                  type: object
+                  properties:
+                    n:
+                      $ref: '#/components/schemas/N'
+                  required:
+                    - n
+        "})
+        .unwrap();
+
+        let arena = Arena::new();
+        let spec = Spec::from_doc(&arena, &doc).unwrap();
+        let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
+
+        let actual: syn::File = syn::parse2(
+            graph
+                .schemas()
+                .filter(|s| matches!(s.name(), "A" | "N" | "T"))
+                .map(|schema| {
+                    let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+                        panic!("expected struct; got `{schema:?}`");
+                    };
+                    let name = CodegenTypeName::Schema(schema);
+                    let codegen = CodegenStruct::new(name, struct_view);
+                    quote!(#codegen)
+                })
+                .reduce(|a, b| quote! { #a #b })
+                .unwrap(),
+        )
+        .unwrap();
+        let expected: syn::File = parse_quote! {
+            #[derive(Debug, Clone, PartialEq, Eq, Hash, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
+            #[serde(crate = "::ploidy_util::serde")]
+            #[ploidy(pointer(crate = "::ploidy_util::pointer"))]
+            pub struct A {
+                pub link: ::ploidy_util::url::Url,
+            }
+
+            #[derive(Debug, Clone, PartialEq, Eq, Hash, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
+            #[serde(crate = "::ploidy_util::serde")]
+            #[ploidy(pointer(crate = "::ploidy_util::pointer"))]
+            pub struct N {
+                pub link: ::ploidy_util::url::Url,
+                pub t: ::std::boxed::Box<crate::types::T>,
+            }
+
+            #[derive(Debug, Clone, PartialEq, Eq, Hash, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
+            #[serde(crate = "::ploidy_util::serde")]
+            #[ploidy(pointer(crate = "::ploidy_util::pointer"))]
+            pub struct T {
+                pub n: ::std::boxed::Box<crate::types::N>,
+            }
+        };
+        assert_eq!(actual, expected);
+    }
 
     #[test]
     fn test_struct_derives_default_when_all_optional() {

--- a/ploidy-core/src/ir/graph.rs
+++ b/ploidy-core/src/ir/graph.rs
@@ -825,112 +825,86 @@ impl<'graph, 'a> MetadataBuilder<'graph, 'a> {
             }
         }
 
-        // Propagate marked leaves backward through the non-inheritance edges
-        // that affect each trait. A reverse BFS from the leaves marks each type
-        // that transitively reaches an unhashable or undefaultable leaf.
-        {
-            let mut queue: VecDeque<_> = unhashable.ones().map(NodeIndex::new).collect();
-            while let Some(node) = queue.pop_front() {
-                for edge in self.graph.edges_directed(node, Direction::Incoming) {
-                    if !matches!(
-                        edge.weight(),
-                        GraphEdge::Field { .. } | GraphEdge::Contains | GraphEdge::Variant(_)
-                    ) {
-                        continue;
-                    }
-                    let source = edge.source();
-                    if !unhashable[source.index()] {
-                        unhashable.insert(source.index());
-                        queue.push_back(source);
-                    }
-                }
-            }
+        // Compute the transitive closure over the inheritance subgraph.
+        let inherits = Closure::new(&EdgeFiltered::from_fn(self.graph, |e| {
+            matches!(e.weight(), GraphEdge::Inherits { .. })
+        }));
 
-            let mut queue: VecDeque<_> = undefaultable.ones().map(NodeIndex::new).collect();
-            while let Some(node) = queue.pop_front() {
-                for edge in self.graph.edges_directed(node, Direction::Incoming) {
-                    // Optional fields become `AbsentOr<T>`, which is always
-                    // `Default`, so only required field edges propagate.
-                    if !matches!(
-                        edge.weight(),
-                        GraphEdge::Field { meta, .. } if meta.required
-                    ) {
-                        continue;
+        // Propagate unhashability backward, from leaves to roots.
+        //
+        // This is conservative: if a descendant overrides an inherited
+        // unhashable or undefaultable field with a different hashable or
+        // defaultable type, that descendant is still marked.
+        let mut queue: VecDeque<_> = unhashable.ones().map(NodeIndex::new).collect();
+        while let Some(node) = queue.pop_front() {
+            for edge in self.graph.edges_directed(node, Direction::Incoming) {
+                let source = edge.source();
+                match edge.weight() {
+                    GraphEdge::Contains | GraphEdge::Variant(_) => {
+                        if !unhashable.put(source.index()) {
+                            queue.push_back(source);
+                        }
                     }
-                    let source = edge.source();
-                    if !undefaultable[source.index()] {
-                        undefaultable.insert(source.index());
-                        queue.push_back(source);
+                    GraphEdge::Field { .. } => {
+                        if !unhashable.put(source.index()) {
+                            queue.push_back(source);
+                        }
+                        // Every type that inherits from `source` also
+                        // inherits this unhashable field, so mark all
+                        // descendants of `source` as unhashable.
+                        for desc in inherits.dependents_of(source).filter(|&d| d != source) {
+                            if !unhashable.put(desc.index()) {
+                                queue.push_back(desc);
+                            }
+                        }
                     }
+                    // Don't follow inheritance edges: a parent's intrinsic
+                    // unhashability (e.g., being a tagged union) doesn't
+                    // make its children unhashable, because children only
+                    // inherit the parent's fields, not its shape.
+                    GraphEdge::Inherits { .. } => {}
                 }
             }
         }
 
-        // Compute the transitive closure over the inheritance subgraph.
-        // The BFS above doesn't follow inheritance edges, because it would
-        // propagate a parent's intrinsic undefaultability to its children:
-        // for example, a tagged union is never `Default`, but its variants
-        // can be. The closure resolves inherited fields separately.
-        let ancestors = Closure::new(&EdgeFiltered::from_fn(self.graph, |e| {
-            matches!(e.weight(), GraphEdge::Inherits { .. })
-        }));
-
-        // Visit nodes in reverse topological order so that each node
-        // has a complete view of the types it depends on.
-        let mut hashable = FixedBitSet::with_capacity(n);
-        let mut defaultable = FixedBitSet::with_capacity(n);
-        for node in self.closure.topo_nodes().rev() {
-            // Are we intrinsically hashable / defaultable?
-            let mut h = !unhashable[node.index()];
-            let mut d = !undefaultable[node.index()];
-
-            // Are all our inner types and inherited fields
-            // hashable / defaultable?
-            let contained = self
-                .graph
-                .edges_directed(node, Direction::Outgoing)
-                .filter(|e| !matches!(e.weight(), GraphEdge::Inherits { .. }));
-            let inherited = ancestors
-                .dependencies_of(node) // All transitive ancestors of the node.
-                .filter(|&ancestor| ancestor != node)
-                .flat_map(|ancestor| {
-                    self.graph
-                        .edges_directed(ancestor, Direction::Outgoing)
-                        .filter(|e| matches!(e.weight(), GraphEdge::Field { .. }))
-                });
-            let node_scc = self.closure.scc_index_of(node);
-            for edge in contained
-                .chain(inherited)
-                // Ignore types in our SCC; the BFS already marks them.
-                .filter(|e| self.closure.scc_index_of(e.target()) != node_scc)
-            {
-                match edge.weight() {
-                    GraphEdge::Field { meta, .. } => {
-                        h &= hashable[edge.target().index()];
-                        if meta.required {
-                            d &= defaultable[edge.target().index()];
-                        }
-                    }
-                    GraphEdge::Contains | GraphEdge::Variant(_) => {
-                        h &= hashable[edge.target().index()];
-                    }
-                    _ => {}
+        // Propagate undefaultability backward.
+        let mut queue: VecDeque<_> = undefaultable.ones().map(NodeIndex::new).collect();
+        while let Some(node) = queue.pop_front() {
+            for edge in self.graph.edges_directed(node, Direction::Incoming) {
+                if !matches!(
+                    edge.weight(),
+                    GraphEdge::Field { meta, .. } if meta.required
+                ) {
+                    // Optional fields become `AbsentOr<T>`,
+                    // which is always `Default`.
+                    continue;
                 }
-            }
-
-            if h {
-                hashable.insert(node.index());
-            }
-            if d {
-                defaultable.insert(node.index());
+                let source = edge.source();
+                if !undefaultable.put(source.index()) {
+                    queue.push_back(source);
+                }
+                // Every type that inherits from `source` also
+                // inherits this undefaultable field, so mark all
+                // descendants of `source` as undefaultable.
+                for desc in inherits.dependents_of(source).filter(|&d| d != source) {
+                    if !undefaultable.put(desc.index()) {
+                        queue.push_back(desc);
+                    }
+                }
             }
         }
 
         HashDefault {
-            hashable,
-            defaultable,
+            hashable: invert(unhashable),
+            defaultable: invert(undefaultable),
         }
     }
+}
+
+/// Inverts every bit in the bitset.
+fn invert(mut bits: FixedBitSet) -> FixedBitSet {
+    bits.toggle_range(..);
+    bits
 }
 
 /// Visits all the types and references contained within a [`SpecType`].
@@ -1208,19 +1182,6 @@ impl Closure {
             scc_deps,
             scc_rdeps,
         }
-    }
-
-    /// Iterates over all nodes in topological order.
-    ///
-    /// The order of nodes within an SCC is arbitrary, since all members
-    /// of an SCC share the same dependencies.
-    #[inline]
-    pub fn topo_nodes(&self) -> impl DoubleEndedIterator<Item = NodeIndex<usize>> + use<> {
-        let mut by_scc = vec![vec![]; self.scc_members.len()];
-        for (node, &scc) in self.scc_indices.iter().enumerate() {
-            by_scc[scc].push(NodeIndex::new(node));
-        }
-        by_scc.into_iter().flatten()
     }
 
     /// Returns the topological SCC index for the given node.


### PR DESCRIPTION
The reverse BFS in `hash_default()` skipped inheritance edges to prevent a parent's intrinsic unhashability (e.g., being a tagged union) from making its children unhashable. The `scc_index_of(target) != node_scc` filter only considered cross-SCC inheritance edges, though, so same-SCC field types could incorrectly emit derives for `Eq`, `Hash`, and `Default`.

This commit rewrites the logic to mark unhashable and undefaultable leaves, invert the transitive closure over the ancestors, then propagate backward from leaves to roots.