### PR TITLE
feat(pointer): JsonPointee impl for uuid::Uuid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1184,6 +1184,7 @@ dependencies = [
  "strsim",
  "thiserror 2.0.18",
  "url",
+ "uuid",
 ]
 
 [[package]]

--- a/ploidy-pointer/Cargo.toml
+++ b/ploidy-pointer/Cargo.toml
@@ -31,6 +31,12 @@ default-features = false
 features = []
 optional = true
 
+[dependencies.uuid]
+version = "1"
+default-features = false
+features = []
+optional = true
+
 [features]
 default = ["derive"]
 full = [
@@ -42,6 +48,7 @@ full = [
     "serde_bytes",
     "serde_json",
     "url",
+    "uuid",
 ]
 chrono = ["dep:chrono"]
 derive = ["dep:ploidy-pointer-derive"]
@@ -51,3 +58,4 @@ serde = ["dep:serde"]
 serde_bytes = ["dep:serde_bytes"]
 serde_json = ["dep:serde_json"]
 url = ["dep:url"]
+uuid = ["dep:uuid"]

--- a/ploidy-pointer/src/lib.rs
+++ b/ploidy-pointer/src/lib.rs
@@ -324,6 +324,7 @@ impl_pointee_for!(
     #[cfg(feature = "chrono")] chrono::DateTime<chrono::Utc>,
     #[cfg(feature = "chrono")] chrono::NaiveDate,
     #[cfg(feature = "url")] url::Url,
+    #[cfg(feature = "uuid")] uuid::Uuid,
     #[cfg(feature = "serde_bytes")] serde_bytes::ByteBuf,
 );
 
@@ -353,6 +354,7 @@ impl_copied_pointer_target_for!(
     i8, u8, i16, u16, i32, u32, i64, u64, i128, u128, isize, usize, f32, f64, bool,
     #[cfg(feature = "chrono")] chrono::DateTime<chrono::Utc>,
     #[cfg(feature = "chrono")] chrono::NaiveDate,
+    #[cfg(feature = "uuid")] uuid::Uuid,
 );
 
 #[cfg(feature = "serde_bytes")]

--- a/ploidy-pointer/tests/pointee.rs
+++ b/ploidy-pointer/tests/pointee.rs
@@ -465,6 +465,23 @@ fn test_pointer_to_url() {
 }
 
 #[test]
+#[cfg(feature = "uuid")]
+fn test_pointer_to_uuid() {
+    use uuid::Uuid;
+
+    let id = Uuid::nil();
+
+    // Empty pointer should return the UUID itself.
+    let pointer = JsonPointer::parse("").unwrap();
+    let result = id.resolve(pointer).unwrap() as &dyn Any;
+    assert_eq!(result.downcast_ref::<Uuid>(), Some(&id));
+
+    // Non-empty pointer should fail.
+    let pointer = JsonPointer::parse("/foo").unwrap();
+    assert!(id.resolve(pointer).is_err());
+}
+
+#[test]
 #[cfg(feature = "serde_json")]
 fn test_pointer_to_serde_json() {
     use serde_json::json;

--- a/ploidy-util/Cargo.toml
+++ b/ploidy-util/Cargo.toml
@@ -22,6 +22,7 @@ ploidy-pointer = { workspace = true, features = [
     "serde_bytes",
     "serde_json",
     "url",
+    "uuid",
 ] }
 reqwest = { version = "0.13", default-features = false, features = [
     "form",


### PR DESCRIPTION
Adds feature-gated `JsonPointee` and `JsonPointerTarget` impls for `uuid::Uuid` in `ploidy-pointer`, mirroring the existing impls for `chrono::DateTime<Utc>` and `url::Url`.

`ploidy-util` enables the new feature, so generated client code can resolve JSON Pointers through `Uuid` fields the same way it already does for `String`, `i64`, etc.