### PR TITLE
fix(ir): Preserve schema identity through single-variant unwrapping.

### DIFF
--- a/ploidy-core/src/ir/tests/transform.rs
+++ b/ploidy-core/src/ir/tests/transform.rs
@@ -1545,6 +1545,80 @@ fn test_untagged_single_variant_unwraps() {
 }
 
 #[test]
+fn test_untagged_single_inline_object_variant_preserves_schema_identity() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test
+          version: 1.0.0
+    "})
+    .unwrap();
+    let schema: Schema = serde_saphyr::from_str(indoc::indoc! {"
+        oneOf:
+          - type: object
+            properties:
+              data:
+                type: string
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let result = transform(&arena, &doc, "ThreadStreamEvent", &schema);
+
+    // A single inline object variant should unwrap to a `Schema(Struct(...))`
+    // that preserves the original schema name, not an `Inline(Struct(...))`.
+    assert_matches!(
+        result,
+        SpecType::Schema(SpecSchemaType::Struct(
+            SchemaTypeInfo {
+                name: "ThreadStreamEvent",
+                ..
+            },
+            SpecStruct {
+                fields: [SpecStructField {
+                    name: StructFieldName::Name("data"),
+                    ty: SpecType::Inline(..),
+                    ..
+                }],
+                ..
+            },
+        )),
+    );
+}
+
+#[test]
+fn test_untagged_single_inline_primitive_variant_preserves_schema_identity() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test
+          version: 1.0.0
+    "})
+    .unwrap();
+    let schema: Schema = serde_saphyr::from_str(indoc::indoc! {"
+        oneOf:
+          - type: string
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let result = transform(&arena, &doc, "WrappedString", &schema);
+
+    // A single inline primitive variant should unwrap to a
+    // `Schema(Primitive(...))` that preserves the schema name.
+    assert_matches!(
+        result,
+        SpecType::Schema(SpecSchemaType::Primitive(
+            SchemaTypeInfo {
+                name: "WrappedString",
+                ..
+            },
+            PrimitiveType::String,
+        )),
+    );
+}
+
+#[test]
 fn test_untagged_variant_numbering() {
     let doc = Document::from_yaml(indoc::indoc! {"
         openapi: 3.0.0
@@ -1621,6 +1695,80 @@ fn test_untagged_null_detection() {
 }
 
 // MARK: `try_any_of()`
+
+#[test]
+fn test_any_of_single_inline_object_variant_preserves_schema_identity() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test
+          version: 1.0.0
+    "})
+    .unwrap();
+    let schema: Schema = serde_saphyr::from_str(indoc::indoc! {"
+        anyOf:
+          - type: object
+            properties:
+              data:
+                type: string
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let result = transform(&arena, &doc, "EventPayload", &schema);
+
+    // A single inline object variant should unwrap to a `Schema(Struct(...))`
+    // that preserves the original schema name, not an `Inline(Struct(...))`.
+    assert_matches!(
+        result,
+        SpecType::Schema(SpecSchemaType::Struct(
+            SchemaTypeInfo {
+                name: "EventPayload",
+                ..
+            },
+            SpecStruct {
+                fields: [SpecStructField {
+                    name: StructFieldName::Name("data"),
+                    ty: SpecType::Inline(..),
+                    ..
+                }],
+                ..
+            },
+        )),
+    );
+}
+
+#[test]
+fn test_any_of_single_inline_primitive_variant_preserves_schema_identity() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test
+          version: 1.0.0
+    "})
+    .unwrap();
+    let schema: Schema = serde_saphyr::from_str(indoc::indoc! {"
+        anyOf:
+          - type: string
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let result = transform(&arena, &doc, "WrappedString", &schema);
+
+    // A single inline primitive variant should unwrap to a
+    // `Schema(Primitive(...))` that preserves the schema name.
+    assert_matches!(
+        result,
+        SpecType::Schema(SpecSchemaType::Primitive(
+            SchemaTypeInfo {
+                name: "WrappedString",
+                ..
+            },
+            PrimitiveType::String,
+        )),
+    );
+}
 
 #[test]
 fn test_any_of_fields_marked_flattened_not_required() {

--- a/ploidy-core/src/ir/transform.rs
+++ b/ploidy-core/src/ir/transform.rs
@@ -137,27 +137,47 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
             return Err(self);
         };
 
-        let variants = one_of
-            .iter()
-            .enumerate()
-            .map(|(index, schema)| (index + 1, schema))
-            .map(|(index, schema)| {
-                let ty = match schema {
-                    RefOrSchema::Ref(r) => Some(SpecType::Ref(r)),
-                    RefOrSchema::Inline(s) if matches!(&*s.ty, [Ty::Null]) => None,
+        let variants = match &**one_of {
+            [] => {
+                return Ok(match self.name {
+                    TypeInfo::Schema(info) => SpecSchemaType::Any(info).into(),
+                    TypeInfo::Inline(path) => SpecInlineType::Any(path).into(),
+                });
+            }
+            [schema] => {
+                // Unwrap single-variant untagged unions.
+                return Ok(match schema {
+                    RefOrSchema::Ref(r) => SpecType::Ref(r),
+                    RefOrSchema::Inline(s) if matches!(&*s.ty, [Ty::Null]) => match self.name {
+                        TypeInfo::Schema(info) => SpecSchemaType::Any(info).into(),
+                        TypeInfo::Inline(path) => SpecInlineType::Any(path).into(),
+                    },
                     RefOrSchema::Inline(schema) => {
-                        let segment = InlineTypePathSegment::Variant(index);
-                        let path = match self.name {
-                            TypeInfo::Schema(info) => InlineTypePath {
-                                root: InlineTypePathRoot::Type(info.name),
-                                segments: self.arena().alloc_slice_copy(&[segment]),
-                            },
-                            TypeInfo::Inline(path) => path.join(self.arena(), &[segment]),
-                        };
-                        Some(transform_with_context(self.context, path, schema))
+                        transform_with_context(self.context, self.name, schema)
                     }
-                };
-                ty.map(|ty| {
+                });
+            }
+            variants => variants
+                .iter()
+                .enumerate()
+                .map(|(index, schema)| (index + 1, schema))
+                .map(|(index, schema)| {
+                    let ty = match schema {
+                        RefOrSchema::Ref(r) => Some(SpecType::Ref(r)),
+                        RefOrSchema::Inline(s) if matches!(&*s.ty, [Ty::Null]) => None,
+                        RefOrSchema::Inline(schema) => {
+                            let segment = InlineTypePathSegment::Variant(index);
+                            let path = match self.name {
+                                TypeInfo::Schema(info) => InlineTypePath {
+                                    root: InlineTypePathRoot::Type(info.name),
+                                    segments: self.arena().alloc_slice_copy(&[segment]),
+                                },
+                                TypeInfo::Inline(path) => path.join(self.arena(), &[segment]),
+                            };
+                            Some(transform_with_context(self.context, path, schema))
+                        }
+                    };
+                    ty.map(|ty| {
                         let hint = match ty {
                             SpecType::Schema(SpecSchemaType::Primitive(_, p))
                             | SpecType::Inline(SpecInlineType::Primitive(_, p)) => {
@@ -184,22 +204,11 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
                         SpecUntaggedVariant::Some(hint, self.arena().alloc(ty))
                     })
                     .unwrap_or(SpecUntaggedVariant::Null)
-            })
-            .collect_vec();
+                })
+                .collect_vec(),
+        };
 
         Ok(match &*variants {
-            [] => match self.name {
-                TypeInfo::Schema(info) => SpecSchemaType::Any(info).into(),
-                TypeInfo::Inline(path) => SpecInlineType::Any(path).into(),
-            },
-
-            // Unwrap single-variant untagged unions.
-            [SpecUntaggedVariant::Null] => match self.name {
-                TypeInfo::Schema(info) => SpecSchemaType::Any(info).into(),
-                TypeInfo::Inline(path) => SpecInlineType::Any(path).into(),
-            },
-            [SpecUntaggedVariant::Some(_, ty)] => **ty,
-
             // Simplify two-variant untagged unions, where one is a type
             // and the other is `null`, into optionals.
             [SpecUntaggedVariant::Some(_, ty), SpecUntaggedVariant::Null]
@@ -238,14 +247,7 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
             return Ok(match schema {
                 RefOrSchema::Ref(r) => SpecType::Ref(r),
                 RefOrSchema::Inline(schema) => {
-                    let path = match self.name {
-                        TypeInfo::Schema(info) => InlineTypePath {
-                            root: InlineTypePathRoot::Type(info.name),
-                            segments: &[],
-                        },
-                        TypeInfo::Inline(path) => path,
-                    };
-                    transform_with_context(self.context, path, schema)
+                    transform_with_context(self.context, self.name, schema)
                 }
             });
         }


### PR DESCRIPTION
Single-variant `oneOf` and `anyOf` schemas were demoted to inline types during unwrapping, dropping their schema name from the graph.

`IrTransformer::try_untagged()` now checks for single-variants unions before transforming, and passes `self.name` to preserve the original's `TypeInfo::Schema`.