### PR TITLE
feat(parse): Support sibling properties on `$ref`s.

### DIFF
--- a/ploidy-core/src/ir/spec.rs
+++ b/ploidy-core/src/ir/spec.rs
@@ -105,7 +105,7 @@ impl<'a> Spec<'a> {
                         .filter_map(|p| match p {
                             RefOrParameter::Other(p) => Some(p),
                             RefOrParameter::Ref(r) => {
-                                r.path.pointer().follow::<&Parameter>(doc).ok()
+                                r.ref_.pointer().follow::<&Parameter>(doc).ok()
                             }
                         })
                     {
@@ -149,8 +149,8 @@ impl<'a> Spec<'a> {
                     let params = sources.into_iter().filter_map(|source| match source {
                         Source::Declared(param) => {
                             let ty: &_ = match &param.schema {
-                                Some(RefOrSchema::Ref(r)) => arena.alloc(SpecType::Ref(&r.path)),
-                                Some(RefOrSchema::Other(schema)) => arena.alloc(transform(
+                                Some(RefOrSchema::Ref(r)) => arena.alloc(SpecType::Ref(r)),
+                                Some(RefOrSchema::Inline(schema)) => arena.alloc(transform(
                                     arena,
                                     doc,
                                     InlineTypePath {
@@ -238,7 +238,7 @@ impl<'a> Spec<'a> {
                         let request = match request_or_ref {
                             RefOrRequestBody::Other(rb) => rb,
                             RefOrRequestBody::Ref(r) => {
-                                r.path.pointer().follow::<&RequestBody>(doc).ok()?
+                                r.ref_.pointer().follow::<&RequestBody>(doc).ok()?
                             }
                         };
 
@@ -259,9 +259,9 @@ impl<'a> Spec<'a> {
                     .map(|content| match content {
                         RequestContent::Multipart => SpecRequest::Multipart,
                         RequestContent::Json(RefOrSchema::Ref(r)) => {
-                            SpecRequest::Json(arena.alloc(SpecType::Ref(&r.path)))
+                            SpecRequest::Json(arena.alloc(SpecType::Ref(r)))
                         }
-                        RequestContent::Json(RefOrSchema::Other(schema)) => {
+                        RequestContent::Json(RefOrSchema::Inline(schema)) => {
                             SpecRequest::Json(arena.alloc(transform(
                                 arena,
                                 doc,
@@ -310,7 +310,7 @@ impl<'a> Spec<'a> {
                             let response = match response_or_ref {
                                 RefOrResponse::Other(r) => r,
                                 RefOrResponse::Ref(r) => {
-                                    r.path.pointer().follow::<&Response>(doc).ok()?
+                                    r.ref_.pointer().follow::<&Response>(doc).ok()?
                                 }
                             };
                             response.content.as_ref()
@@ -330,9 +330,9 @@ impl<'a> Spec<'a> {
                         })
                         .map(|content| match content {
                             ResponseContent::Json(RefOrSchema::Ref(r)) => {
-                                SpecResponse::Json(arena.alloc(SpecType::Ref(&r.path)))
+                                SpecResponse::Json(arena.alloc(SpecType::Ref(r)))
                             }
-                            ResponseContent::Json(RefOrSchema::Other(schema)) => {
+                            ResponseContent::Json(RefOrSchema::Inline(schema)) => {
                                 SpecResponse::Json(arena.alloc(transform(
                                     arena,
                                     doc,

--- a/ploidy-core/src/ir/transform.rs
+++ b/ploidy-core/src/ir/transform.rs
@@ -98,23 +98,22 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
             for schema in one_of {
                 match schema {
                     RefOrSchema::Ref(r) => {
-                        let name: &_ = self.arena().alloc_str(&r.path.name());
-                        let aliases =
-                            match inverted.get(&r.path).map(|s| s.as_slice()).unwrap_or(&[]) {
-                                // When a discriminator value doesn't have
-                                // an explicit `mapping`, use the schema name.
-                                [] => &[name],
-                                aliases => aliases,
-                            };
+                        let name: &_ = self.arena().alloc_str(&r.name());
+                        let aliases = match inverted.get(r).map(|s| s.as_slice()).unwrap_or(&[]) {
+                            // When a discriminator value doesn't have
+                            // an explicit `mapping`, use the schema name.
+                            [] => &[name],
+                            aliases => aliases,
+                        };
                         variants.push(SpecTaggedVariant {
                             name,
-                            ty: self.arena().alloc(SpecType::Ref(&r.path)),
+                            ty: self.arena().alloc(SpecType::Ref(r)),
                             aliases: self.arena().alloc_slice_copy(aliases),
                         });
                     }
                     // An inline schema variant can't have a discriminator mapping;
                     // fall through to `try_untagged`.
-                    RefOrSchema::Other(_) => return Err(self),
+                    RefOrSchema::Inline(_) => return Err(self),
                 }
             }
             variants
@@ -144,9 +143,9 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
             .map(|(index, schema)| (index + 1, schema))
             .map(|(index, schema)| {
                 let ty = match schema {
-                    RefOrSchema::Ref(r) => Some(SpecType::Ref(&r.path)),
-                    RefOrSchema::Other(s) if matches!(&*s.ty, [Ty::Null]) => None,
-                    RefOrSchema::Other(schema) => {
+                    RefOrSchema::Ref(r) => Some(SpecType::Ref(r)),
+                    RefOrSchema::Inline(s) if matches!(&*s.ty, [Ty::Null]) => None,
+                    RefOrSchema::Inline(schema) => {
                         let segment = InlineTypePathSegment::Variant(index);
                         let path = match self.name {
                             TypeInfo::Schema(info) => InlineTypePath {
@@ -237,8 +236,8 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
             // A single-variant `anyOf` should unwrap to the variant type. This
             // preserves type references that would otherwise become `Any`.
             return Ok(match schema {
-                RefOrSchema::Ref(r) => SpecType::Ref(&r.path),
-                RefOrSchema::Other(schema) => {
+                RefOrSchema::Ref(r) => SpecType::Ref(r),
+                RefOrSchema::Inline(schema) => {
                     let path = match self.name {
                         TypeInfo::Schema(info) => InlineTypePath {
                             root: InlineTypePathRoot::Type(info.name),
@@ -260,17 +259,16 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
                         // For references, use the referenced type's name
                         // as the field name. For example, a pointer like
                         // `#/components/schemas/Address` becomes `address`.
-                        let name = StructFieldName::Name(self.arena().alloc_str(&r.path.name()));
-                        let ty: &_ = self.arena().alloc(SpecType::Ref(&r.path));
+                        let name = StructFieldName::Name(self.arena().alloc_str(&r.name()));
+                        let ty: &_ = self.arena().alloc(SpecType::Ref(r));
                         let desc = r
-                            .path
                             .pointer()
                             .follow::<&Schema>(self.context.doc)
                             .ok()
                             .and_then(|s| s.description.as_deref());
                         (name, ty, desc)
                     }
-                    RefOrSchema::Other(schema) => {
+                    RefOrSchema::Inline(schema) => {
                         // For inline schemas, we don't have a name that we can use,
                         // so use its index in `anyOf` as a naming hint.
                         let name = StructFieldName::Hint(StructFieldNameHint::Index(index + 1));
@@ -453,8 +451,8 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
 
                 (Ty::Array, _) => {
                     let items = match &self.schema.items {
-                        Some(RefOrSchema::Ref(r)) => SpecType::Ref(&r.path),
-                        Some(RefOrSchema::Other(schema)) => {
+                        Some(RefOrSchema::Ref(r)) => SpecType::Ref(r),
+                        Some(RefOrSchema::Inline(schema)) => {
                             let segment = InlineTypePathSegment::ArrayItem;
                             let path = match self.name {
                                 TypeInfo::Schema(info) => InlineTypePath {
@@ -491,10 +489,10 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
                         Some(AdditionalProperties::RefOrSchema(RefOrSchema::Ref(r))) => {
                             Some(SpecInner {
                                 description: self.schema.description.as_deref(),
-                                ty: self.arena().alloc(SpecType::Ref(&r.path)),
+                                ty: self.arena().alloc(SpecType::Ref(r)),
                             })
                         }
-                        Some(AdditionalProperties::RefOrSchema(RefOrSchema::Other(schema))) => {
+                        Some(AdditionalProperties::RefOrSchema(RefOrSchema::Inline(schema))) => {
                             let segment = InlineTypePathSegment::MapValue;
                             let path = match self.name {
                                 TypeInfo::Schema(info) => InlineTypePath {
@@ -617,8 +615,8 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
             .enumerate()
             .map(|(index, parent)| (index + 1, parent))
             .map(move |(index, parent)| &*match parent {
-                RefOrSchema::Ref(r) => self.arena().alloc(SpecType::Ref(&r.path)),
-                RefOrSchema::Other(schema) => {
+                RefOrSchema::Ref(r) => self.arena().alloc(SpecType::Ref(r)),
+                RefOrSchema::Inline(schema) => {
                     let segment = InlineTypePathSegment::Parent(index);
                     let path = match self.name {
                         TypeInfo::Schema(info) => InlineTypePath {
@@ -644,8 +642,8 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
                 let field_name = name.as_str();
                 let required = self.schema.required.contains(name);
                 let ty: &_ = match field_schema {
-                    RefOrSchema::Ref(r) => self.arena().alloc(SpecType::Ref(&r.path)),
-                    RefOrSchema::Other(schema) => {
+                    RefOrSchema::Ref(r) => self.arena().alloc(SpecType::Ref(r)),
+                    RefOrSchema::Inline(schema) => {
                         let segment =
                             InlineTypePathSegment::Field(StructFieldName::Name(field_name));
                         let path = match self.name {
@@ -660,18 +658,16 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
                     }
                 };
                 let description = match field_schema {
-                    RefOrSchema::Other(schema) => schema.description.as_deref(),
+                    RefOrSchema::Inline(schema) => schema.description.as_deref(),
                     RefOrSchema::Ref(r) => r
-                        .path
                         .pointer()
                         .follow::<&Schema>(self.context.doc)
                         .ok()
                         .and_then(|schema| schema.description.as_deref()),
                 };
                 let nullable = match field_schema {
-                    RefOrSchema::Other(schema) if schema.nullable => true,
+                    RefOrSchema::Inline(schema) if schema.nullable => true,
                     RefOrSchema::Ref(r) => r
-                        .path
                         .pointer()
                         .follow::<&Schema>(self.context.doc)
                         .is_ok_and(|schema| schema.nullable),
@@ -725,9 +721,9 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
         let inner = match &self.schema.additional_properties {
             Some(AdditionalProperties::RefOrSchema(RefOrSchema::Ref(r))) => SpecInner {
                 description: self.schema.description.as_deref(),
-                ty: self.arena().alloc(SpecType::Ref(&r.path)),
+                ty: self.arena().alloc(SpecType::Ref(r)),
             },
-            Some(AdditionalProperties::RefOrSchema(RefOrSchema::Other(schema))) => {
+            Some(AdditionalProperties::RefOrSchema(RefOrSchema::Inline(schema))) => {
                 let path = path.join(self.arena(), &[InlineTypePathSegment::MapValue]);
                 SpecInner {
                     description: self.schema.description.as_deref(),

--- a/ploidy-core/src/parse/types.rs
+++ b/ploidy-core/src/parse/types.rs
@@ -230,14 +230,8 @@ pub struct Components {
 
 /// Either a reference to a component or an inline component definition.
 ///
-/// This generic type is used throughout the OpenAPI parse tree to represent
-/// locations where a component can either be defined inline, or referenced via
-/// `$ref`. The [`RefOr::Ref`] variant holds a JSON Pointer to a component definition
-/// in the `#/components/*` section; the [`RefOr::Other`] variant holds an
-/// inline definition.
-///
-/// The type uses `#[serde(untagged)]` to match the OpenAPI specification's
-/// untagged union semantics, and `#[ploidy(pointer(untagged))]` for JSON Pointer traversal.
+/// [`RefOr::Ref`] holds a JSON Pointer to a component definition in the
+/// `#/components/*` section; [`RefOr::Other`] holds an inline definition.
 #[derive(Clone, Debug, Deserialize, JsonPointee, JsonPointerTarget)]
 #[serde(untagged)]
 #[ploidy(pointer(untagged))]
@@ -249,8 +243,38 @@ pub enum RefOr<T> {
     Other(T),
 }
 
-/// Either a reference or a schema definition.
-pub type RefOrSchema = RefOr<Box<Schema>>;
+/// Either a reference or an inline schema definition.
+///
+/// [`RefOrSchema::deserialize`] desugars OpenAPI 3.1-style schemas like
+/// `{ "$ref": "...", "description": "..." }` into the semantically equivalent
+/// `{ "allOf": [{ "$ref": "..." }], "description": "..." }`.
+#[derive(Clone, Debug, JsonPointee, JsonPointerTarget)]
+#[ploidy(pointer(untagged))]
+pub enum RefOrSchema {
+    /// A reference to another schema.
+    #[ploidy(pointer(skip))]
+    Ref(ComponentRef),
+    /// An inline schema definition.
+    Inline(Box<Schema>),
+}
+
+impl<'de> Deserialize<'de> for RefOrSchema {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        match RefOr::deserialize(deserializer)? {
+            RefOr::Other(schema) => Ok(Self::Inline(schema)),
+            RefOr::Ref(r) if r.rest.is_empty() => Ok(Self::Ref(r.ref_)),
+            RefOr::Ref(r) => {
+                let mut schema: Schema =
+                    serde_json::from_value(r.rest.into()).map_err(serde::de::Error::custom)?;
+                schema
+                    .all_of
+                    .get_or_insert_default()
+                    .insert(0, Self::Ref(r.ref_));
+                Ok(Self::Inline(schema.into()))
+            }
+        }
+    }
+}
 
 /// Either a reference or a parameter definition.
 pub type RefOrParameter = RefOr<Parameter>;
@@ -261,11 +285,13 @@ pub type RefOrRequestBody = RefOr<RequestBody>;
 /// Either a reference or a response definition.
 pub type RefOrResponse = RefOr<Response>;
 
-/// A reference to another schema.
+/// A reference to another component.
 #[derive(Debug, Clone, Deserialize)]
 pub struct Ref {
     #[serde(rename = "$ref")]
-    pub path: ComponentRef,
+    pub ref_: ComponentRef,
+    #[serde(flatten)]
+    pub rest: serde_json::Map<String, serde_json::Value>,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, JsonPointee, JsonPointerTarget)]
@@ -478,6 +504,10 @@ impl<'a> FromExtension<'a> for &'a str {
 mod tests {
     use super::*;
 
+    use crate::tests::assert_matches;
+
+    // MARK: `ComponentRef`
+
     #[test]
     fn test_component_ref_name() {
         let r: ComponentRef = "#/components/schemas/Pet".parse().unwrap();
@@ -493,12 +523,69 @@ mod tests {
     #[test]
     fn test_component_ref_rejects_external_ref() {
         let err = "other.yaml#/components/schemas/Pet".parse::<ComponentRef>();
-        assert!(matches!(err, Err(BadComponentRef::NotSameDocument)));
+        assert_matches!(err, Err(BadComponentRef::NotSameDocument));
     }
 
     #[test]
     fn test_component_ref_rejects_empty() {
         let err = "#".parse::<ComponentRef>();
-        assert!(matches!(err, Err(BadComponentRef::Empty)));
+        assert_matches!(err, Err(BadComponentRef::Empty));
+    }
+
+    // MARK: `RefOrSchema`
+
+    #[test]
+    fn test_schema_ref_desugars_adjacent_keywords_into_all_of() {
+        let json = serde_json::json!({
+            "$ref": "#/components/schemas/Pet",
+            "description": "A very good pet",
+        });
+
+        let schema_ref: RefOrSchema = serde_json::from_value(json).unwrap();
+        let RefOrSchema::Inline(schema) = &schema_ref else {
+            panic!("expected `Inline` schema; got `{schema_ref:?}`");
+        };
+        assert_eq!(schema.description.as_deref(), Some("A very good pet"));
+
+        let all_of = schema.all_of.as_ref().unwrap();
+        let [RefOrSchema::Ref(r)] = &**all_of else {
+            panic!("expected one `allOf` schema; got {all_of:?}");
+        };
+        assert_eq!(r.name(), "Pet");
+    }
+
+    #[test]
+    fn test_schema_ref_desugars_adjacent_keywords_merges_existing_all_of() {
+        let json = serde_json::json!({
+            "$ref": "#/components/schemas/Pet",
+            "description": "A very good pet",
+            "allOf": [{ "$ref": "#/components/schemas/Named" }]
+        });
+
+        let schema_ref: RefOrSchema = serde_json::from_value(json).unwrap();
+        let RefOrSchema::Inline(schema) = &schema_ref else {
+            panic!("expected `Inline` schema; got `{schema_ref:?}`");
+        };
+        assert_eq!(schema.description.as_deref(), Some("A very good pet"));
+
+        let all_of = schema.all_of.as_ref().unwrap();
+        let [RefOrSchema::Ref(first), RefOrSchema::Ref(second)] = &**all_of else {
+            panic!("expected two `allOf` schemas; got {all_of:?}");
+        };
+        assert_eq!(first.name(), "Pet");
+        assert_eq!(second.name(), "Named");
+    }
+
+    #[test]
+    fn test_schema_ref_preserves_pure_ref() {
+        let json = serde_json::json!({
+            "$ref": "#/components/schemas/Pet"
+        });
+
+        let schema_ref: RefOrSchema = serde_json::from_value(json).unwrap();
+        let RefOrSchema::Ref(r) = &schema_ref else {
+            panic!("expected schema `Ref`; got `{schema_ref:?}`");
+        };
+        assert_eq!(r.name(), "Pet");
     }
 }


### PR DESCRIPTION
OpenAPI 3.1 (via JSON Schema 2020-12) treats a `$ref` object with additional properties as a subschema that inherits from the referenced schema. These are semantically equivalent to `allOf` composition.

This commit replaces the `RefOrSchema` type alias with a dedicated enum that rewrites `$ref`s with sibling properties into `allOf`s during deserialization.