### PR TITLE
fix(codegen): Struct field and variant name hints should participate in uniquification.

### DIFF
--- a/ploidy-codegen-rust/src/naming.rs
+++ b/ploidy-codegen-rust/src/naming.rs
@@ -228,8 +228,8 @@ impl CodegenIdentRef {
     #[ref_cast_custom]
     fn new(s: &str) -> &Self;
 
-    /// Returns a suitable identifier for a struct field that
-    /// doesn't have an explicit name in the spec.
+    /// Returns a suitable identifier for a struct field,
+    /// before uniquification.
     pub fn from_field_name_hint(hint: StructFieldNameHint) -> Cow<'static, Self> {
         match hint {
             StructFieldNameHint::Index(index) => {
@@ -238,6 +238,36 @@ impl CodegenIdentRef {
             StructFieldNameHint::AdditionalProperties => {
                 Cow::Borrowed(Self::new("additional_properties"))
             }
+        }
+    }
+
+    /// Returns a suitable identifier for an untagged union variant,
+    /// before uniquification.
+    pub fn from_variant_name_hint(hint: UntaggedVariantNameHint) -> Cow<'static, Self> {
+        use {PrimitiveType::*, UntaggedVariantNameHint::*};
+        match hint {
+            Primitive(String) => Cow::Borrowed(Self::new("String")),
+            Primitive(I8) => Cow::Borrowed(Self::new("I8")),
+            Primitive(U8) => Cow::Borrowed(Self::new("U8")),
+            Primitive(I16) => Cow::Borrowed(Self::new("I16")),
+            Primitive(U16) => Cow::Borrowed(Self::new("U16")),
+            Primitive(I32) => Cow::Borrowed(Self::new("I32")),
+            Primitive(U32) => Cow::Borrowed(Self::new("U32")),
+            Primitive(I64) => Cow::Borrowed(Self::new("I64")),
+            Primitive(U64) => Cow::Borrowed(Self::new("U64")),
+            Primitive(F32) => Cow::Borrowed(Self::new("F32")),
+            Primitive(F64) => Cow::Borrowed(Self::new("F64")),
+            Primitive(Bool) => Cow::Borrowed(Self::new("Bool")),
+            Primitive(DateTime) => Cow::Borrowed(Self::new("DateTime")),
+            Primitive(UnixTime) => Cow::Borrowed(Self::new("UnixTime")),
+            Primitive(Date) => Cow::Borrowed(Self::new("Date")),
+            Primitive(Url) => Cow::Borrowed(Self::new("Url")),
+            Primitive(Uuid) => Cow::Borrowed(Self::new("Uuid")),
+            Primitive(Bytes) => Cow::Borrowed(Self::new("Bytes")),
+            Primitive(Binary) => Cow::Borrowed(Self::new("Binary")),
+            Array => Cow::Borrowed(Self::new("Array")),
+            Map => Cow::Borrowed(Self::new("Map")),
+            Index(index) => Cow::Owned(CodegenIdent(format!("V{index}"))),
         }
     }
 }
@@ -389,39 +419,10 @@ impl<'a> CodegenIdentScope<'a> {
     pub fn uniquify(&mut self, name: &str) -> CodegenIdent {
         CodegenIdent(self.0.uniquify(&clean(name)).into_owned())
     }
-}
 
