### PR TITLE
Inline untagged union variants with fields

### DIFF
--- a/ploidy-codegen-rust/src/untagged.rs
+++ b/ploidy-codegen-rust/src/untagged.rs
@@ -82,7 +82,7 @@ mod tests {
     use pretty_assertions::assert_eq;
     use syn::parse_quote;
 
-    use crate::CodegenGraph;
+    use crate::{CodegenGraph, CodegenSchemaType};
 
     #[test]
     fn test_untagged_union_serde_untagged_attr() {
@@ -215,6 +215,84 @@ mod tests {
             pub enum Animal {
                 V1(crate::types::Dog),
                 V2(crate::types::Cat)
+            }
+        };
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_untagged_union_inlined_variant_wraps_inline_type() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Animal:
+                  oneOf:
+                    - $ref: '#/components/schemas/Dog'
+                    - $ref: '#/components/schemas/Cat'
+                  required:
+                    - name
+                  properties:
+                    name:
+                      type: string
+                Dog:
+                  type: object
+                  required:
+                    - bark
+                  properties:
+                    bark:
+                      type: string
+                Cat:
+                  type: object
+                  required:
+                    - meow
+                  properties:
+                    meow:
+                      type: string
+        "})
+        .unwrap();
+
+        let arena = Arena::new();
+        let spec = Spec::from_doc(&arena, &doc).unwrap();
+        let mut raw = RawGraph::new(&arena, &spec);
+        raw.inline_untagged_variants();
+        let graph = CodegenGraph::new(raw.cook());
+
+        let schema = graph.schema("Animal").unwrap();
+        let schema @ SchemaTypeView::Untagged(_, _) = &schema else {
+            panic!("expected untagged union `Animal`; got `{schema:?}`");
+        };
+
+        let codegen = CodegenSchemaType::new(schema);
+
+        let actual: syn::File = parse_quote!(#codegen);
+        let expected: syn::File = parse_quote! {
+            #[derive(Debug, Clone, PartialEq, Eq, Hash, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
+            #[serde(crate = "::ploidy_util::serde", untagged)]
+            #[ploidy(pointer(crate = "::ploidy_util::pointer", untagged))]
+            pub enum Animal {
+                V1(crate::types::animal::types::V1),
+                V2(crate::types::animal::types::V2)
+            }
+            pub mod types {
+                #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
+                #[serde(crate = "::ploidy_util::serde")]
+                #[ploidy(pointer(crate = "::ploidy_util::pointer"))]
+                pub struct V1 {
+                    pub name: ::std::string::String,
+                    pub bark: ::std::string::String,
+                }
+                #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
+                #[serde(crate = "::ploidy_util::serde")]
+                #[ploidy(pointer(crate = "::ploidy_util::pointer"))]
+                pub struct V2 {
+                    pub name: ::std::string::String,
+                    pub meow: ::std::string::String,
+                }
             }
         };
         assert_eq!(actual, expected);

--- a/ploidy-core/src/ir/graph.rs
+++ b/ploidy-core/src/ir/graph.rs
@@ -31,9 +31,10 @@ use super::{
     spec::{ResolvedSpecType, Spec},
     types::{
         FieldMeta, GraphContainer, GraphInlineType, GraphOperation, GraphSchemaType, GraphStruct,
-        GraphTagged, GraphType, InlineTypePath, InlineTypePathRoot, InlineTypePathSegment,
-        PrimitiveType, SpecInlineType, SpecSchemaType, SpecType, SpecUntaggedVariant,
-        StructFieldName, TaggedVariantMeta, VariantMeta,
+        GraphTagged, GraphType, GraphUntagged, InlineTypePath, InlineTypePathRoot,
+        InlineTypePathSegment, PrimitiveType, SpecInlineType, SpecSchemaType, SpecType,
+        SpecUntaggedVariant, StructFieldName, TaggedVariantMeta, UntaggedVariantNameHint,
+        VariantMeta,
         shape::{Operation, Parameter, ParameterInfo, Request, Response},
     },
     views::{operation::OperationView, primitive::PrimitiveView, schema::SchemaTypeView},
@@ -50,8 +51,9 @@ type CookedDiGraph<'a> = DiGraph<GraphType<'a>, GraphEdge<'a>, usize>;
 ///
 /// This graph is constructed directly from a [`Spec`], and represents
 /// type relationships as they exist in the spec. Transformations like
-/// [`inline_tagged_variants`][Self::inline_tagged_variants] rewrite this graph
-/// in place.
+/// [`inline_tagged_variants`][Self::inline_tagged_variants] and
+/// [`inline_untagged_variants`][Self::inline_untagged_variants] rewrite this
+/// graph in place.
 ///
 /// After applying all transformations, call [`cook`][Self::cook] to
 /// turn this graph into a [`CookedGraph`] that's ready for code generation.
@@ -288,6 +290,79 @@ impl<'a> RawGraph<'a> {
         self
     }
 
+    /// Inlines struct variants of untagged unions with common fields.
+    ///
+    /// OpenAPI allows `oneOf` schemas to declare sibling `properties`.
+    /// Ploidy stores those as fields on the union, and structs that inherit
+    /// from the union through `allOf` already see them. Struct variants that
+    /// only appear through `oneOf` need an inline copy so that the union's
+    /// fields apply in that variant context without changing the original
+    /// schema type.
+    pub fn inline_untagged_variants(&mut self) -> &mut Self {
+        let inlinables = self.inlinable_untagged_variants().collect_vec();
+
+        let mut retargets = FxHashMap::default();
+        retargets.reserve(inlinables.len());
+
+        for InlinableUntaggedVariant {
+            untagged,
+            variant,
+            segment,
+        } in inlinables
+        {
+            let index = self
+                .graph
+                .add_node(GraphType::Inline(GraphInlineType::Struct(
+                    InlineTypePath {
+                        root: InlineTypePathRoot::Type(untagged.info.name),
+                        segments: self.arena.alloc_slice_copy(&[segment]),
+                    },
+                    variant.ty,
+                )));
+
+            let original_field_edges = self.fields(variant.index).collect_vec();
+            for edge in original_field_edges.into_iter().rev() {
+                self.graph.add_edge(
+                    index,
+                    edge.target,
+                    GraphEdge::Field {
+                        meta: edge.meta,
+                        shadow: true,
+                    },
+                );
+            }
+
+            self.graph
+                .add_edge(index, untagged.index, GraphEdge::Inherits { shadow: true });
+            self.graph
+                .add_edge(index, variant.index, GraphEdge::Inherits { shadow: true });
+
+            retargets.insert((untagged.index, variant.index), index);
+        }
+
+        let untaggeds: FixedBitSet = retargets
+            .keys()
+            .map(|&(untagged, _)| untagged.index())
+            .collect();
+        for index in untaggeds.ones().map(NodeIndex::new) {
+            let old_edges = self
+                .graph
+                .edges_directed(index, Direction::Outgoing)
+                .filter(|e| matches!(e.weight(), GraphEdge::Variant(_)))
+                .map(|e| (e.id(), *e.weight(), e.target()))
+                .collect_vec();
+            for &(id, _, _) in &old_edges {
+                self.graph.remove_edge(id);
+            }
+            for (_, weight, target) in old_edges.into_iter().rev() {
+                let new_target = retargets.get(&(index, target)).copied().unwrap_or(target);
+                self.graph.add_edge(index, new_target, weight);
+            }
+        }
+
+        self
+    }
+
     /// Builds an immutable [`CookedGraph`] from this mutable raw graph.
     #[inline]
     pub fn cook(&self) -> CookedGraph<'a> {
@@ -426,6 +501,57 @@ impl<'a> RawGraph<'a> {
                 self.fields(tagged.index).next()?;
 
                 Some(InlinableVariant { tagged, variant })
+            })
+    }
+
+    /// Returns an iterator over all the untagged union variant structs
+    /// that should be inlined.
+    fn inlinable_untagged_variants(&self) -> impl Iterator<Item = InlinableUntaggedVariant<'a>> {
+        self.graph
+            .node_indices()
+            .filter_map(|index| match self.graph[index] {
+                GraphType::Schema(GraphSchemaType::Untagged(info, ty)) => {
+                    Some(Node { index, info, ty })
+                }
+                _ => None,
+            })
+            .filter(|untagged| self.fields(untagged.index).next().is_some())
+            .flat_map(move |untagged| {
+                self.graph
+                    .edges_directed(untagged.index, Direction::Outgoing)
+                    .filter_map(move |e| {
+                        let segment = match e.weight() {
+                            GraphEdge::Variant(VariantMeta::Untagged(
+                                UntaggedVariantMeta::Type {
+                                    hint: UntaggedVariantNameHint::Index(index),
+                                },
+                            )) => InlineTypePathSegment::Variant(*index),
+                            _ => return None,
+                        };
+                        match self.graph[e.target()] {
+                            GraphType::Schema(GraphSchemaType::Struct(info, ty)) => {
+                                let index = e.target();
+                                Some((untagged, Node { index, info, ty }, segment))
+                            }
+                            _ => None,
+                        }
+                    })
+            })
+            .filter_map(|(untagged, variant, segment)| {
+                let ancestors = EdgeFiltered::from_fn(&self.graph, |e| {
+                    matches!(e.weight(), GraphEdge::Inherits { .. })
+                });
+                let mut dfs = DfsPostOrder::new(&ancestors, variant.index);
+                while dfs.next(&ancestors).is_some() {}
+                if dfs.discovered[untagged.index.index()] {
+                    return None;
+                }
+
+                Some(InlinableUntaggedVariant {
+                    untagged,
+                    variant,
+                    segment,
+                })
             })
     }
 }
