### PR TITLE
fix: Support literal query parameters in path templates and `.request()`arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1147,6 +1147,7 @@ dependencies = [
  "bumpalo",
  "either",
  "fixedbitset",
+ "form_urlencoded",
  "indexmap",
  "indoc",
  "itertools",

--- a/ploidy-codegen-rust/src/client.rs
+++ b/ploidy-codegen-rust/src/client.rs
@@ -50,7 +50,7 @@ impl ToTokens for CodegenClientModule<'_> {
             }
 
             impl Client {
-                /// Create a new client.
+                /// Creates a new client.
                 pub fn new(base_url: impl AsRef<str>) -> Result<Self, crate::error::Error> {
                     Ok(Self::with_reqwest_client(
                         ::ploidy_util::reqwest::Client::new(),
@@ -130,24 +130,38 @@ impl ToTokens for CodegenClientModule<'_> {
 
                 /// Returns a raw [`RequestBuilder`].
                 ///
-                /// The builder sets the base URL and default headers. Use this for
-                /// requests that the typed client methods don't support.
+                /// Constructs the request URL by appending `path_and_query`
+                /// to the base URL's path and query, respectively. For example,
+                /// given a base URL of `https://api.example.com/v1` and a
+                /// `path_and_query` of `/pets/list?limit=10`, the request URL is
+                /// `https://api.example.com/v1/pets/list?limit=10`.
+                ///
+                /// The request includes the client's default headers.
+                ///
+                /// Use this for requests that the typed client methods
+                /// don't support.
                 ///
                 /// [`RequestBuilder`]: crate::util::reqwest::RequestBuilder
                 pub fn request(
                     &self,
                     method: crate::util::reqwest::Method,
-                    path: &str,
-                ) -> crate::util::reqwest::RequestBuilder {
+                    path_and_query: &str,
+                ) -> Result<crate::util::reqwest::RequestBuilder, crate::error::Error> {
+                    let parts: ::ploidy_util::http::uri::PathAndQuery = path_and_query.parse()?;
                     let mut url = self.base_url.clone();
                     let _ = url
                         .path_segments_mut()
                         .map(|mut segments| {
-                            segments.pop_if_empty().extend(path.split('/'));
+                            segments.pop_if_empty()
+                                .extend(parts.path().split('/'));
                         });
-                    self.client
+                    if let Some(query) = parts.query() {
+                        url.query_pairs_mut()
+                            .extend_pairs(::ploidy_util::url::form_urlencoded::parse(query.as_bytes()));
+                    }
+                    Ok(self.client
                         .request(method, url)
-                        .headers(self.headers.clone())
+                        .headers(self.headers.clone()))
                 }
             }
 

--- a/ploidy-codegen-rust/src/operation.rs
+++ b/ploidy-codegen-rust/src/operation.rs
@@ -72,6 +72,23 @@ impl<'a> CodegenOperation<'a> {
                     quote! { &format!(#format, #(#args),*) }
                 }
             });
+        let query = self
+            .op
+            .path()
+            .query()
+            .map(|param| {
+                let name = param.name;
+                let value = param.value;
+                quote! { .append_pair(#name, #value) }
+            })
+            .reduce(|a, b| quote!(#a #b))
+            .map(|pairs| {
+                quote! {
+                    url.query_pairs_mut()
+                        #pairs;
+                }
+            });
+
         quote! {
             let url = {
                 let mut url = self.base_url.clone();
@@ -81,6 +98,7 @@ impl<'a> CodegenOperation<'a> {
                         segments.pop_if_empty()
                             #(.push(#segments))*;
                     });
+                #query
                 url
             };
         }
@@ -679,6 +697,267 @@ mod tests {
                     .error_for_status()?;
                 let _ = response;
                 Ok(())
+            }
+        };
+        assert_eq!(actual, expected);
+    }
+
+    // MARK: Literal query params in path
+
+    #[test]
+    fn test_operation_with_literal_query_params() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths:
+              /v1/messages?beta=true&expand:
+                post:
+                  operationId: betaCreateMessage
+                  requestBody:
+                    content:
+                      application/json:
+                        schema:
+                          $ref: '#/components/schemas/Message'
+                  responses:
+                    '200':
+                      description: OK
+                      content:
+                        application/json:
+                          schema:
+                            $ref: '#/components/schemas/Message'
+            components:
+              schemas:
+                Message:
+                  type: object
+                  properties:
+                    content:
+                      type: string
+        "})
+        .unwrap();
+
+        let arena = Arena::new();
+        let spec = Spec::from_doc(&arena, &doc).unwrap();
+        let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
+
+        let op = graph.operations().next().unwrap();
+        let codegen = CodegenOperation::new(&op);
+
+        let actual: syn::ImplItemFn = parse_quote!(#codegen);
+        let expected: syn::ImplItemFn = parse_quote! {
+            pub async fn beta_create_message(
+                &self,
+                request: impl Into<crate::types::Message>
+            ) -> Result<crate::types::Message, crate::error::Error> {
+                let url = {
+                    let mut url = self.base_url.clone();
+                    let _ = url
+                        .path_segments_mut()
+                        .map(|mut segments| {
+                            segments.pop_if_empty()
+                                .push("v1")
+                                .push("messages");
+                        });
+                    url.query_pairs_mut()
+                        .append_pair("beta", "true")
+                        .append_pair("expand", "");
+                    url
+                };
+                let response = self
+                    .client
+                    .post(url)
+                    .headers(self.headers.clone())
+                    .json(&request.into())
+                    .send()
+                    .await?
+                    .error_for_status()?;
+                let body = response.bytes().await?;
+                let deserializer = &mut ::ploidy_util::serde_json::Deserializer::from_slice(&body);
+                let result = ::ploidy_util::serde_path_to_error::deserialize(deserializer)
+                    .map_err(crate::error::JsonError::from)?;
+                Ok(result)
+            }
+        };
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_operation_with_literal_and_declared_query_params() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths:
+              /v1/messages?beta=true:
+                post:
+                  operationId: betaCreateMessage
+                  parameters:
+                    - name: limit
+                      in: query
+                      schema:
+                        type: integer
+                        format: int32
+                  requestBody:
+                    content:
+                      application/json:
+                        schema:
+                          $ref: '#/components/schemas/Message'
+                  responses:
+                    '200':
+                      description: OK
+                      content:
+                        application/json:
+                          schema:
+                            $ref: '#/components/schemas/Message'
+            components:
+              schemas:
+                Message:
+                  type: object
+                  properties:
+                    content:
+                      type: string
+        "})
+        .unwrap();
+
+        let arena = Arena::new();
+        let spec = Spec::from_doc(&arena, &doc).unwrap();
+        let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
+
+        let op = graph.operations().next().unwrap();
+        let codegen = CodegenOperation::new(&op);
+
+        let actual: syn::ImplItemFn = parse_quote!(#codegen);
+        let expected: syn::ImplItemFn = parse_quote! {
+            pub async fn beta_create_message(
+                &self,
+                query: &parameters::BetaCreateMessageQuery,
+                request: impl Into<crate::types::Message>
+            ) -> Result<crate::types::Message, crate::error::Error> {
+                let url = {
+                    let mut url = self.base_url.clone();
+                    let _ = url
+                        .path_segments_mut()
+                        .map(|mut segments| {
+                            segments.pop_if_empty()
+                                .push("v1")
+                                .push("messages");
+                        });
+                    url.query_pairs_mut()
+                        .append_pair("beta", "true");
+                    url
+                };
+                let url = ::ploidy_util::serde::Serialize::serialize(
+                    query,
+                    ::ploidy_util::QuerySerializer::new(
+                        url,
+                        parameters::BetaCreateMessageQuery::STYLES,
+                    ),
+                )?;
+                let response = self
+                    .client
+                    .post(url)
+                    .headers(self.headers.clone())
+                    .json(&request.into())
+                    .send()
+                    .await?
+                    .error_for_status()?;
+                let body = response.bytes().await?;
+                let deserializer = &mut ::ploidy_util::serde_json::Deserializer::from_slice(&body);
+                let result = ::ploidy_util::serde_path_to_error::deserialize(deserializer)
+                    .map_err(crate::error::JsonError::from)?;
+                Ok(result)
+            }
+        };
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_operation_with_path_params_and_literal_and_declared_query_params() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths:
+              /v1/models/{model_id}?beta=true:
+                get:
+                  operationId: betaGetModel
+                  parameters:
+                    - name: model_id
+                      in: path
+                      required: true
+                      schema:
+                        type: string
+                    - name: expand
+                      in: query
+                      schema:
+                        type: boolean
+                  responses:
+                    '200':
+                      description: OK
+                      content:
+                        application/json:
+                          schema:
+                            $ref: '#/components/schemas/Model'
+            components:
+              schemas:
+                Model:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+        "})
+        .unwrap();
+
+        let arena = Arena::new();
+        let spec = Spec::from_doc(&arena, &doc).unwrap();
+        let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
+
+        let op = graph.operations().next().unwrap();
+        let codegen = CodegenOperation::new(&op);
+
+        let actual: syn::ImplItemFn = parse_quote!(#codegen);
+        let expected: syn::ImplItemFn = parse_quote! {
+            pub async fn beta_get_model(
+                &self,
+                model_id: &str,
+                query: &parameters::BetaGetModelQuery
+            ) -> Result<crate::types::Model, crate::error::Error> {
+                let url = {
+                    let mut url = self.base_url.clone();
+                    let _ = url
+                        .path_segments_mut()
+                        .map(|mut segments| {
+                            segments.pop_if_empty()
+                                .push("v1")
+                                .push("models")
+                                .push(model_id);
+                        });
+                    url.query_pairs_mut()
+                        .append_pair("beta", "true");
+                    url
+                };
+                let url = ::ploidy_util::serde::Serialize::serialize(
+                    query,
+                    ::ploidy_util::QuerySerializer::new(
+                        url,
+                        parameters::BetaGetModelQuery::STYLES,
+                    ),
+                )?;
+                let response = self
+                    .client
+                    .get(url)
+                    .headers(self.headers.clone())
+                    .send()
+                    .await?
+                    .error_for_status()?;
+                let body = response.bytes().await?;
+                let deserializer = &mut ::ploidy_util::serde_json::Deserializer::from_slice(&body);
+                let result = ::ploidy_util::serde_path_to_error::deserialize(deserializer)
+                    .map_err(crate::error::JsonError::from)?;
+                Ok(result)
             }
         };
         assert_eq!(actual, expected);

--- a/ploidy-core/Cargo.toml
+++ b/ploidy-core/Cargo.toml
@@ -14,6 +14,7 @@ atomic_refcell = "0.1"
 bumpalo = { version = "3", features = ["collections"] }
 either = { workspace = true }
 fixedbitset = "0.5"
+form_urlencoded = "1"
 indexmap = { version = "2", features = ["serde"] }
 itertools = "0.14"
 miette = "7"

--- a/ploidy-core/src/ir/spec.rs
+++ b/ploidy-core/src/ir/spec.rs
@@ -8,7 +8,7 @@ use crate::{
         self, Document, Info, Method, Operation, Parameter, ParameterLocation,
         ParameterStyle as ParsedParameterStyle, RefOrParameter, RefOrRequestBody, RefOrResponse,
         RefOrSchema, RequestBody, Response,
-        path::{PathFragment, PathSegment},
+        path::{ParsedPath, PathFragment},
     },
 };
 
@@ -71,10 +71,9 @@ impl<'a> Spec<'a> {
             .paths
             .iter()
             .map(|(path, item)| {
-                let segments: &_ =
-                    arena.alloc_slice_copy(&parse::path::parse(arena, path.as_str())?);
+                let path = parse::path::parse(arena, path.as_str())?;
                 Ok(item.operations().map(move |(method, op)| PathOperation {
-                    path: segments,
+                    path,
                     method,
                     params: &item.parameters,
                     op,
@@ -119,6 +118,7 @@ impl<'a> Spec<'a> {
                     let mut sources = {
                         let mut seen = FxHashSet::default();
                         item.path
+                            .segments
                             .iter()
                             .flat_map(|segment| segment.fragments())
                             .filter_map(|fragment| match fragment {
@@ -422,7 +422,7 @@ enum ResponseContent<'a> {
 
 #[derive(Clone, Copy, Debug)]
 struct PathOperation<'a> {
-    path: &'a [PathSegment<'a>],
+    path: ParsedPath<'a>,
     method: Method,
     params: &'a [RefOrParameter],
     op: &'a Operation,

--- a/ploidy-core/src/ir/tests/spec.rs
+++ b/ploidy-core/src/ir/tests/spec.rs
@@ -11,7 +11,7 @@ use crate::{
             SpecParameterInfo, SpecRequest, SpecResponse, SpecType,
         },
     },
-    parse::{Document, Method},
+    parse::{Document, Method, path::ParsedPath},
     tests::assert_matches,
 };
 
@@ -149,7 +149,16 @@ fn test_parses_path_with_parameter_segments() {
     let arena = Arena::new();
     let ir = Spec::from_doc(&arena, &doc).unwrap();
 
-    assert_matches!(&*ir.operations, [SpecOperation { path: [_, _], .. }]);
+    assert_matches!(
+        &*ir.operations,
+        [SpecOperation {
+            path: ParsedPath {
+                segments: [_, _],
+                ..
+            },
+            ..
+        }],
+    );
 }
 
 // MARK: Path parameters

--- a/ploidy-core/src/ir/types/shape.rs
+++ b/ploidy-core/src/ir/types/shape.rs
@@ -1,7 +1,7 @@
 //! Generic operation types, parameterized over the type reference
 //! representation. Used by both spec and graph layers.
 
-use crate::parse::{Method, path::PathSegment};
+use crate::parse::{Method, path::ParsedPath};
 
 use super::ParameterStyle;
 
@@ -9,7 +9,7 @@ use super::ParameterStyle;
 pub struct Operation<'a, Ty> {
     pub id: &'a str,
     pub method: Method,
-    pub path: &'a [PathSegment<'a>],
+    pub path: ParsedPath<'a>,
     pub resource: Option<&'a str>,
     pub description: Option<&'a str>,
     pub params: &'a [Parameter<'a, Ty>],

--- a/ploidy-core/src/ir/views/operation.rs
+++ b/ploidy-core/src/ir/views/operation.rs
@@ -69,7 +69,10 @@ use crate::{
             GraphType, ParameterStyle,
         },
     },
-    parse::{Method, path::PathSegment},
+    parse::{
+        Method,
+        path::{PathQueryParameter, PathSegment},
+    },
 };
 
 use super::{View, inline::InlineTypeView, ir::TypeView};
@@ -223,7 +226,14 @@ impl<'view, 'a> OperationViewPath<'view, 'a> {
     /// Returns an iterator over this path's segments.
     #[inline]
     pub fn segments(self) -> std::slice::Iter<'view, PathSegment<'a>> {
-        self.0.op.path.iter()
+        self.0.op.path.segments.iter()
+    }
+
+    /// Returns an iterator over any literal query parameters
+    /// after the path template.
+    #[inline]
+    pub fn query(self) -> std::slice::Iter<'view, PathQueryParameter<'a>> {
+        self.0.op.path.query.iter()
     }
 
     /// Returns an iterator over this operation's path parameters.

--- a/ploidy-core/src/parse/path.rs
+++ b/ploidy-core/src/parse/path.rs
@@ -13,18 +13,38 @@ type Input<'a> = Stateful<&'a str, &'a Arena>;
 /// Parses a path template, like `/v1/pets/{petId}/toy`.
 ///
 /// The grammar for path templating is adapted directly from
-/// [the OpenAPI spec][spec].
+/// [the OpenAPI spec][spec], and supports trailing literal
+/// query parameters as an extension.
 ///
 /// [spec]: https://spec.openapis.org/oas/v3.2.0.html#x4-8-2-path-templating
-pub fn parse<'a>(arena: &'a Arena, input: &'a str) -> Result<Vec<PathSegment<'a>>, BadPath> {
+pub fn parse<'a>(arena: &'a Arena, input: &'a str) -> Result<ParsedPath<'a>, BadPath> {
     let stateful = Input {
         input,
         state: arena,
     };
-    (self::parser::template, eof)
-        .map(|(segments, _)| segments)
+    (self::parser::path, eof)
+        .map(|((segments, query), _)| ParsedPath {
+            segments: arena.alloc_slice_copy(&segments),
+            query: arena.alloc_slice_copy(&query),
+        })
         .parse(stateful)
         .map_err(BadPath::from_parse_error)
+}
+
+/// A parsed path template.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct ParsedPath<'a> {
+    /// The slash-delimited path segments.
+    pub segments: &'a [PathSegment<'a>],
+    /// Literal query parameters that follow the path.
+    pub query: &'a [PathQueryParameter<'a>],
+}
+
+/// A literal query parameter parsed from the path template.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct PathQueryParameter<'a> {
+    pub name: &'a str,
+    pub value: &'a str,
 }
 
 /// A slash-delimited path segment that contains zero or more
@@ -55,11 +75,36 @@ mod parser {
 
     use winnow::{
         Parser,
-        combinator::{alt, delimited, repeat},
+        combinator::{alt, delimited, opt, preceded, repeat},
         token::take_while,
     };
 
-    pub fn template<'a>(input: &mut Input<'a>) -> winnow::Result<Vec<PathSegment<'a>>> {
+    pub fn path<'a>(
+        input: &mut Input<'a>,
+    ) -> winnow::Result<(Vec<PathSegment<'a>>, Vec<PathQueryParameter<'a>>)> {
+        let segments = template.parse_next(input)?;
+        let query = opt(preceded(
+            '?',
+            take_while(0.., is_query_char).map(|query: &str| {
+                form_urlencoded::parse(query.as_bytes())
+                    .map(|(name, value)| PathQueryParameter {
+                        name: match name {
+                            Cow::Borrowed(name) => name,
+                            Cow::Owned(name) => input.state.alloc_str(&name),
+                        },
+                        value: match value {
+                            Cow::Borrowed(value) => value,
+                            Cow::Owned(value) => input.state.alloc_str(&value),
+                        },
+                    })
+                    .collect()
+            }),
+        ))
+        .parse_next(input)?;
+        Ok((segments, query.unwrap_or_default()))
+    }
+
+    fn template<'a>(input: &mut Input<'a>) -> winnow::Result<Vec<PathSegment<'a>>> {
         alt((
             ('/', segment, template)
                 .map(|(_, head, tail)| std::iter::once(head).chain(tail).collect()),
@@ -86,24 +131,36 @@ mod parser {
     }
 
     pub fn literal<'a>(input: &mut Input<'a>) -> winnow::Result<PathFragment<'a>> {
-        take_while(1.., |c| {
-            matches!(c,
-                'A'..='Z' | 'a'..='z' | '0'..='9' |
-                '-' | '.' | '_' | '~' | ':' | '@' |
-                '!' | '$' | '&' | '\'' | '(' | ')' |
-                '*' | '+' | ',' | ';' | '=' | '%'
-            )
-        })
-        .verify_map(|text: &str| {
-            let decoded = percent_encoding::percent_decode_str(text)
-                .decode_utf8()
-                .ok()?;
-            Some(PathFragment::Literal(match decoded {
-                Cow::Borrowed(s) => s,
-                Cow::Owned(s) => input.state.alloc_str(&s),
-            }))
-        })
-        .parse_next(input)
+        take_while(1.., is_path_char)
+            .verify_map(|text: &str| {
+                let decoded = percent_encoding::percent_decode_str(text)
+                    .decode_utf8()
+                    .ok()?;
+                Some(PathFragment::Literal(match decoded {
+                    Cow::Borrowed(s) => s,
+                    Cow::Owned(s) => input.state.alloc_str(&s),
+                }))
+            })
+            .parse_next(input)
+    }
+
+    /// Returns whether `c` is allowed in a URL path segment per
+    /// the WHATWG URL Standard's [path percent-encode set][set].
+    ///
+    /// [set]: https://url.spec.whatwg.org/#path-percent-encode-set
+    fn is_path_char(c: char) -> bool {
+        is_query_char(c) && !matches!(c, '/' | '?' | '^' | '`' | '{' | '}')
+    }
+
+    /// Returns whether `c` is allowed in a URL query string per
+    /// the WHATWG URL Standard's [query percent-encode set][set].
+    ///
+    /// [set]: https://url.spec.whatwg.org/#query-percent-encode-set
+    fn is_query_char(c: char) -> bool {
+        !matches!(
+            c,
+            '\x00'..='\x1f' | ('\x7f'..) | ' ' | '"' | '#' | '<' | '>'
+        )
     }
 }
 
@@ -138,7 +195,8 @@ mod test {
         let arena = Arena::new();
         let result = parse(&arena, "/").unwrap();
 
-        assert_matches!(&*result, [PathSegment([])]);
+        assert_matches!(result.segments, [PathSegment([])]);
+        assert!(result.query.is_empty());
     }
 
     #[test]
@@ -146,7 +204,10 @@ mod test {
         let arena = Arena::new();
         let result = parse(&arena, "/users").unwrap();
 
-        assert_matches!(&*result, [PathSegment([PathFragment::Literal("users")])]);
+        assert_matches!(
+            result.segments,
+            [PathSegment([PathFragment::Literal("users")])],
+        );
     }
 
     #[test]
@@ -155,7 +216,7 @@ mod test {
         let result = parse(&arena, "/users/").unwrap();
 
         assert_matches!(
-            &*result,
+            result.segments,
             [
                 PathSegment([PathFragment::Literal("users")]),
                 PathSegment([]),
@@ -169,7 +230,7 @@ mod test {
         let result = parse(&arena, "/users/{userId}").unwrap();
 
         assert_matches!(
-            &*result,
+            result.segments,
             [
                 PathSegment([PathFragment::Literal("users")]),
                 PathSegment([PathFragment::Param("userId")]),
@@ -183,7 +244,7 @@ mod test {
         let result = parse(&arena, "/api/v1/resources/{resourceId}").unwrap();
 
         assert_matches!(
-            &*result,
+            result.segments,
             [
                 PathSegment([PathFragment::Literal("api")]),
                 PathSegment([PathFragment::Literal("v1")]),
@@ -199,7 +260,7 @@ mod test {
         let result = parse(&arena, "/users/{userId}/posts/{postId}").unwrap();
 
         assert_matches!(
-            &*result,
+            result.segments,
             [
                 PathSegment([PathFragment::Literal("users")]),
                 PathSegment([PathFragment::Param("userId")]),
@@ -219,7 +280,7 @@ mod test {
         .unwrap();
 
         assert_matches!(
-            &*result,
+            result.segments,
             [
                 PathSegment([PathFragment::Literal("v1")]),
                 PathSegment([PathFragment::Literal("storage")]),
@@ -245,7 +306,7 @@ mod test {
         .unwrap();
 
         assert_matches!(
-            &*result,
+            result.segments,
             [
                 PathSegment([PathFragment::Literal("v1")]),
                 PathSegment([PathFragment::Literal("storage")]),
@@ -275,5 +336,140 @@ mod test {
         // Parameter names can contain any character except for
         // `{` and `}`, per the `template-expression-param-name` terminal.
         assert!(parse(&arena, "/users/{user/{id}}").is_err());
+    }
+
+    #[test]
+    fn test_path_with_single_query_param() {
+        let arena = Arena::new();
+        let result = parse(&arena, "/v1/messages?beta=true").unwrap();
+
+        assert_matches!(
+            result,
+            ParsedPath {
+                segments: [
+                    PathSegment([PathFragment::Literal("v1")]),
+                    PathSegment([PathFragment::Literal("messages")]),
+                ],
+                query: [PathQueryParameter {
+                    name: "beta",
+                    value: "true",
+                }],
+            },
+        );
+    }
+
+    #[test]
+    fn test_path_with_multiple_query_params() {
+        let arena = Arena::new();
+        let result = parse(&arena, "/v1/items?beta=true&version=2").unwrap();
+
+        assert_matches!(
+            result,
+            ParsedPath {
+                segments: [
+                    PathSegment([PathFragment::Literal("v1")]),
+                    PathSegment([PathFragment::Literal("items")]),
+                ],
+                query: [
+                    PathQueryParameter {
+                        name: "beta",
+                        value: "true",
+                    },
+                    PathQueryParameter {
+                        name: "version",
+                        value: "2",
+                    },
+                ],
+            },
+        );
+    }
+
+    #[test]
+    fn test_path_with_template_and_query_param() {
+        let arena = Arena::new();
+        let result = parse(&arena, "/v1/models/{model_id}?beta=true").unwrap();
+
+        assert_matches!(
+            result,
+            ParsedPath {
+                segments: [
+                    PathSegment([PathFragment::Literal("v1")]),
+                    PathSegment([PathFragment::Literal("models")]),
+                    PathSegment([PathFragment::Param("model_id")]),
+                ],
+                query: [PathQueryParameter {
+                    name: "beta",
+                    value: "true",
+                }],
+            },
+        );
+    }
+
+    #[test]
+    fn test_path_with_valueless_query_param() {
+        let arena = Arena::new();
+        let result = parse(&arena, "/v1/items?beta").unwrap();
+
+        assert_matches!(
+            result,
+            ParsedPath {
+                segments: [
+                    PathSegment([PathFragment::Literal("v1")]),
+                    PathSegment([PathFragment::Literal("items")]),
+                ],
+                query: [PathQueryParameter {
+                    name: "beta",
+                    value: "",
+                }],
+            },
+        );
+    }
+
+    #[test]
+    fn test_path_with_trailing_question_mark() {
+        let arena = Arena::new();
+        let result = parse(&arena, "/foo?").unwrap();
+
+        assert_matches!(
+            result,
+            ParsedPath {
+                segments: [PathSegment([PathFragment::Literal("foo")])],
+                query: [],
+            },
+        );
+    }
+
+    #[test]
+    fn test_path_with_percent_encoded_query_params() {
+        let arena = Arena::new();
+        let result = parse(&arena, "/foo?a%20b=c%20d").unwrap();
+
+        assert_matches!(
+            result,
+            ParsedPath {
+                segments: [PathSegment([PathFragment::Literal("foo")])],
+                query: [PathQueryParameter {
+                    name: "a b",
+                    value: "c d",
+                }],
+            },
+        );
+    }
+
+    #[test]
+    fn test_root_path_with_query_param() {
+        let arena = Arena::new();
+        let result = parse(&arena, "/?beta=true").unwrap();
+
+        assert_matches!(
+            result,
+            ParsedPath {
+                segments: [PathSegment([])],
+                query: [PathQueryParameter {
+                    name: "beta",
+                    value: "true",
+                }],
+            },
+        );
     }
 }

--- a/ploidy-util/src/error.rs
+++ b/ploidy-util/src/error.rs
@@ -17,6 +17,10 @@ pub enum Error {
     #[error("Invalid query parameter")]
     QueryParam(#[from] crate::QueryParamError),
 
+    /// Invalid request path.
+    #[error("Invalid request path")]
+    InvalidPath(#[from] crate::http::uri::InvalidUri),
+
     /// Invalid HTTP header name.
     #[error("Invalid header name")]
     BadHeaderName(#[source] http::Error),


### PR DESCRIPTION
This commit:

* Extends the path parser to soak up literal query parameters as a spec extension, and emit `query_pairs_mut()` builder calls for them in codegen. This lets Ploidy parse the [Anthropic spec](https://github.com/anthropics/anthropic-sdk-typescript/blob/93ac7c7e05496c2dad95fbe65c1b54f5bb38f8fd/.stats.yml).
* Changes the generated `Client::request()` method to parse its path argument with `http::uri::PathAndQuery`, so that literal query parameters become part of the request, instead of garbled as path components.

This is a breaking change to generated crates: `request()` now returns `Result<RequestBuilder, Error>`.