-#[derive(Clone, Copy, Debug)]
-pub struct CodegenUntaggedVariantName(pub UntaggedVariantNameHint);
-
-impl ToTokens for CodegenUntaggedVariantName {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        use UntaggedVariantNameHint::*;
-        let s = match self.0 {
-            Primitive(PrimitiveType::String) => "String".into(),
-            Primitive(PrimitiveType::I8) => "I8".into(),
-            Primitive(PrimitiveType::U8) => "U8".into(),
-            Primitive(PrimitiveType::I16) => "I16".into(),
-            Primitive(PrimitiveType::U16) => "U16".into(),
-            Primitive(PrimitiveType::I32) => "I32".into(),
-            Primitive(PrimitiveType::U32) => "U32".into(),
-            Primitive(PrimitiveType::I64) => "I64".into(),
-            Primitive(PrimitiveType::U64) => "U64".into(),
-            Primitive(PrimitiveType::F32) => "F32".into(),
-            Primitive(PrimitiveType::F64) => "F64".into(),
-            Primitive(PrimitiveType::Bool) => "Bool".into(),
-            Primitive(PrimitiveType::DateTime) => "DateTime".into(),
-            Primitive(PrimitiveType::UnixTime) => "UnixTime".into(),
-            Primitive(PrimitiveType::Date) => "Date".into(),
-            Primitive(PrimitiveType::Url) => "Url".into(),
-            Primitive(PrimitiveType::Uuid) => "Uuid".into(),
-            Primitive(PrimitiveType::Bytes) => "Bytes".into(),
-            Primitive(PrimitiveType::Binary) => "Binary".into(),
-            Array => "Array".into(),
-            Map => "Map".into(),
-            Index(index) => Cow::Owned(format!("V{index}")),
-        };
-        tokens.append(Ident::new(&s, Span::call_site()));
+    /// Uniquifies an identifier within this scope.
+    pub fn uniquify_ident(&mut self, ident: &CodegenIdentRef) -> CodegenIdent {
+        CodegenIdent(self.0.uniquify(&ident.0).into_owned())
     }
 }
 