@@ -630,6 +756,16 @@ struct InlinableVariant<'a> {
     tagged: Node<'a, GraphTagged<'a>>,
     /// The original variant struct node.
     variant: Node<'a, GraphStruct<'a>>,
+}
+
+/// A variant that should be inlined into its untagged union.
+struct InlinableUntaggedVariant<'a> {
+    /// The untagged union that owns this variant.
+    untagged: Node<'a, GraphUntagged<'a>>,
+    /// The original variant struct node.
+    variant: Node<'a, GraphStruct<'a>>,
+    /// The inline path segment for the copied variant struct.
+    segment: InlineTypePathSegment<'a>,
 }
 
 /// An edge between two types in the type graph.

--- a/ploidy-core/src/ir/graph.rs
+++ b/ploidy-core/src/ir/graph.rs
@@ -310,34 +310,48 @@ impl<'a> RawGraph<'a> {
             segment,
         } in inlinables
         {
-            let index = self
-                .graph
-                .add_node(GraphType::Inline(GraphInlineType::Struct(
-                    InlineTypePath {
-                        root: InlineTypePathRoot::Type(untagged.info.name),
-                        segments: self.arena.alloc_slice_copy(&[segment]),
-                    },
-                    variant.ty,
-                )));
+            match variant {
+                VariantStruct::Schema(variant) => {
+                    let index = self
+                        .graph
+                        .add_node(GraphType::Inline(GraphInlineType::Struct(
+                            InlineTypePath {
+                                root: InlineTypePathRoot::Type(untagged.info.name),
+                                segments: self.arena.alloc_slice_copy(&[segment]),
+                            },
+                            variant.ty,
+                        )));
 
-            let original_field_edges = self.fields(variant.index).collect_vec();
-            for edge in original_field_edges.into_iter().rev() {
-                self.graph.add_edge(
-                    index,
-                    edge.target,
-                    GraphEdge::Field {
-                        meta: edge.meta,
-                        shadow: true,
-                    },
-                );
+                    let original_field_edges = self.fields(variant.index).collect_vec();
+                    for edge in original_field_edges.into_iter().rev() {
+                        self.graph.add_edge(
+                            index,
+                            edge.target,
+                            GraphEdge::Field {
+                                meta: edge.meta,
+                                shadow: true,
+                            },
+                        );
+                    }
+
+                    self.graph.add_edge(
+                        index,
+                        untagged.index,
+                        GraphEdge::Inherits { shadow: true },
+                    );
+                    self.graph
+                        .add_edge(index, variant.index, GraphEdge::Inherits { shadow: true });
+
+                    retargets.insert((untagged.index, variant.index), index);
+                }
+                VariantStruct::Inline(variant) => {
+                    self.graph.add_edge(
+                        variant.index,
+                        untagged.index,
+                        GraphEdge::Inherits { shadow: true },
+                    );
+                }
             }
-
-            self.graph
-                .add_edge(index, untagged.index, GraphEdge::Inherits { shadow: true });
-            self.graph
-                .add_edge(index, variant.index, GraphEdge::Inherits { shadow: true });
-
-            retargets.insert((untagged.index, variant.index), index);
         }
 
         let untaggeds: FixedBitSet = retargets
@@ -401,25 +415,12 @@ impl<'a> RawGraph<'a> {
             .map(|index| index.index())
             .collect();
 
-        self.graph
-            .node_indices()
-            .filter_map(|index| match self.graph[index] {
-                GraphType::Schema(GraphSchemaType::Tagged(info, ty)) => {
-                    Some(Node { index, info, ty })
+        self.inlinable_union_variants()
+            .filter_map(|variant| match (variant.union, variant.variant) {
+                (VariantUnion::Tagged(tagged), VariantStruct::Schema(variant)) => {
+                    Some((tagged, variant))
                 }
                 _ => None,
-            })
-            .flat_map(move |tagged| {
-                self.graph
-                    .edges_directed(tagged.index, Direction::Outgoing)
-                    .filter(|e| matches!(e.weight(), GraphEdge::Variant(_)))
-                    .filter_map(move |e| match self.graph[e.target()] {
-                        GraphType::Schema(GraphSchemaType::Struct(info, ty)) => {
-                            let index = e.target();
-                            Some((tagged, Node { index, info, ty }))
-                        }
-                        _ => None,
-                    })
             })
             .filter_map(move |(tagged, variant)| {
                 // A variant struct only needs inlining if it has multiple
@@ -507,41 +508,29 @@ impl<'a> RawGraph<'a> {
     /// Returns an iterator over all the untagged union variant structs
     /// that should be inlined.
     fn inlinable_untagged_variants(&self) -> impl Iterator<Item = InlinableUntaggedVariant<'a>> {
-        self.graph
-            .node_indices()
-            .filter_map(|index| match self.graph[index] {
-                GraphType::Schema(GraphSchemaType::Untagged(info, ty)) => {
-                    Some(Node { index, info, ty })
-                }
-                _ => None,
-            })
-            .filter(|untagged| self.fields(untagged.index).next().is_some())
-            .flat_map(move |untagged| {
-                self.graph
-                    .edges_directed(untagged.index, Direction::Outgoing)
-                    .filter_map(move |e| {
-                        let segment = match e.weight() {
-                            GraphEdge::Variant(VariantMeta::Untagged(
-                                UntaggedVariantMeta::Type {
-                                    hint: UntaggedVariantNameHint::Index(index),
-                                },
-                            )) => InlineTypePathSegment::Variant(*index),
-                            _ => return None,
-                        };
-                        match self.graph[e.target()] {
-                            GraphType::Schema(GraphSchemaType::Struct(info, ty)) => {
-                                let index = e.target();
-                                Some((untagged, Node { index, info, ty }, segment))
-                            }
-                            _ => None,
-                        }
-                    })
+        self.inlinable_union_variants()
+            .filter_map(|variant| {
+                let VariantUnion::Untagged(untagged) = variant.union else {
+                    return None;
+                };
+                self.fields(untagged.index).next()?;
+                let VariantMeta::Untagged(UntaggedVariantMeta::Type {
+                    hint: UntaggedVariantNameHint::Index(index),
+                }) = variant.meta
+                else {
+                    return None;
+                };
+                Some((
+                    untagged,
+                    variant.variant,
+                    InlineTypePathSegment::Variant(index),
+                ))
             })
             .filter_map(|(untagged, variant, segment)| {
                 let ancestors = EdgeFiltered::from_fn(&self.graph, |e| {
                     matches!(e.weight(), GraphEdge::Inherits { .. })
                 });
-                let mut dfs = DfsPostOrder::new(&ancestors, variant.index);
+                let mut dfs = DfsPostOrder::new(&ancestors, variant.index());
                 while dfs.next(&ancestors).is_some() {}
                 if dfs.discovered[untagged.index.index()] {
                     return None;
@@ -552,6 +541,46 @@ impl<'a> RawGraph<'a> {
                     variant,
                     segment,
                 })
+            })
+    }
+
+    /// Returns an iterator over struct variants of tagged and untagged
+    /// unions.
+    fn inlinable_union_variants(&self) -> impl Iterator<Item = InlinableUnionVariant<'a>> {
+        self.graph
+            .node_indices()
+            .filter_map(|index| match self.graph[index] {
+                GraphType::Schema(GraphSchemaType::Tagged(info, ty)) => {
+                    Some(VariantUnion::Tagged(Node { index, info, ty }))
+                }
+                GraphType::Schema(GraphSchemaType::Untagged(info, ty)) => {
+                    Some(VariantUnion::Untagged(Node { index, info, ty }))
+                }
+                _ => None,
+            })
+            .flat_map(move |union| {
+                self.graph
+                    .edges_directed(union.index(), Direction::Outgoing)
+                    .filter_map(move |e| {
+                        let &GraphEdge::Variant(meta) = e.weight() else {
+                            return None;
+                        };
+                        let index = e.target();
+                        let variant = match self.graph[index] {
+                            GraphType::Schema(GraphSchemaType::Struct(info, ty)) => {
+                                VariantStruct::Schema(Node { index, info, ty })
+                            }
+                            GraphType::Inline(GraphInlineType::Struct(..)) => {
+                                VariantStruct::Inline(InlineNode { index })
+                            }
+                            _ => return None,
+                        };
+                        Some(InlinableUnionVariant {
+                            union,
+                            meta,
+                            variant,
+                        })
+                    })
             })
     }
 }
@@ -762,10 +791,60 @@ struct InlinableVariant<'a> {
 struct InlinableUntaggedVariant<'a> {
     /// The untagged union that owns this variant.
     untagged: Node<'a, GraphUntagged<'a>>,
-    /// The original variant struct node.
-    variant: Node<'a, GraphStruct<'a>>,
+    /// The variant struct node.
+    variant: VariantStruct<'a>,
     /// The inline path segment for the copied variant struct.
     segment: InlineTypePathSegment<'a>,
+}
+
+/// A tagged or untagged union that owns struct variants.
+#[derive(Clone, Copy)]
+enum VariantUnion<'a> {
+    Tagged(Node<'a, GraphTagged<'a>>),
+    Untagged(Node<'a, GraphUntagged<'a>>),
+}
+
+impl VariantUnion<'_> {
+    #[inline]
+    fn index(&self) -> NodeIndex<usize> {
+        match self {
+            Self::Tagged(node) => node.index,
+            Self::Untagged(node) => node.index,
+        }
+    }
+}
+
+/// A named or inline struct used as a union variant.
+#[derive(Clone, Copy)]
+enum VariantStruct<'a> {
+    Schema(Node<'a, GraphStruct<'a>>),
+    Inline(InlineNode),
+}
+
+impl VariantStruct<'_> {
+    #[inline]
+    fn index(&self) -> NodeIndex<usize> {
+        match self {
+            Self::Schema(node) => node.index,
+            Self::Inline(node) => node.index,
+        }
+    }
+}
+
+/// An inline graph node.
+#[derive(Clone, Copy)]
+struct InlineNode {
+    index: NodeIndex<usize>,
+}
+
+/// A struct variant of a tagged or untagged union.
+struct InlinableUnionVariant<'a> {
+    /// The union that owns this variant.
+    union: VariantUnion<'a>,
+    /// Metadata from the variant edge.
+    meta: VariantMeta<'a>,
+    /// The target struct node.
+    variant: VariantStruct<'a>,
 }
 
 /// An edge between two types in the type graph.

--- a/ploidy-core/src/ir/tests/graph.rs
+++ b/ploidy-core/src/ir/tests/graph.rs
@@ -2149,6 +2149,189 @@ fn test_untagged_union_with_properties() {
 }
 
 #[test]
+fn test_untagged_union_inlines_variants_with_fields() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test
+          version: 1.0.0
+        components:
+          schemas:
+            Animal:
+              oneOf:
+                - $ref: '#/components/schemas/Dog'
+                - $ref: '#/components/schemas/Cat'
+              properties:
+                name:
+                  type: string
+            Dog:
+              type: object
+              properties:
+                bark:
+                  type: string
+            Cat:
+              type: object
+              properties:
+                meow:
+                  type: string
+            Owner:
+              type: object
+              properties:
+                dog:
+                  $ref: '#/components/schemas/Dog'
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let spec = Spec::from_doc(&arena, &doc).unwrap();
+    let mut raw = RawGraph::new(&arena, &spec);
+    raw.inline_untagged_variants();
+    let graph = raw.cook();
+
+    let animal = graph.schema("Animal").unwrap();
+    let untagged = match animal {
+        SchemaTypeView::Untagged(_, view) => view,
+        other => panic!("expected untagged `Animal`; got {other:?}"),
+    };
+
+    let variant = untagged.variants().next().unwrap();
+    let variant_struct = match variant.ty().unwrap().view {
+        TypeView::Inline(InlineTypeView::Struct(_, view)) => view,
+        other => panic!("expected inline struct variant; got {other:?}"),
+    };
+    let field_names = variant_struct.fields().map(|f| f.name()).collect_vec();
+    assert_matches!(
+        &*field_names,
+        [StructFieldName::Name("name"), StructFieldName::Name("bark")]
+    );
+
+    let dog = graph.schema("Dog").unwrap();
+    let dog_struct = match dog {
+        SchemaTypeView::Struct(_, view) => view,
+        other => panic!("expected struct `Dog`; got {other:?}"),
+    };
+    let dog_field_names = dog_struct.fields().map(|f| f.name()).collect_vec();
+    assert_matches!(&*dog_field_names, [StructFieldName::Name("bark")]);
+}
+
+#[test]
+fn test_untagged_union_skips_variant_that_already_inherits_fields() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test
+          version: 1.0.0
+        components:
+          schemas:
+            Animal:
+              oneOf:
+                - $ref: '#/components/schemas/Dog'
+                - $ref: '#/components/schemas/Cat'
+              properties:
+                name:
+                  type: string
+            Dog:
+              allOf:
+                - $ref: '#/components/schemas/Animal'
+              properties:
+                bark:
+                  type: string
+            Cat:
+              allOf:
+                - $ref: '#/components/schemas/Animal'
+              properties:
+                meow:
+                  type: string
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let spec = Spec::from_doc(&arena, &doc).unwrap();
+    let mut raw = RawGraph::new(&arena, &spec);
+    raw.inline_untagged_variants();
+    let graph = raw.cook();
+
+    let animal = graph.schema("Animal").unwrap();
+    let untagged = match animal {
+        SchemaTypeView::Untagged(_, view) => view,
+        other => panic!("expected untagged `Animal`; got {other:?}"),
+    };
+
+    let variant = untagged.variants().next().unwrap();
+    assert_matches!(
+        variant.ty().unwrap().view,
+        TypeView::Schema(SchemaTypeView::Struct(..))
+    );
+
+    let dog = graph.schema("Dog").unwrap();
+    let dog_struct = match dog {
+        SchemaTypeView::Struct(_, view) => view,
+        other => panic!("expected struct `Dog`; got {other:?}"),
+    };
+    let field_names = dog_struct.fields().map(|f| f.name()).collect_vec();
+    assert_matches!(
+        &*field_names,
+        [StructFieldName::Name("name"), StructFieldName::Name("bark")]
+    );
+}
+
+#[test]
+fn test_untagged_union_inlining_preserves_field_type_edges() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test
+          version: 1.0.0
+        components:
+          schemas:
+            Animal:
+              oneOf:
+                - $ref: '#/components/schemas/Dog'
+                - $ref: '#/components/schemas/Cat'
+              required:
+                - severity
+              properties:
+                severity:
+                  type: string
+                  enum: [low, high]
+            Dog:
+              type: object
+              properties:
+                bark:
+                  type: string
+            Cat:
+              type: object
+              properties:
+                meow:
+                  type: string
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let spec = Spec::from_doc(&arena, &doc).unwrap();
+    let mut raw = RawGraph::new(&arena, &spec);
+    raw.inline_untagged_variants();
+    let graph = raw.cook();
+
+    let animal = graph.schema("Animal").unwrap();
+    let untagged = match animal {
+        SchemaTypeView::Untagged(_, view) => view,
+        other => panic!("expected untagged `Animal`; got {other:?}"),
+    };
+
+    let variant = untagged.variants().next().unwrap();
+    let variant_struct = match variant.ty().unwrap().view {
+        TypeView::Inline(InlineTypeView::Struct(_, view)) => view,
+        other => panic!("expected inline struct variant; got {other:?}"),
+    };
+    let severity = variant_struct
+        .fields()
+        .find(|f| matches!(f.name(), StructFieldName::Name("severity")))
+        .unwrap();
+    assert_matches!(severity.ty(), TypeView::Inline(InlineTypeView::Enum(..)));
+}
+
+#[test]
 fn test_tagged_union_inlines_include_field_types() {
     // A tagged union with an own inline enum property should
     // include that enum in its `inlines()`.

--- a/ploidy-core/src/ir/tests/graph.rs
+++ b/ploidy-core/src/ir/tests/graph.rs
@@ -2189,6 +2189,12 @@ fn test_untagged_union_inlines_variants_with_fields() {
     let graph = raw.cook();
 
     let animal = graph.schema("Animal").unwrap();
+    let inline_struct_count = animal
+        .inlines()
+        .filter(|inline| matches!(inline, InlineTypeView::Struct(..)))
+        .count();
+    assert_eq!(inline_struct_count, 2);
+
     let untagged = match animal {
         SchemaTypeView::Untagged(_, view) => view,
         other => panic!("expected untagged `Animal`; got {other:?}"),
@@ -2212,6 +2218,76 @@ fn test_untagged_union_inlines_variants_with_fields() {
     };
     let dog_field_names = dog_struct.fields().map(|f| f.name()).collect_vec();
     assert_matches!(&*dog_field_names, [StructFieldName::Name("bark")]);
+}
+
+#[test]
+fn test_untagged_union_adds_fields_to_inline_variants() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test
+          version: 1.0.0
+        components:
+          schemas:
+            Animal:
+              oneOf:
+                - type: object
+                  properties:
+                    bark:
+                      type: string
+                - type: object
+                  properties:
+                    meow:
+                      type: string
+              properties:
+                name:
+                  type: string
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let spec = Spec::from_doc(&arena, &doc).unwrap();
+    let mut raw = RawGraph::new(&arena, &spec);
+    raw.inline_untagged_variants();
+    let graph = raw.cook();
+
+    let animal = graph.schema("Animal").unwrap();
+    let inline_struct_count = animal
+        .inlines()
+        .filter(|inline| matches!(inline, InlineTypeView::Struct(..)))
+        .count();
+    assert_eq!(inline_struct_count, 2);
+
+    let untagged = match animal {
+        SchemaTypeView::Untagged(_, view) => view,
+        other => panic!("expected untagged `Animal`; got {other:?}"),
+    };
+
+    let field_names = untagged
+        .variants()
+        .map(|variant| {
+            let variant = variant.ty().unwrap();
+            let view = match variant.view {
+                TypeView::Inline(InlineTypeView::Struct(_, view)) => view,
+                other => panic!("expected inline struct variant; got `{other:?}`"),
+            };
+            view.fields().map(|f| f.name()).collect_vec()
+        })
+        .collect_vec();
+
+    assert_matches!(
+        &*field_names,
+        [
+            dog,
+            cat,
+        ] if matches!(
+            &**dog,
+            [StructFieldName::Name("name"), StructFieldName::Name("bark")]
+        ) && matches!(
+            &**cat,
+            [StructFieldName::Name("name"), StructFieldName::Name("meow")]
+        )
+    );
 }
 
 #[test]

--- a/ploidy-core/src/lib.rs
+++ b/ploidy-core/src/lib.rs
@@ -23,6 +23,7 @@
 //! let spec = Spec::from_doc(&arena, &doc)?;
 //! let mut raw = RawGraph::new(&arena, &spec);
 //! raw.inline_tagged_variants();
+//! raw.inline_untagged_variants();
 //! let graph = raw.cook();
 //!
 //! for view in graph.schemas() { /* ... */ }

--- a/ploidy/src/main.rs
+++ b/ploidy/src/main.rs
@@ -44,6 +44,7 @@ fn main() -> Result<()> {
             let spec = Spec::from_doc(&arena, &doc).into_diagnostic()?;
             let mut raw = RawGraph::new(&arena, &spec);
             raw.inline_tagged_variants();
+            raw.inline_untagged_variants();
 
             let config = language
                 .manifest


### PR DESCRIPTION
Closes #68

Adds an `inline_untagged_variants()` graph transformation for untagged unions with common fields. The pass creates inline struct copies for referenced variant structs that do not already inherit from the union, adds inheritance edges to the union and original variant and retargets the union variant edges to the inline copies.

Also wires the transform into CLI generation and adds graph/codegen coverage.

Verification:
- cargo check --workspace
- cargo test --workspace --no-fail-fast --all-features
- cargo doc --workspace --no-deps
- cargo clippy --workspace --all-targets --fix --allow-dirty --allow-staged --no-deps
- cargo +nightly fmt --all