@@ -621,131 +622,12 @@ mod tests {
     // MARK: Untagged variant names
 
     #[test]
-    fn test_untagged_variant_name_string() {
-        let variant_name =
-            CodegenUntaggedVariantName(UntaggedVariantNameHint::Primitive(PrimitiveType::String));
-        let actual: syn::Ident = parse_quote!(#variant_name);
-        let expected: syn::Ident = parse_quote!(String);
-        assert_eq!(actual, expected);
-    }
-
-    #[test]
-    fn test_untagged_variant_name_i32() {
-        let variant_name =
-            CodegenUntaggedVariantName(UntaggedVariantNameHint::Primitive(PrimitiveType::I32));
-        let actual: syn::Ident = parse_quote!(#variant_name);
-        let expected: syn::Ident = parse_quote!(I32);
-        assert_eq!(actual, expected);
-    }
-
-    #[test]
-    fn test_untagged_variant_name_i64() {
-        let variant_name =
-            CodegenUntaggedVariantName(UntaggedVariantNameHint::Primitive(PrimitiveType::I64));
-        let actual: syn::Ident = parse_quote!(#variant_name);
-        let expected: syn::Ident = parse_quote!(I64);
-        assert_eq!(actual, expected);
-    }
-
-    #[test]
-    fn test_untagged_variant_name_f32() {
-        let variant_name =
-            CodegenUntaggedVariantName(UntaggedVariantNameHint::Primitive(PrimitiveType::F32));
-        let actual: syn::Ident = parse_quote!(#variant_name);
-        let expected: syn::Ident = parse_quote!(F32);
-        assert_eq!(actual, expected);
-    }
-
-    #[test]
-    fn test_untagged_variant_name_f64() {
-        let variant_name =
-            CodegenUntaggedVariantName(UntaggedVariantNameHint::Primitive(PrimitiveType::F64));
-        let actual: syn::Ident = parse_quote!(#variant_name);
-        let expected: syn::Ident = parse_quote!(F64);
-        assert_eq!(actual, expected);
-    }
-
-    #[test]
-    fn test_untagged_variant_name_bool() {
-        let variant_name =
-            CodegenUntaggedVariantName(UntaggedVariantNameHint::Primitive(PrimitiveType::Bool));
-        let actual: syn::Ident = parse_quote!(#variant_name);
-        let expected: syn::Ident = parse_quote!(Bool);
-        assert_eq!(actual, expected);
-    }
-
-    #[test]
-    fn test_untagged_variant_name_datetime() {
-        let variant_name =
-            CodegenUntaggedVariantName(UntaggedVariantNameHint::Primitive(PrimitiveType::DateTime));
-        let actual: syn::Ident = parse_quote!(#variant_name);
-        let expected: syn::Ident = parse_quote!(DateTime);
-        assert_eq!(actual, expected);
-    }
-
-    #[test]
-    fn test_untagged_variant_name_date() {
-        let variant_name =
-            CodegenUntaggedVariantName(UntaggedVariantNameHint::Primitive(PrimitiveType::Date));
-        let actual: syn::Ident = parse_quote!(#variant_name);
-        let expected: syn::Ident = parse_quote!(Date);
-        assert_eq!(actual, expected);
-    }
-
-    #[test]
-    fn test_untagged_variant_name_url() {
-        let variant_name =
-            CodegenUntaggedVariantName(UntaggedVariantNameHint::Primitive(PrimitiveType::Url));
-        let actual: syn::Ident = parse_quote!(#variant_name);
-        let expected: syn::Ident = parse_quote!(Url);
-        assert_eq!(actual, expected);
-    }
-
-    #[test]
-    fn test_untagged_variant_name_uuid() {
-        let variant_name =
-            CodegenUntaggedVariantName(UntaggedVariantNameHint::Primitive(PrimitiveType::Uuid));
-        let actual: syn::Ident = parse_quote!(#variant_name);
-        let expected: syn::Ident = parse_quote!(Uuid);
-        assert_eq!(actual, expected);
-    }
-
-    #[test]
-    fn test_untagged_variant_name_bytes() {
-        let variant_name =
-            CodegenUntaggedVariantName(UntaggedVariantNameHint::Primitive(PrimitiveType::Bytes));
-        let actual: syn::Ident = parse_quote!(#variant_name);
-        let expected: syn::Ident = parse_quote!(Bytes);
-        assert_eq!(actual, expected);
-    }
-
-    #[test]
     fn test_untagged_variant_name_index() {
-        let variant_name = CodegenUntaggedVariantName(UntaggedVariantNameHint::Index(0));
-        let actual: syn::Ident = parse_quote!(#variant_name);
-        let expected: syn::Ident = parse_quote!(V0);
-        assert_eq!(actual, expected);
+        let name = CodegenIdentRef::from_variant_name_hint(UntaggedVariantNameHint::Index(0));
+        assert_eq!(&*name, CodegenIdentRef::new("V0"));
 
-        let variant_name = CodegenUntaggedVariantName(UntaggedVariantNameHint::Index(42));
-        let actual: syn::Ident = parse_quote!(#variant_name);
-        let expected: syn::Ident = parse_quote!(V42);
-        assert_eq!(actual, expected);
-    }
-
-    #[test]
-    fn test_untagged_variant_name_array() {
-        let variant_name = CodegenUntaggedVariantName(UntaggedVariantNameHint::Array);
-        let actual: syn::Ident = parse_quote!(#variant_name);
-        let expected: syn::Ident = parse_quote!(Array);
-        assert_eq!(actual, expected);
-    }
-
-    #[test]
-    fn test_untagged_variant_name_map() {
-        let variant_name = CodegenUntaggedVariantName(UntaggedVariantNameHint::Map);
-        let actual: syn::Ident = parse_quote!(#variant_name);
-        let expected: syn::Ident = parse_quote!(Map);
-        assert_eq!(actual, expected);
+        let name = CodegenIdentRef::from_variant_name_hint(UntaggedVariantNameHint::Index(42));
+        assert_eq!(&*name, CodegenIdentRef::new("V42"));
     }
 
     // MARK: Struct field names

--- a/ploidy-codegen-rust/src/struct_.rs
+++ b/ploidy-codegen-rust/src/struct_.rs
@@ -1,9 +1,7 @@
-use std::borrow::Cow;
-
 use itertools::Itertools;
 use ploidy_core::{
     codegen::UniqueNames,
-    ir::{Required, StructFieldName, StructFieldNameHint, StructFieldView, StructView, View},
+    ir::{Required, StructFieldName, StructFieldView, StructView, View},
 };
 use proc_macro2::TokenStream;
 use quote::{ToTokens, TokenStreamExt, quote};
@@ -31,20 +29,7 @@ impl<'a> CodegenStruct<'a> {
 impl ToTokens for CodegenStruct<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let unique = UniqueNames::new();
-        let mut scope = {
-            if self.ty.fields().any(|f| {
-                matches!(
-                    f.name(),
-                    StructFieldName::Hint(StructFieldNameHint::AdditionalProperties)
-                )
-            }) {
-                // Make sure the `additional_properties` field that we emit
-                // doesn't conflict with a schema property of the same name.
-                CodegenIdentScope::with_reserved(&unique, &["additional_properties"])
-            } else {
-                CodegenIdentScope::new(&unique)
-            }
-        };
+        let mut scope = CodegenIdentScope::new(&unique);
         let fields = self
             .ty
             .fields()
@@ -53,8 +38,10 @@ impl ToTokens for CodegenStruct<'_> {
                 let doc_attrs = field.description().map(doc_attrs);
 
                 let name = match field.name() {
-                    StructFieldName::Name(n) => Cow::Owned(scope.uniquify(n)),
-                    StructFieldName::Hint(hint) => CodegenIdentRef::from_field_name_hint(hint),
+                    StructFieldName::Name(n) => scope.uniquify(n),
+                    StructFieldName::Hint(hint) => {
+                        scope.uniquify_ident(&CodegenIdentRef::from_field_name_hint(hint))
+                    }
                 };
                 let field_name = CodegenIdentUsage::Field(&name);
                 let field_attrs = StructFieldAttrs::new(field_name, &field);
@@ -2826,6 +2813,60 @@ mod tests {
             pub struct Pet {
                 pub name: ::std::string::String,
                 pub status: ::std::option::Option<crate::types::Status>,
+            }
+        };
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_struct_deduplicates_additional_properties_collision() {
+        // When a struct has both an own property named `additionalProperties`
+        // _and_ an `additionalProperties` schema, the hint field should be
+        // uniquified to avoid collision. The named property claims the
+        // unsuffixed name, since own properties take precedence over
+        // additional properties in the IR.
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Config:
+                  type: object
+                  additionalProperties:
+                    type: string
+                  properties:
+                    additionalProperties:
+                      type: boolean
+        "})
+        .unwrap();
+
+        let arena = Arena::new();
+        let spec = Spec::from_doc(&arena, &doc).unwrap();
+        let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
+
+        let schema = graph.schemas().find(|s| s.name() == "Config");
+        let Some(schema @ SchemaTypeView::Struct(_, struct_view)) = &schema else {
+            panic!("expected struct `Config`; got `{schema:?}`");
+        };
+
+        let name = CodegenTypeName::Schema(schema);
+        let codegen = CodegenStruct::new(name, struct_view);
+
+        let actual: syn::ItemStruct = parse_quote!(#codegen);
+        let expected: syn::ItemStruct = parse_quote! {
+            #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
+            #[serde(crate = "::ploidy_util::serde")]
+            #[ploidy(pointer(crate = "::ploidy_util::pointer"))]
+            pub struct Config {
+                #[serde(rename = "additionalProperties", default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent")]
+                #[ploidy(pointer(rename = "additionalProperties"))]
+                pub additional_properties: ::ploidy_util::absent::AbsentOr<bool>,
+                #[serde(flatten)]
+                #[ploidy(pointer(flatten))]
+                pub additional_properties2: ::std::collections::BTreeMap<::std::string::String, ::std::string::String>,
             }
         };
         assert_eq!(actual, expected);

--- a/ploidy-codegen-rust/src/untagged.rs
+++ b/ploidy-codegen-rust/src/untagged.rs
@@ -1,11 +1,14 @@
-use ploidy_core::ir::{UntaggedView, View};
+use ploidy_core::{
+    codegen::UniqueNames,
+    ir::{UntaggedView, View},
+};
 use proc_macro2::TokenStream;
 use quote::{ToTokens, TokenStreamExt, quote};
 
 use super::{
     derives::ExtraDerive,
     doc_attrs,
-    naming::{CodegenTypeName, CodegenUntaggedVariantName},
+    naming::{CodegenIdentRef, CodegenIdentScope, CodegenIdentUsage, CodegenTypeName},
     ref_::CodegenRef,
 };
 
@@ -23,16 +26,24 @@ impl<'a> CodegenUntagged<'a> {
 
 impl ToTokens for CodegenUntagged<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
+        let unique = UniqueNames::new();
+        let mut scope = CodegenIdentScope::new(&unique);
         let mut variants = Vec::new();
 
         for variant in self.ty.variants() {
             match variant.ty() {
                 Some(variant) => {
-                    let variant_name = CodegenUntaggedVariantName(variant.hint);
+                    let base = CodegenIdentRef::from_variant_name_hint(variant.hint);
+                    let ident = scope.uniquify_ident(&base);
+                    let variant_name = CodegenIdentUsage::Variant(&ident);
                     let rust_type = CodegenRef::new(&variant.view);
                     variants.push(quote! { #variant_name(#rust_type) });
                 }
-                None => variants.push(quote! { None }),
+                None => {
+                    let ident = scope.uniquify("None");
+                    let variant_name = CodegenIdentUsage::Variant(&ident);
+                    variants.push(quote! { #variant_name });
+                }
             }
         }
 
@@ -335,6 +346,103 @@ mod tests {
             pub enum StringOrDouble {
                 String(::std::string::String),
                 F64(f64)
+            }
+        };
+        assert_eq!(actual, expected);
+    }
+
+    // MARK: Deduplication
+
+    #[test]
+    fn test_untagged_union_deduplicates_array_variants() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Input:
+                  oneOf:
+                    - type: string
+                    - type: array
+                      items:
+                        type: string
+                    - type: array
+                      items:
+                        type: object
+                        properties:
+                          kind:
+                            type: string
+        "})
+        .unwrap();
+
+        let arena = Arena::new();
+        let spec = Spec::from_doc(&arena, &doc).unwrap();
+        let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
+
+        let schema = graph.schemas().find(|s| s.name() == "Input");
+        let Some(schema @ SchemaTypeView::Untagged(_, untagged_view)) = &schema else {
+            panic!("expected untagged union `Input`; got `{schema:?}`");
+        };
+
+        let name = CodegenTypeName::Schema(schema);
+        let untagged = CodegenUntagged::new(name, untagged_view);
+
+        let actual: syn::ItemEnum = parse_quote!(#untagged);
+        let expected: syn::ItemEnum = parse_quote! {
+            #[derive(Debug, Clone, PartialEq, Eq, Hash, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
+            #[serde(crate = "::ploidy_util::serde", untagged)]
+            #[ploidy(pointer(crate = "::ploidy_util::pointer", untagged))]
+            pub enum Input {
+                String(::std::string::String),
+                Array(::std::vec::Vec<::std::string::String>),
+                Array2(::std::vec::Vec<crate::types::input::types::V3Item>)
+            }
+        };
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_untagged_union_deduplicates_multiple_null_variants() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.1.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Weird:
+                  oneOf:
+                    - type: string
+                    - type: 'null'
+                    - type: 'null'
+        "})
+        .unwrap();
+
+        let arena = Arena::new();
+        let spec = Spec::from_doc(&arena, &doc).unwrap();
+        let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
+
+        let schema = graph.schemas().find(|s| s.name() == "Weird");
+        let Some(schema @ SchemaTypeView::Untagged(_, untagged_view)) = &schema else {
+            panic!("expected untagged union `Weird`; got `{schema:?}`");
+        };
+
+        let name = CodegenTypeName::Schema(schema);
+        let untagged = CodegenUntagged::new(name, untagged_view);
+
+        let actual: syn::ItemEnum = parse_quote!(#untagged);
+        let expected: syn::ItemEnum = parse_quote! {
+            #[derive(Debug, Clone, PartialEq, Eq, Hash, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
+            #[serde(crate = "::ploidy_util::serde", untagged)]
+            #[ploidy(pointer(crate = "::ploidy_util::pointer", untagged))]
+            pub enum Weird {
+                String(::std::string::String),
+                None,
+                None2
             }
         };
         assert_eq!(actual, expected);


### PR DESCRIPTION
Untagged variants with the same type hint (for example, a `oneOf` schema with multiple inline `array` subschemas, like `CreateCompletionRequest` in OpenAI's spec) produced duplicate enum variant names, breaking compilation.

Struct field names didn't have the same problem, since their only static hint is `AdditionalProperties`, but the logic to conditionally reserve `additional_properties` was convoluted and fragile. The `uniquify_ident()` method that we added for variants can help here, too.