### PR TITLE
Inline type naming overhaul

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1140,6 +1140,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "ref-cast",
+ "rustc-hash",
  "semver",
  "serde",
  "syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ ploidy-pointer = { path = "ploidy-pointer", version = "0.12.2" }
 ploidy-pointer-derive = { path = "ploidy-pointer-derive", version = "0.12.2" }
 pretty_assertions = "1"
 ref-cast = "1"
+rustc-hash = "2"
 toml_edit = { version = "0.25", features = ["serde"] }
 
 [workspace.lints.rust]

--- a/ploidy-codegen-rust/Cargo.toml
+++ b/ploidy-codegen-rust/Cargo.toml
@@ -19,6 +19,7 @@ prettyplease = "0.2"
 proc-macro2 = { version = "1", default-features = false }
 quote = { version = "1", default-features = false }
 ref-cast = { workspace = true }
+rustc-hash = { workspace = true }
 semver = "1"
 syn = { version = "2", default-features = false, features = [
     "parsing",

--- a/ploidy-codegen-rust/src/cargo.rs
+++ b/ploidy-codegen-rust/src/cargo.rs
@@ -47,7 +47,8 @@ impl<'a> CodegenCargoManifest<'a> {
                     schema
                         .dependencies()
                         .filter_map(|ty| ty.into_schema().right())
-                        .filter_map(|schema| self.graph.resource_for(&schema).name()),
+                        .filter_map(|schema| self.graph.resource_for(&schema).name())
+                        .filter(|dep| *dep != resource),
                 );
             }
 
@@ -62,7 +63,8 @@ impl<'a> CodegenCargoManifest<'a> {
                 entry.extend(
                     op.dependencies()
                         .filter_map(|ty| ty.into_schema().right())
-                        .filter_map(|schema| self.graph.resource_for(&schema).name()),
+                        .filter_map(|schema| self.graph.resource_for(&schema).name())
+                        .filter(|dep| *dep != resource),
                 );
             }
 
@@ -841,8 +843,8 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
         let manifest = CodegenCargoManifest::new(&graph, &default_manifest()).to_manifest();
 
-        // `Order` → `Customer` → `BillingInfo`, so `order` should
-        // depend on both `customer` and `billing`.
+        // `Order` -> `Customer` -> `BillingInfo`, so `orders` depends on
+        // both `customer` and `billing`.
         let features = manifest.features();
         assert_eq!(features["orders"], ["billing", "customer"]);
     }
@@ -910,6 +912,40 @@ mod tests {
         // Self-referential schemas should not create self-dependencies.
         let features = manifest.features();
         assert_matches!(&*features["nodes"], []);
+    }
+
+    #[test]
+    fn test_schema_dependency_on_own_resource_does_not_create_feature_dependency() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test
+              version: 1.0.0
+            components:
+              schemas:
+                Default:
+                  type: object
+                  x-resourceId: default
+                  properties:
+                    child:
+                      $ref: '#/components/schemas/DefaultChild'
+                DefaultChild:
+                  type: object
+                  x-resourceId: default
+                  properties:
+                    id:
+                      type: string
+        "})
+        .unwrap();
+
+        let arena = Arena::new();
+        let spec = Spec::from_doc(&arena, &doc).unwrap();
+        let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
+        let manifest = CodegenCargoManifest::new(&graph, &default_manifest()).to_manifest();
+
+        let features = manifest.features();
+        assert_matches!(&*features["default2"], []);
+        assert_matches!(&*features["default"], ["default2"]);
     }
 
     // MARK: Operation feature dependencies
@@ -1009,6 +1045,48 @@ mod tests {
         assert_matches!(&*features["customer"], []);
     }
 
+    #[test]
+    fn test_operation_dependency_on_own_resource_does_not_create_feature_dependency() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test
+              version: 1.0.0
+            paths:
+              /defaults:
+                get:
+                  operationId: listDefaults
+                  x-resource-name: default
+                  responses:
+                    '200':
+                      description: OK
+                      content:
+                        application/json:
+                          schema:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Default'
+            components:
+              schemas:
+                Default:
+                  type: object
+                  x-resourceId: default
+                  properties:
+                    id:
+                      type: string
+        "})
+        .unwrap();
+
+        let arena = Arena::new();
+        let spec = Spec::from_doc(&arena, &doc).unwrap();
+        let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
+        let manifest = CodegenCargoManifest::new(&graph, &default_manifest()).to_manifest();
+
+        let features = manifest.features();
+        assert_matches!(&*features["default2"], []);
+        assert_matches!(&*features["default"], ["default2"]);
+    }
+
     // MARK: Diamond dependencies
 
     #[test]
@@ -1058,8 +1136,8 @@ mod tests {
 
         let features = manifest.features();
 
-        // `a` depends directly on `b`, `c`;
-        // transitively on `d` though `b` and `c`.
+        // `a` depends directly on `b` and `c`, and
+        // transitively on `d` through both.
         assert_eq!(features["a"], ["b", "c", "d"]);
 
         // `b` and `c` each depend on `d`.
@@ -1123,9 +1201,9 @@ mod tests {
     }
 
     #[test]
-    fn test_cycle_with_all_named_resources_creates_mutual_dependencies() {
+    fn test_cycle_with_all_named_resources_preserves_feature_members() {
         // Type A (resource `a`) -> Type B (resource `b`) -> Type C (resource `c`) -> Type A.
-        // Each feature should depend on the others in the cycle.
+        // Each feature needs every other cycle member to compile.
         let doc = Document::from_yaml(indoc::indoc! {"
             openapi: 3.0.0
             info:

--- a/ploidy-codegen-rust/src/cargo.rs
+++ b/ploidy-codegen-rust/src/cargo.rs
@@ -13,7 +13,7 @@ use semver::Version;
 use serde::{Deserialize, de::IntoDeserializer};
 use toml_edit::{Array, DocumentMut, InlineTable, Table, TableLike, value};
 
-use super::{config::CodegenConfig, graph::CodegenGraph, naming::CargoFeature};
+use super::{config::CodegenConfig, graph::CodegenGraph, naming::AsFeatureName};
 
 const PLOIDY_VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -33,55 +33,48 @@ impl<'a> CodegenCargoManifest<'a> {
         // Translate resource names from operations and schemas into
         // Cargo feature names with dependencies.
         let features = {
-            let mut deps_by_feature = BTreeMap::new();
+            let mut deps_by_resource = BTreeMap::new();
 
             // For each schema type with an explicitly declared resource name,
-            // use the resource name as the feature name, and enable features
+            // use the resource as the feature name, and enable features
             // for all its transitive dependencies.
             for schema in self.graph.schemas() {
-                let feature = match schema.resource().map(CargoFeature::from_name) {
-                    Some(CargoFeature::Named(name)) => CargoFeature::Named(name),
-                    _ => continue,
+                let Some(resource) = self.graph.resource_for(&schema).name() else {
+                    continue;
                 };
-                let entry: &mut BTreeSet<_> = deps_by_feature.entry(feature).or_default();
-                for dep in schema.dependencies().filter_map(|ty| {
-                    match CargoFeature::from_name(ty.into_schema().right()?.resource()?) {
-                        CargoFeature::Named(name) => Some(CargoFeature::Named(name)),
-                        CargoFeature::Default => None,
-                    }
-                }) {
-                    entry.insert(dep);
-                }
+                let entry: &mut BTreeSet<_> = deps_by_resource.entry(resource).or_default();
+                entry.extend(
+                    schema
+                        .dependencies()
+                        .filter_map(|ty| ty.into_schema().right())
+                        .filter_map(|schema| self.graph.resource_for(&schema).name()),
+                );
             }
 
             // For each operation with an explicitly declared resource name,
-            // use the resource name as the feature name, and enable features for
+            // use the resource as the feature name, and enable features for
             // all the types that are reachable from the operation.
             for op in self.graph.operations() {
-                let feature = match op.resource().map(CargoFeature::from_name) {
-                    Some(CargoFeature::Named(name)) => CargoFeature::Named(name),
-                    _ => continue,
+                let Some(resource) = self.graph.resource_for(&op).name() else {
+                    continue;
                 };
-                let entry = deps_by_feature.entry(feature).or_default();
-                for dep in op.dependencies().filter_map(|ty| {
-                    match CargoFeature::from_name(ty.into_schema().right()?.resource()?) {
-                        CargoFeature::Named(name) => Some(CargoFeature::Named(name)),
-                        CargoFeature::Default => None,
-                    }
-                }) {
-                    entry.insert(dep);
-                }
+                let entry = deps_by_resource.entry(resource).or_default();
+                entry.extend(
+                    op.dependencies()
+                        .filter_map(|ty| ty.into_schema().right())
+                        .filter_map(|schema| self.graph.resource_for(&schema).name()),
+                );
             }
 
             // Build the `features` section of the manifest.
-            let mut features: BTreeMap<_, _> = deps_by_feature
+            let mut features: BTreeMap<_, _> = deps_by_resource
                 .iter()
-                .map(|(feature, deps)| {
+                .map(|(resource, deps)| {
                     (
-                        feature.display().to_string(),
+                        AsFeatureName(resource).to_string(),
                         FeatureDependencies(
                             deps.iter()
-                                .map(|dep| dep.display().to_string())
+                                .map(|resource| AsFeatureName(resource).to_string())
                                 .collect_vec(),
                         ),
                     )
@@ -94,9 +87,9 @@ impl<'a> CodegenCargoManifest<'a> {
                 features.insert(
                     "default".to_owned(),
                     FeatureDependencies(
-                        deps_by_feature
+                        deps_by_resource
                             .keys()
-                            .map(|feature| feature.display().to_string())
+                            .map(|resource| AsFeatureName(resource).to_string())
                             .collect_vec(),
                     ),
                 );

--- a/ploidy-codegen-rust/src/cfg.rs
+++ b/ploidy-codegen-rust/src/cfg.rs
@@ -23,35 +23,40 @@
 
 use std::collections::BTreeSet;
 
-use itertools::Itertools;
-use ploidy_core::ir::{InlineTypeView, OperationView, SchemaTypeView, View};
+use ploidy_core::ir::{HasResource, InlineTypeView, OperationView, SchemaTypeView, View};
 use proc_macro2::TokenStream;
 use quote::{ToTokens, quote};
 
-use super::naming::CargoFeature;
+use super::{
+    graph::CodegenGraph,
+    naming::{AsFeatureName, ResourceGroup, UniqueIdent},
+};
 
 /// Generates a `#[cfg(...)]` attribute for conditional compilation.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum CfgFeature {
+pub enum CfgFeature<'a> {
     /// A single `feature = "name"` predicate.
-    Single(CargoFeature),
+    Single(&'a UniqueIdent),
     /// A compound `any(feature = "a", feature = "b", ...)` predicate.
-    AnyOf(BTreeSet<CargoFeature>),
+    AnyOf(BTreeSet<&'a UniqueIdent>),
     /// A compound `all(feature = "a", feature = "b", ...)` predicate.
-    AllOf(BTreeSet<CargoFeature>),
+    AllOf(BTreeSet<&'a UniqueIdent>),
     /// A compound `all(feature = "own", any(feature = "a", ...))` predicate,
     /// used for schema types that both specify an `x-resourceId`, and are
     /// used by operations that specify an `x-resource-name`.
     OwnAndUsedBy {
-        own: CargoFeature,
-        used_by: BTreeSet<CargoFeature>,
+        own: &'a UniqueIdent,
+        used_by: BTreeSet<&'a UniqueIdent>,
     },
 }
 
-impl CfgFeature {
+impl<'a> CfgFeature<'a> {
     /// Builds a `#[cfg(...)]` attribute for a schema type, based on
     /// its own resource, and the resources of the operations that use it.
-    pub fn for_schema_type(view: &SchemaTypeView<'_, '_>) -> Option<Self> {
+    pub fn for_schema_type(
+        graph: &CodegenGraph<'a>,
+        view: &SchemaTypeView<'_, 'a>,
+    ) -> Option<Self> {
         // If this type has any transitive ungated root dependents,
         // it can't have a feature gate. An "ungated root" type
         // has no `x-resourceId`, _and_ isn't used by any operation with
@@ -60,35 +65,38 @@ impl CfgFeature {
         let has_ungated_root_dependent = view
             .dependents()
             .filter_map(|v| v.into_schema().right())
-            .any(|s| s.resource().is_none() && s.used_by().all(|op| op.resource().is_none()));
+            .any(|s| {
+                graph.resource_for(&s).is_default()
+                    && s.used_by().all(|op| graph.resource_for(&op).is_default())
+            });
         if has_ungated_root_dependent {
             return None;
         }
 
         // Compute all the operations with resources that use this type.
-        let used_by_features: BTreeSet<_> = view
+        let used_by_resources: BTreeSet<_> = view
             .used_by()
-            .filter_map(|op| op.resource())
-            .map(CargoFeature::from_name)
+            .filter_map(|op| graph.resource_for(&op).name())
             .collect();
 
-        match (view.resource(), used_by_features.is_empty()) {
+        match (graph.resource_for(view), used_by_resources.is_empty()) {
             // Type has own resource, _and_ is used by operations.
-            (Some(name), false) => {
-                Self::own_and_used_by(CargoFeature::from_name(name), used_by_features)
-            }
+            (ResourceGroup::Named(name), false) => Self::own_and_used_by(name, used_by_resources),
             // Type has own resource only (Stripe-style; no resources on operations).
-            (Some(name), true) => Some(Self::Single(CargoFeature::from_name(name))),
+            (ResourceGroup::Named(name), true) => Some(Self::Single(name)),
             // Type has no own resource, but is used by operations
             // (resource annotation-style; no resources on types).
-            (None, false) => Self::any_of(used_by_features),
+            (ResourceGroup::Default, false) => Self::any_of(used_by_resources),
             // No resource name; not used by any operation.
-            (None, true) => None,
+            (ResourceGroup::Default, true) => None,
         }
     }
 
     /// Builds a `#[cfg(...)]` attribute for an inline type.
-    pub fn for_inline_type(view: &InlineTypeView<'_, '_>) -> Option<Self> {
+    pub fn for_inline_type(
+        graph: &CodegenGraph<'a>,
+        view: &InlineTypeView<'_, 'a>,
+    ) -> Option<Self> {
         // Inline types depended on by ungated root types can't be gated, either.
         // See `for_schema_type` for the definition of an "ungated root".
         let has_ungated_root_dependent = view
@@ -99,59 +107,28 @@ impl CfgFeature {
             return None;
         }
 
-        let used_by_features: BTreeSet<_> = view
+        let used_by_resources: BTreeSet<_> = view
             .used_by()
-            .filter_map(|op| op.resource())
-            .map(CargoFeature::from_name)
+            .filter_map(|op| graph.resource_for(&op).name())
             .collect();
 
-        if used_by_features.is_empty() {
+        if used_by_resources.is_empty() {
             // No operations use this inline type directly, so use its
-            // transitive dependencies for gating. Filter out dependencies
-            // without a resource name, because these aren't gated.
-            let pairs = view
-                .dependencies()
-                .filter_map(|v| v.into_schema().right())
-                .filter_map(|ty| ty.resource().map(|r| (CargoFeature::from_name(r), ty)))
-                .collect_vec();
-            Self::all_of(reduce_transitive_features(&pairs))
+            // transitive dependencies for gating.
+            Self::all_of(reduce_transitive_features(graph, view))
         } else {
             // Some operations use this inline type; use those operations for gating.
-            Self::any_of(used_by_features)
+            Self::any_of(used_by_resources)
         }
     }
 
     /// Builds a `#[cfg(...)]` attribute for a client method.
-    pub fn for_operation(view: &OperationView<'_, '_>) -> Option<Self> {
-        // Collect all features from transitive dependencies, then
-        // reduce redundant features.
-        let pairs = view
-            .dependencies()
-            .filter_map(|v| v.into_schema().right())
-            .filter_map(|ty| ty.resource().map(|r| (CargoFeature::from_name(r), ty)))
-            .collect_vec();
-
-        Self::all_of(reduce_transitive_features(&pairs))
-    }
-
-    /// Builds a `#[cfg(...)]` attribute for a resource `mod` declaration in a
-    /// [`CodegenClientModule`](super::client::CodegenClientModule).
-    pub fn for_resource_module(feature: &CargoFeature) -> Option<Self> {
-        if matches!(feature, CargoFeature::Default) {
-            // Modules associated with the default resource shouldn't be gated,
-            // because that would make them unreachable under
-            // `--no-default-features`.
-            return None;
-        }
-        Some(Self::Single(feature.clone()))
+    pub fn for_operation(graph: &CodegenGraph<'a>, view: &OperationView<'_, 'a>) -> Option<Self> {
+        Self::all_of(reduce_transitive_features(graph, view))
     }
 
     /// Builds a `#[cfg(any(...))]` predicate, simplifying if possible.
-    fn any_of(mut features: BTreeSet<CargoFeature>) -> Option<Self> {
-        if features.contains(&CargoFeature::Default) {
-            // Items associated with the default resource shouldn't be gated.
-            return None;
-        }
+    fn any_of(mut features: BTreeSet<&'a UniqueIdent>) -> Option<Self> {
         let first = features.pop_first()?;
         Some(if features.is_empty() {
             // Simplify `any(first)` to `first`.
@@ -163,11 +140,7 @@ impl CfgFeature {
     }
 
     /// Builds a `#[cfg(all(...))]` predicate, simplifying if possible.
-    fn all_of(mut features: BTreeSet<CargoFeature>) -> Option<Self> {
-        if features.contains(&CargoFeature::Default) {
-            // Items associated with the default resource shouldn't be gated.
-            return None;
-        }
+    fn all_of(mut features: BTreeSet<&'a UniqueIdent>) -> Option<Self> {
         let first = features.pop_first()?;
         Some(if features.is_empty() {
             // Simplify `all(first)` to `first`.
@@ -179,11 +152,10 @@ impl CfgFeature {
     }
 
     /// Builds a `#[cfg(all(own, any(...)))]` predicate, simplifying if possible.
-    fn own_and_used_by(own: CargoFeature, mut used_by: BTreeSet<CargoFeature>) -> Option<Self> {
-        if matches!(own, CargoFeature::Default) || used_by.contains(&CargoFeature::Default) {
-            // Items associated with the default resource shouldn't be gated.
-            return None;
-        }
+    fn own_and_used_by(
+        own: &'a UniqueIdent,
+        mut used_by: BTreeSet<&'a UniqueIdent>,
+    ) -> Option<Self> {
         let Some(first) = used_by.pop_first() else {
             // No `used_by`; simplify to `own`.
             return Some(Self::Single(own));
@@ -199,31 +171,31 @@ impl CfgFeature {
     }
 }
 
-impl ToTokens for CfgFeature {
+impl ToTokens for CfgFeature<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let predicate = match self {
-            Self::Single(feature) => {
-                let name = feature.display().to_string();
+            Self::Single(resource) => {
+                let name = AsFeatureName(resource).to_string();
                 quote! { feature = #name }
             }
-            Self::AnyOf(features) => {
-                let predicates = features.iter().map(|f| {
-                    let name = f.display().to_string();
+            Self::AnyOf(resources) => {
+                let predicates = resources.iter().map(|f| {
+                    let name = AsFeatureName(f).to_string();
                     quote! { feature = #name }
                 });
                 quote! { any(#(#predicates),*) }
             }
-            Self::AllOf(features) => {
-                let predicates = features.iter().map(|f| {
-                    let name = f.display().to_string();
+            Self::AllOf(resources) => {
+                let predicates = resources.iter().map(|f| {
+                    let name = AsFeatureName(f).to_string();
                     quote! { feature = #name }
                 });
                 quote! { all(#(#predicates),*) }
             }
             Self::OwnAndUsedBy { own, used_by } => {
-                let own_name = own.display().to_string();
+                let own_name = AsFeatureName(own).to_string();
                 let used_by_predicates = used_by.iter().map(|f| {
-                    let name = f.display().to_string();
+                    let name = AsFeatureName(f).to_string();
                     quote! { feature = #name }
                 });
                 quote! { all(feature = #own_name, any(#(#used_by_predicates),*)) }
@@ -233,35 +205,38 @@ impl ToTokens for CfgFeature {
     }
 }
 
-/// Reduces a set of (feature, type) pairs by removing all the features
-/// that are transitively implied by other features. If feature A's type
-/// depends on feature B's type, then enabling A in `Cargo.toml` already
-/// enables B, so B is redundant.
-fn reduce_transitive_features(
-    pairs: &[(CargoFeature, SchemaTypeView<'_, '_>)],
-) -> BTreeSet<CargoFeature> {
-    pairs
-        .iter()
-        .enumerate()
-        .filter(|&(i, (feature, ty))| {
-            // Keep this `feature` unless some `other_ty` depends on it,
-            // meaning that `other_feature` already enables this `feature`.
-            let mut others = pairs.iter().enumerate().filter(|&(j, _)| i != j);
-            !others.any(|(_, (other_feature, other_ty))| {
-                // Does the other type depend on this type?
-                if !other_ty.depends_on(ty) {
-                    return false;
-                }
-                // Do the types form a cycle, and depend on each other?
-                // If so, the lexicographically lower feature name
-                // breaks the tie.
-                if ty.depends_on(other_ty) {
-                    return other_feature < feature;
-                }
-                true
-            })
+/// Reduces the set of resource features in a view's dependencies by
+/// removing features that are transitively implied by other features.
+/// If feature A's type depends on feature B's type, then enabling A
+/// in `Cargo.toml` already enables B, so B is redundant.
+fn reduce_transitive_features<'graph, 'a: 'graph>(
+    graph: &CodegenGraph<'a>,
+    view: &impl View<'graph, 'a>,
+) -> BTreeSet<&'a UniqueIdent> {
+    view.dependencies()
+        .filter_map(|v| {
+            let ty = v.into_schema().right()?;
+            // Filter out dependencies without a resource name,
+            // because these aren't gated.
+            let feature = graph.resource_for(&ty).name()?;
+            // Keep our `feature` unless some `other_ty` depends on it,
+            // meaning that `other_feature` already enables ours.
+            // If this `ty` and `other_ty` depend on each other, the
+            // lexicographically lower feature name breaks the tie.
+            let implied = view
+                .dependencies()
+                .filter_map(|v| v.into_schema().right())
+                .any(|other_ty| {
+                    if let ResourceGroup::Named(other_feature) = graph.resource_for(&other_ty)
+                        && other_ty.depends_on(&ty)
+                    {
+                        !ty.depends_on(&other_ty) || other_feature < feature
+                    } else {
+                        false
+                    }
+                });
+            (!implied).then_some(feature)
         })
-        .map(|(_, (feature, _))| feature.clone())
         .collect()
 }
 
@@ -278,13 +253,15 @@ mod tests {
     use pretty_assertions::assert_eq;
     use syn::parse_quote;
 
-    use crate::graph::CodegenGraph;
+    use crate::{UniqueIdents, graph::CodegenGraph};
 
     // MARK: Predicates
 
     #[test]
     fn test_single_feature() {
-        let cfg = CfgFeature::Single(CargoFeature::from_name("pets"));
+        let arena = Arena::new();
+        let mut scope = UniqueIdents::new(&arena);
+        let cfg = CfgFeature::Single(scope.ident("pets"));
 
         let actual: syn::Attribute = parse_quote!(#cfg);
         let expected: syn::Attribute = parse_quote!(#[cfg(feature = "pets")]);
@@ -293,10 +270,12 @@ mod tests {
 
     #[test]
     fn test_any_of_features() {
+        let arena = Arena::new();
+        let mut scope = UniqueIdents::new(&arena);
         let cfg = CfgFeature::AnyOf(BTreeSet::from_iter([
-            CargoFeature::from_name("cats"),
-            CargoFeature::from_name("dogs"),
-            CargoFeature::from_name("aardvarks"),
+            scope.ident("cats"),
+            scope.ident("dogs"),
+            scope.ident("aardvarks"),
         ]));
 
         let actual: syn::Attribute = parse_quote!(#cfg);
@@ -307,10 +286,12 @@ mod tests {
 
     #[test]
     fn test_all_of_features() {
+        let arena = Arena::new();
+        let mut scope = UniqueIdents::new(&arena);
         let cfg = CfgFeature::AllOf(BTreeSet::from_iter([
-            CargoFeature::from_name("cats"),
-            CargoFeature::from_name("dogs"),
-            CargoFeature::from_name("aardvarks"),
+            scope.ident("cats"),
+            scope.ident("dogs"),
+            scope.ident("aardvarks"),
         ]));
 
         let actual: syn::Attribute = parse_quote!(#cfg);
@@ -321,12 +302,11 @@ mod tests {
 
     #[test]
     fn test_own_and_used_by_feature() {
+        let arena = Arena::new();
+        let mut scope = UniqueIdents::new(&arena);
         let cfg = CfgFeature::OwnAndUsedBy {
-            own: CargoFeature::from_name("own"),
-            used_by: BTreeSet::from_iter([
-                CargoFeature::from_name("a"),
-                CargoFeature::from_name("b"),
-            ]),
+            own: scope.ident("own"),
+            used_by: BTreeSet::from_iter([scope.ident("a"), scope.ident("b")]),
         };
 
         let actual: syn::Attribute = parse_quote!(#cfg);
@@ -337,7 +317,9 @@ mod tests {
 
     #[test]
     fn test_any_of_simplifies_single_feature() {
-        let cfg = CfgFeature::any_of(BTreeSet::from_iter([CargoFeature::from_name("pets")]));
+        let arena = Arena::new();
+        let mut scope = UniqueIdents::new(&arena);
+        let cfg = CfgFeature::any_of(BTreeSet::from_iter([scope.ident("pets")]));
 
         let actual: syn::Attribute = parse_quote!(#cfg);
         let expected: syn::Attribute = parse_quote!(#[cfg(feature = "pets")]);
@@ -346,7 +328,9 @@ mod tests {
 
     #[test]
     fn test_all_of_simplifies_single_feature() {
-        let cfg = CfgFeature::all_of(BTreeSet::from_iter([CargoFeature::from_name("pets")]));
+        let arena = Arena::new();
+        let mut scope = UniqueIdents::new(&arena);
+        let cfg = CfgFeature::all_of(BTreeSet::from_iter([scope.ident("pets")]));
 
         let actual: syn::Attribute = parse_quote!(#cfg);
         let expected: syn::Attribute = parse_quote!(#[cfg(feature = "pets")]);
@@ -360,77 +344,33 @@ mod tests {
     }
 
     #[test]
-    fn test_any_of_returns_none_when_contains_default() {
-        // Items associated with the default resource shouldn't be gated.
-        let cfg = CfgFeature::any_of(BTreeSet::from_iter([
-            CargoFeature::from_name("customer"),
-            CargoFeature::Default,
-            CargoFeature::from_name("billing"),
-        ]));
-        assert_eq!(cfg, None);
-    }
-
-    #[test]
     fn test_all_of_returns_none_for_empty() {
         let cfg = CfgFeature::all_of(BTreeSet::new());
         assert_eq!(cfg, None);
     }
 
     #[test]
-    fn test_all_of_returns_none_when_contains_default() {
-        // Items associated with the default resource shouldn't be gated.
-        let cfg = CfgFeature::all_of(BTreeSet::from_iter([
-            CargoFeature::from_name("customer"),
-            CargoFeature::Default,
-            CargoFeature::from_name("billing"),
-        ]));
-        assert_eq!(cfg, None);
-    }
-
-    #[test]
     fn test_own_and_used_by_simplifies_single_used_by_to_all_of() {
+        let arena = Arena::new();
+        let mut scope = UniqueIdents::new(&arena);
+        let own = scope.ident("own");
+        let other = scope.ident("other");
         // `OwnedAndUsedBy` with one `used_by` feature should simplify to `AllOf`.
-        let cfg = CfgFeature::own_and_used_by(
-            CargoFeature::from_name("own"),
-            BTreeSet::from_iter([CargoFeature::from_name("other")]),
-        );
+        let cfg = CfgFeature::own_and_used_by(own, BTreeSet::from_iter([other]));
         assert_eq!(
             cfg,
-            Some(CfgFeature::AllOf(BTreeSet::from_iter([
-                CargoFeature::from_name("other"),
-                CargoFeature::from_name("own"),
-            ])))
+            Some(CfgFeature::AllOf(BTreeSet::from_iter([other, own])))
         );
     }
 
     #[test]
     fn test_own_and_used_by_simplifies_empty_to_single() {
+        let arena = Arena::new();
+        let mut scope = UniqueIdents::new(&arena);
+        let own = scope.ident("own");
         // `OwnedAndUsedBy` with no `used_by` features should simplify to `Single`.
-        let cfg = CfgFeature::own_and_used_by(CargoFeature::from_name("own"), BTreeSet::new());
-        assert_eq!(
-            cfg,
-            Some(CfgFeature::Single(CargoFeature::from_name("own")))
-        );
-    }
-
-    #[test]
-    fn test_own_and_used_by_returns_none_when_own_is_default() {
-        // Items associated with the default resource shouldn't be gated.
-        let cfg = CfgFeature::own_and_used_by(
-            CargoFeature::Default,
-            BTreeSet::from_iter([CargoFeature::from_name("other")]),
-        );
-        assert_eq!(cfg, None);
-    }
-
-    #[test]
-    fn test_own_and_used_by_returns_none_when_used_by_contains_default() {
-        // Items associated with the default resource shouldn't be gated.
-        let cfg = CfgFeature::own_and_used_by(
-            CargoFeature::from_name("own"),
-            BTreeSet::from_iter([CargoFeature::from_name("other"), CargoFeature::Default]),
-        );
-        assert_eq!(cfg, None);
+        let cfg = CfgFeature::own_and_used_by(own, BTreeSet::new());
+        assert_eq!(cfg, Some(CfgFeature::Single(own)));
     }
 
     // MARK: Schema types
@@ -460,7 +400,7 @@ mod tests {
         let customer = graph.schema("Customer").unwrap();
 
         // Shouldn't generate any feature gates for graph without named resources.
-        let cfg = CfgFeature::for_schema_type(&customer);
+        let cfg = CfgFeature::for_schema_type(&graph, &customer);
         assert_eq!(cfg, None);
     }
 
@@ -489,7 +429,7 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let customer = graph.schema("Customer").unwrap();
-        let cfg = CfgFeature::for_schema_type(&customer);
+        let cfg = CfgFeature::for_schema_type(&graph, &customer);
 
         let actual: syn::Attribute = parse_quote!(#cfg);
         let expected: syn::Attribute = parse_quote!(#[cfg(feature = "customer")]);
@@ -527,15 +467,47 @@ mod tests {
 
         // `Customer` should be gated.
         let customer = graph.schema("Customer").unwrap();
-        let cfg = CfgFeature::for_schema_type(&customer);
+        let cfg = CfgFeature::for_schema_type(&graph, &customer);
         let actual: syn::Attribute = parse_quote!(#cfg);
         let expected: syn::Attribute = parse_quote!(#[cfg(feature = "customer")]);
         assert_eq!(actual, expected);
 
         // `Address` should be ungated.
         let address = graph.schema("Address").unwrap();
-        let cfg = CfgFeature::for_schema_type(&address);
+        let cfg = CfgFeature::for_schema_type(&graph, &address);
         assert_eq!(cfg, None);
+    }
+
+    #[test]
+    fn test_for_schema_type_with_resource_id_named_default() {
+        // `CodegenGraph` reserves `default` for the `default` Cargo feature,
+        // so a resource named "default" won't collide with it.
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test
+              version: 1.0.0
+            components:
+              schemas:
+                Default:
+                  type: object
+                  x-resourceId: default
+                  properties:
+                    value:
+                      type: string
+        "})
+        .unwrap();
+
+        let arena = Arena::new();
+        let spec = Spec::from_doc(&arena, &doc).unwrap();
+        let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
+
+        let default_type = graph.schema("Default").unwrap();
+        let cfg = CfgFeature::for_schema_type(&graph, &default_type);
+
+        let actual: syn::Attribute = parse_quote!(#cfg);
+        let expected: syn::Attribute = parse_quote!(#[cfg(feature = "default2")]);
+        assert_eq!(actual, expected);
     }
 
     // MARK: Resource annotation-style
@@ -576,7 +548,7 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let customer = graph.schema("Customer").unwrap();
-        let cfg = CfgFeature::for_schema_type(&customer);
+        let cfg = CfgFeature::for_schema_type(&graph, &customer);
 
         let actual: syn::Attribute = parse_quote!(#cfg);
         let expected: syn::Attribute = parse_quote!(#[cfg(feature = "customer")]);
@@ -632,7 +604,7 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let address = graph.schema("Address").unwrap();
-        let cfg = CfgFeature::for_schema_type(&address);
+        let cfg = CfgFeature::for_schema_type(&graph, &address);
 
         let actual: syn::Attribute = parse_quote!(#cfg);
         let expected: syn::Attribute =
@@ -677,7 +649,7 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let customer = graph.schema("Customer").unwrap();
-        let cfg = CfgFeature::for_schema_type(&customer);
+        let cfg = CfgFeature::for_schema_type(&graph, &customer);
 
         let actual: syn::Attribute = parse_quote!(#cfg);
         let expected: syn::Attribute =
@@ -731,7 +703,7 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let customer = graph.schema("Customer").unwrap();
-        let cfg = CfgFeature::for_schema_type(&customer);
+        let cfg = CfgFeature::for_schema_type(&graph, &customer);
 
         let actual: syn::Attribute = parse_quote!(#cfg);
         let expected: syn::Attribute = parse_quote!(
@@ -784,7 +756,7 @@ mod tests {
 
         // `Customer` keeps its compound feature gate (own + used by).
         let customer = graph.schema("Customer").unwrap();
-        let cfg = CfgFeature::for_schema_type(&customer);
+        let cfg = CfgFeature::for_schema_type(&graph, &customer);
         let actual: syn::Attribute = parse_quote!(#cfg);
         let expected: syn::Attribute =
             parse_quote!(#[cfg(all(feature = "billing", feature = "customer"))]);
@@ -793,7 +765,7 @@ mod tests {
         // `Address` has no `x-resourceId`, but is used by the operation transitively,
         // so it inherits the operation's feature gate.
         let address = graph.schema("Address").unwrap();
-        let cfg = CfgFeature::for_schema_type(&address);
+        let cfg = CfgFeature::for_schema_type(&graph, &address);
         let actual: syn::Attribute = parse_quote!(#cfg);
         let expected: syn::Attribute = parse_quote!(#[cfg(feature = "billing")]);
         assert_eq!(actual, expected);
@@ -831,10 +803,76 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let simple = graph.schema("Simple").unwrap();
-        let cfg = CfgFeature::for_schema_type(&simple);
+        let cfg = CfgFeature::for_schema_type(&graph, &simple);
 
         // Types without a resource, and without operations that use them,
         // should be ungated.
+        assert_eq!(cfg, None);
+    }
+
+    #[test]
+    fn test_for_schema_type_used_by_unresourced_operation() {
+        // `Status` is only used by `healthCheck`, which doesn't have an
+        // `x-resource-name`. Even though the spec has other resourced
+        // operations, `Status` should be ungated because its only consumer
+        // is ungated.
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test
+              version: 1.0.0
+            paths:
+              /customers:
+                get:
+                  operationId: listCustomers
+                  x-resource-name: customer
+                  responses:
+                    '200':
+                      description: OK
+                      content:
+                        application/json:
+                          schema:
+                            $ref: '#/components/schemas/Customer'
+              /health:
+                get:
+                  operationId: healthCheck
+                  responses:
+                    '200':
+                      description: OK
+                      content:
+                        application/json:
+                          schema:
+                            $ref: '#/components/schemas/Status'
+            components:
+              schemas:
+                Customer:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                Status:
+                  type: object
+                  properties:
+                    ok:
+                      type: boolean
+        "})
+        .unwrap();
+
+        let arena = Arena::new();
+        let spec = Spec::from_doc(&arena, &doc).unwrap();
+        let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
+
+        // `Customer` is used by a resourced operation; it should be gated.
+        let customer = graph.schema("Customer").unwrap();
+        let cfg = CfgFeature::for_schema_type(&graph, &customer);
+        let actual: syn::Attribute = parse_quote!(#cfg);
+        let expected: syn::Attribute = parse_quote!(#[cfg(feature = "customer")]);
+        assert_eq!(actual, expected);
+
+        // `Status` is only used by an unresourced operation;
+        // it should be ungated.
+        let status = graph.schema("Status").unwrap();
+        let cfg = CfgFeature::for_schema_type(&graph, &status);
         assert_eq!(cfg, None);
     }
 
@@ -879,15 +917,15 @@ mod tests {
         // In a cycle involving B, all types become ungated, because
         // B depends on C, which depends on A, which depends on B.
         let a = graph.schema("A").unwrap();
-        let cfg = CfgFeature::for_schema_type(&a);
+        let cfg = CfgFeature::for_schema_type(&graph, &a);
         assert_eq!(cfg, None);
 
         let b = graph.schema("B").unwrap();
-        let cfg = CfgFeature::for_schema_type(&b);
+        let cfg = CfgFeature::for_schema_type(&graph, &b);
         assert_eq!(cfg, None);
 
         let c = graph.schema("C").unwrap();
-        let cfg = CfgFeature::for_schema_type(&c);
+        let cfg = CfgFeature::for_schema_type(&graph, &c);
         assert_eq!(cfg, None);
     }
 
@@ -931,19 +969,19 @@ mod tests {
         // Each type uses just its own feature; Cargo feature dependencies
         // handle the transitive requirements.
         let a = graph.schema("A").unwrap();
-        let cfg = CfgFeature::for_schema_type(&a);
+        let cfg = CfgFeature::for_schema_type(&graph, &a);
         let actual: syn::Attribute = parse_quote!(#cfg);
         let expected: syn::Attribute = parse_quote!(#[cfg(feature = "a")]);
         assert_eq!(actual, expected);
 
         let b = graph.schema("B").unwrap();
-        let cfg = CfgFeature::for_schema_type(&b);
+        let cfg = CfgFeature::for_schema_type(&graph, &b);
         let actual: syn::Attribute = parse_quote!(#cfg);
         let expected: syn::Attribute = parse_quote!(#[cfg(feature = "b")]);
         assert_eq!(actual, expected);
 
         let c = graph.schema("C").unwrap();
-        let cfg = CfgFeature::for_schema_type(&c);
+        let cfg = CfgFeature::for_schema_type(&graph, &c);
         let actual: syn::Attribute = parse_quote!(#cfg);
         let expected: syn::Attribute = parse_quote!(#[cfg(feature = "c")]);
         assert_eq!(actual, expected);
@@ -986,27 +1024,7 @@ mod tests {
         assert!(!inlines.is_empty());
 
         // Shouldn't generate any feature gates for graph without named resources.
-        let cfg = CfgFeature::for_inline_type(&inlines[0]);
-        assert_eq!(cfg, None);
-    }
-
-    // MARK: Resource modules
-
-    #[test]
-    fn test_for_resource_module_with_named_feature() {
-        let cfg = CfgFeature::for_resource_module(&CargoFeature::from_name("pets"));
-
-        let actual: syn::Attribute = parse_quote!(#cfg);
-        let expected: syn::Attribute = parse_quote!(#[cfg(feature = "pets")]);
-        assert_eq!(actual, expected);
-    }
-
-    #[test]
-    fn test_for_resource_module_skips_default_feature() {
-        // The `default` feature is built in to Cargo. Gating a module
-        // behind it makes operations unreachable when individual features
-        // are enabled via `--no-default-features --features foo`.
-        let cfg = CfgFeature::for_resource_module(&CargoFeature::Default);
+        let cfg = CfgFeature::for_inline_type(&graph, &inlines[0]);
         assert_eq!(cfg, None);
     }
 
@@ -1060,7 +1078,7 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let op = graph.operations().find(|o| o.id() == "getThings").unwrap();
-        let cfg = CfgFeature::for_operation(&op);
+        let cfg = CfgFeature::for_operation(&graph, &op);
 
         let actual: syn::Attribute = parse_quote!(#cfg);
         let expected: syn::Attribute = parse_quote!(#[cfg(feature = "a")]);
@@ -1116,7 +1134,7 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let op = graph.operations().find(|o| o.id() == "getThings").unwrap();
-        let cfg = CfgFeature::for_operation(&op);
+        let cfg = CfgFeature::for_operation(&graph, &op);
 
         // All three are in a cycle; the lowest feature name wins.
         let actual: syn::Attribute = parse_quote!(#cfg);
@@ -1171,7 +1189,7 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let op = graph.operations().find(|o| o.id() == "getThings").unwrap();
-        let cfg = CfgFeature::for_operation(&op);
+        let cfg = CfgFeature::for_operation(&graph, &op);
 
         let actual: syn::Attribute = parse_quote!(#cfg);
         let expected: syn::Attribute = parse_quote!(#[cfg(all(feature = "a", feature = "b"))]);
@@ -1231,7 +1249,7 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let op = graph.operations().find(|o| o.id() == "getThings").unwrap();
-        let cfg = CfgFeature::for_operation(&op);
+        let cfg = CfgFeature::for_operation(&graph, &op);
 
         let actual: syn::Attribute = parse_quote!(#cfg);
         let expected: syn::Attribute = parse_quote!(#[cfg(all(feature = "a", feature = "c"))]);
@@ -1294,7 +1312,7 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let op = graph.operations().find(|o| o.id() == "getThings").unwrap();
-        let cfg = CfgFeature::for_operation(&op);
+        let cfg = CfgFeature::for_operation(&graph, &op);
 
         // A transitively implies B, C, and D; only `a` should remain.
         let actual: syn::Attribute = parse_quote!(#cfg);
@@ -1328,7 +1346,7 @@ mod tests {
             .operations()
             .find(|o| o.id() == "healthCheck")
             .unwrap();
-        let cfg = CfgFeature::for_operation(&op);
+        let cfg = CfgFeature::for_operation(&graph, &op);
 
         // An operation with no type dependencies should have no feature gate.
         assert_eq!(cfg, None);
@@ -1388,7 +1406,7 @@ mod tests {
         let inlines = ops.iter().flat_map(|op| op.inlines()).collect_vec();
         assert!(!inlines.is_empty());
 
-        let cfg = CfgFeature::for_inline_type(&inlines[0]);
+        let cfg = CfgFeature::for_inline_type(&graph, &inlines[0]);
 
         let actual: syn::Attribute = parse_quote!(#cfg);
         let expected: syn::Attribute = parse_quote!(#[cfg(feature = "a")]);

--- a/ploidy-codegen-rust/src/cfg.rs
+++ b/ploidy-codegen-rust/src/cfg.rs
@@ -57,19 +57,15 @@ impl<'a> CfgFeature<'a> {
         graph: &CodegenGraph<'a>,
         view: &SchemaTypeView<'_, 'a>,
     ) -> Option<Self> {
-        // If this type has any transitive ungated root dependents,
-        // it can't have a feature gate. An "ungated root" type
-        // has no `x-resourceId`, _and_ isn't used by any operation with
-        // `x-resource-name`. Because it's ungated, none of its
-        // transitive dependencies can be gated, either.
-        let has_ungated_root_dependent = view
-            .dependents()
-            .filter_map(|v| v.into_schema().right())
-            .any(|s| {
-                graph.resource_for(&s).is_default()
-                    && s.used_by().all(|op| graph.resource_for(&op).is_default())
-            });
-        if has_ungated_root_dependent {
+        // Types in the default resource group aren't feature-gated.
+        // If this type is in the default group, or is depended on by a type
+        // in that group, then it can't have a feature gate, either.
+        if in_default_resource_group(graph, view)
+            || view
+                .dependents()
+                .filter_map(|ty| ty.into_schema().right())
+                .any(|schema| in_default_resource_group(graph, &schema))
+        {
             return None;
         }
 
@@ -81,9 +77,11 @@ impl<'a> CfgFeature<'a> {
 
         match (graph.resource_for(view), used_by_resources.is_empty()) {
             // Type has own resource, _and_ is used by operations.
-            (ResourceGroup::Named(name), false) => Self::own_and_used_by(name, used_by_resources),
+            (ResourceGroup::Named(own), false) => {
+                Some(Self::own_and_used_by(own, used_by_resources))
+            }
             // Type has own resource only (Stripe-style; no resources on operations).
-            (ResourceGroup::Named(name), true) => Some(Self::Single(name)),
+            (ResourceGroup::Named(own), true) => Some(Self::Single(own)),
             // Type has no own resource, but is used by operations
             // (resource annotation-style; no resources on types).
             (ResourceGroup::Default, false) => Self::any_of(used_by_resources),
@@ -97,25 +95,32 @@ impl<'a> CfgFeature<'a> {
         graph: &CodegenGraph<'a>,
         view: &InlineTypeView<'_, 'a>,
     ) -> Option<Self> {
-        // Inline types depended on by ungated root types can't be gated, either.
-        // See `for_schema_type` for the definition of an "ungated root".
-        let has_ungated_root_dependent = view
+        // If this type is depended on by a type in the default resource group,
+        // then it can't have a feature gate.
+        if view
             .dependents()
-            .filter_map(|v| v.into_schema().right())
-            .any(|s| s.resource().is_none() && s.used_by().all(|op| op.resource().is_none()));
-        if has_ungated_root_dependent {
+            .filter_map(|ty| ty.into_schema().right())
+            .any(|schema| in_default_resource_group(graph, &schema))
+        {
             return None;
         }
 
         let used_by_resources: BTreeSet<_> = view
             .used_by()
-            .filter_map(|op| graph.resource_for(&op).name())
+            .filter_map(|op| {
+                use ResourceGroup::*;
+                match (graph.resource_for(view), graph.resource_for(&op)) {
+                    (Default, Named(resource)) => Some(resource),
+                    (Named(own), Named(resource)) if own != resource => Some(resource),
+                    _ => None,
+                }
+            })
             .collect();
 
         if used_by_resources.is_empty() {
             // No operations use this inline type directly, so use its
             // transitive dependencies for gating.
-            Self::all_of(reduce_transitive_features(graph, view))
+            Self::for_transitive_dependencies(graph, view)
         } else {
             // Some operations use this inline type; use those operations for gating.
             Self::any_of(used_by_resources)
@@ -124,7 +129,52 @@ impl<'a> CfgFeature<'a> {
 
     /// Builds a `#[cfg(...)]` attribute for a client method.
     pub fn for_operation(graph: &CodegenGraph<'a>, view: &OperationView<'_, 'a>) -> Option<Self> {
-        Self::all_of(reduce_transitive_features(graph, view))
+        Self::for_transitive_dependencies(graph, view)
+    }
+
+    /// Builds a `#[cfg(...)]` attribute from a view's resource dependencies.
+    ///
+    /// Reduces the set of resource features in a view's dependencies by
+    /// removing features that are transitively implied by other features.
+    /// If feature A's type depends on feature B's type, then enabling A
+    /// in `Cargo.toml` already enables B, so B is redundant.
+    fn for_transitive_dependencies<'graph>(
+        graph: &'graph CodegenGraph<'a>,
+        view: &(impl HasResource<'a> + View<'graph, 'a>),
+    ) -> Option<Self> {
+        Self::all_of(
+            view.dependencies()
+                .filter_map(|ty| {
+                    let schema = ty.into_schema().right()?;
+                    // Filter out dependencies without a resource name,
+                    // because these aren't feature-gated.
+                    let resource = graph.resource_for(&schema).name()?;
+                    // Keep our resource feature unless the other schema
+                    // depends on it, meaning that the other feature already
+                    // enables ours. If this schema and the other schema
+                    // depend on each other, the lexicographically lower
+                    // resource feature breaks the tie.
+                    let implied = view
+                        .dependencies()
+                        .filter_map(|ty| ty.into_schema().right())
+                        .any(|other_schema| {
+                            let ResourceGroup::Named(other_resource) =
+                                graph.resource_for(&other_schema)
+                            else {
+                                return false;
+                            };
+                            other_schema.depends_on(&schema)
+                                && (!schema.depends_on(&other_schema) || other_resource < resource)
+                        });
+                    (!implied).then_some(resource)
+                })
+                .filter(|&resource| match graph.resource_for(view) {
+                    ResourceGroup::Default => true,
+                    ResourceGroup::Named(own) if own != resource => true,
+                    _ => false,
+                })
+                .collect(),
+        )
     }
 
     /// Builds a `#[cfg(any(...))]` predicate, simplifying if possible.
@@ -152,22 +202,23 @@ impl<'a> CfgFeature<'a> {
     }
 
     /// Builds a `#[cfg(all(own, any(...)))]` predicate, simplifying if possible.
-    fn own_and_used_by(
-        own: &'a UniqueIdent,
-        mut used_by: BTreeSet<&'a UniqueIdent>,
-    ) -> Option<Self> {
+    fn own_and_used_by(own: &'a UniqueIdent, mut used_by: BTreeSet<&'a UniqueIdent>) -> Self {
+        if used_by.contains(own) {
+            // Simplify `all(own, any(own, ...))` to `own`.
+            return Self::Single(own);
+        }
         let Some(first) = used_by.pop_first() else {
-            // No `used_by`; simplify to `own`.
-            return Some(Self::Single(own));
+            // Simplify `all(own)` to `own`.
+            return Self::Single(own);
         };
-        Some(if used_by.is_empty() {
+        if used_by.is_empty() {
             // Simplify `all(own, any(first))` to `all(own, first)`.
             Self::AllOf(BTreeSet::from_iter([own, first]))
         } else {
             // Keep `all(own, any(first, used_by...))`.
             used_by.insert(first);
             Self::OwnAndUsedBy { own, used_by }
-        })
+        }
     }
 }
 
@@ -205,39 +256,13 @@ impl ToTokens for CfgFeature<'_> {
     }
 }
 
-/// Reduces the set of resource features in a view's dependencies by
-/// removing features that are transitively implied by other features.
-/// If feature A's type depends on feature B's type, then enabling A
-/// in `Cargo.toml` already enables B, so B is redundant.
-fn reduce_transitive_features<'graph, 'a: 'graph>(
-    graph: &CodegenGraph<'a>,
-    view: &impl View<'graph, 'a>,
-) -> BTreeSet<&'a UniqueIdent> {
-    view.dependencies()
-        .filter_map(|v| {
-            let ty = v.into_schema().right()?;
-            // Filter out dependencies without a resource name,
-            // because these aren't gated.
-            let feature = graph.resource_for(&ty).name()?;
-            // Keep our `feature` unless some `other_ty` depends on it,
-            // meaning that `other_feature` already enables ours.
-            // If this `ty` and `other_ty` depend on each other, the
-            // lexicographically lower feature name breaks the tie.
-            let implied = view
-                .dependencies()
-                .filter_map(|v| v.into_schema().right())
-                .any(|other_ty| {
-                    if let ResourceGroup::Named(other_feature) = graph.resource_for(&other_ty)
-                        && other_ty.depends_on(&ty)
-                    {
-                        !ty.depends_on(&other_ty) || other_feature < feature
-                    } else {
-                        false
-                    }
-                });
-            (!implied).then_some(feature)
-        })
-        .collect()
+fn in_default_resource_group<'graph, 'a>(
+    graph: &'graph CodegenGraph<'a>,
+    view: &(impl View<'graph, 'a> + HasResource<'a>),
+) -> bool {
+    let mut used_by = view.used_by().map(|op| graph.resource_for(&op)).peekable();
+    graph.resource_for(view).is_default()
+        && (used_by.peek().is_none() || used_by.any(|resource| resource.is_default()))
 }
 
 #[cfg(test)]
@@ -357,10 +382,7 @@ mod tests {
         let other = scope.ident("other");
         // `OwnedAndUsedBy` with one `used_by` feature should simplify to `AllOf`.
         let cfg = CfgFeature::own_and_used_by(own, BTreeSet::from_iter([other]));
-        assert_eq!(
-            cfg,
-            Some(CfgFeature::AllOf(BTreeSet::from_iter([other, own])))
-        );
+        assert_eq!(cfg, CfgFeature::AllOf(BTreeSet::from_iter([other, own])),);
     }
 
     #[test]
@@ -370,7 +392,17 @@ mod tests {
         let own = scope.ident("own");
         // `OwnedAndUsedBy` with no `used_by` features should simplify to `Single`.
         let cfg = CfgFeature::own_and_used_by(own, BTreeSet::new());
-        assert_eq!(cfg, Some(CfgFeature::Single(own)));
+        assert_eq!(cfg, CfgFeature::Single(own));
+    }
+
+    #[test]
+    fn test_own_and_used_by_simplifies_own_used_by_to_single() {
+        let arena = Arena::new();
+        let mut scope = UniqueIdents::new(&arena);
+        let own = scope.ident("own");
+        let other = scope.ident("other");
+        let cfg = CfgFeature::own_and_used_by(own, BTreeSet::from_iter([own, other]));
+        assert_eq!(cfg, CfgFeature::Single(own));
     }
 
     // MARK: Schema types
@@ -658,6 +690,101 @@ mod tests {
     }
 
     #[test]
+    fn test_for_schema_type_with_own_and_same_used_by_uses_single_feature() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test
+              version: 1.0.0
+            paths:
+              /defaults:
+                get:
+                  operationId: listDefaults
+                  x-resource-name: default
+                  responses:
+                    '200':
+                      description: OK
+                      content:
+                        application/json:
+                          schema:
+                            $ref: '#/components/schemas/Default'
+            components:
+              schemas:
+                Default:
+                  type: object
+                  x-resourceId: default
+                  properties:
+                    id:
+                      type: string
+        "})
+        .unwrap();
+
+        let arena = Arena::new();
+        let spec = Spec::from_doc(&arena, &doc).unwrap();
+        let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
+
+        let default_type = graph.schema("Default").unwrap();
+        let cfg = CfgFeature::for_schema_type(&graph, &default_type);
+
+        let actual: syn::Attribute = parse_quote!(#cfg);
+        let expected: syn::Attribute = parse_quote!(#[cfg(feature = "default2")]);
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_for_schema_type_with_own_same_and_other_used_by_uses_single_feature() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test
+              version: 1.0.0
+            paths:
+              /customer:
+                get:
+                  operationId: getCustomer
+                  x-resource-name: customer
+                  responses:
+                    '200':
+                      description: OK
+                      content:
+                        application/json:
+                          schema:
+                            $ref: '#/components/schemas/Customer'
+              /billing:
+                get:
+                  operationId: getBilling
+                  x-resource-name: billing
+                  responses:
+                    '200':
+                      description: OK
+                      content:
+                        application/json:
+                          schema:
+                            $ref: '#/components/schemas/Customer'
+            components:
+              schemas:
+                Customer:
+                  type: object
+                  x-resourceId: customer
+                  properties:
+                    id:
+                      type: string
+        "})
+        .unwrap();
+
+        let arena = Arena::new();
+        let spec = Spec::from_doc(&arena, &doc).unwrap();
+        let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
+
+        let customer = graph.schema("Customer").unwrap();
+        let cfg = CfgFeature::for_schema_type(&graph, &customer);
+
+        let actual: syn::Attribute = parse_quote!(#cfg);
+        let expected: syn::Attribute = parse_quote!(#[cfg(feature = "customer")]);
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
     fn test_for_schema_type_with_own_and_multiple_used_by() {
         let doc = Document::from_yaml(indoc::indoc! {"
             openapi: 3.0.0
@@ -876,6 +1003,57 @@ mod tests {
         assert_eq!(cfg, None);
     }
 
+    #[test]
+    fn test_for_schema_type_used_by_resourced_and_unresourced_operations() {
+        // `Status` is used by both an unresourced operation and a resourced
+        // operation. It must stay ungated for the unresourced operation.
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test
+              version: 1.0.0
+            paths:
+              /health:
+                get:
+                  operationId: getHealth
+                  responses:
+                    '200':
+                      description: OK
+                      content:
+                        application/json:
+                          schema:
+                            $ref: '#/components/schemas/Status'
+              /billing/status:
+                get:
+                  operationId: getBillingStatus
+                  x-resource-name: billing
+                  responses:
+                    '200':
+                      description: OK
+                      content:
+                        application/json:
+                          schema:
+                            $ref: '#/components/schemas/Status'
+            components:
+              schemas:
+                Status:
+                  type: object
+                  properties:
+                    ok:
+                      type: boolean
+        "})
+        .unwrap();
+
+        let arena = Arena::new();
+        let spec = Spec::from_doc(&arena, &doc).unwrap();
+        let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
+
+        let status = graph.schema("Status").unwrap();
+        let cfg = CfgFeature::for_schema_type(&graph, &status);
+
+        assert_eq!(cfg, None);
+    }
+
     // MARK: Cycles with mixed resources
 
     #[test]
@@ -1024,6 +1202,51 @@ mod tests {
         assert!(!inlines.is_empty());
 
         // Shouldn't generate any feature gates for graph without named resources.
+        let cfg = CfgFeature::for_inline_type(&graph, &inlines[0]);
+        assert_eq!(cfg, None);
+    }
+
+    #[test]
+    fn test_for_inline_type_used_by_own_resource_has_no_cfg() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test
+              version: 1.0.0
+            paths:
+              /defaults:
+                get:
+                  operationId: listDefaults
+                  x-resource-name: default
+                  responses:
+                    '200':
+                      description: OK
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                            properties:
+                              value:
+                                $ref: '#/components/schemas/Default'
+            components:
+              schemas:
+                Default:
+                  type: object
+                  x-resourceId: default
+                  properties:
+                    id:
+                      type: string
+        "})
+        .unwrap();
+
+        let arena = Arena::new();
+        let spec = Spec::from_doc(&arena, &doc).unwrap();
+        let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
+
+        let ops = graph.operations().collect_vec();
+        let inlines = ops.iter().flat_map(|op| op.inlines()).collect_vec();
+        assert!(!inlines.is_empty());
+
         let cfg = CfgFeature::for_inline_type(&graph, &inlines[0]);
         assert_eq!(cfg, None);
     }

--- a/ploidy-codegen-rust/src/client.rs
+++ b/ploidy-codegen-rust/src/client.rs
@@ -5,33 +5,24 @@ use quote::{ToTokens, TokenStreamExt, quote};
 use super::{
     cfg::CfgFeature,
     graph::CodegenGraph,
-    naming::{CargoFeature, CodegenIdentUsage},
+    naming::{CodegenIdentUsage, ResourceGroup},
 };
 
 /// Generates the `client/mod.rs` source file.
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug)]
 pub struct CodegenClientModule<'a> {
     graph: &'a CodegenGraph<'a>,
-    features: &'a [&'a CargoFeature],
+    resources: &'a [ResourceGroup<'a>],
 }
 
 impl<'a> CodegenClientModule<'a> {
-    pub fn new(graph: &'a CodegenGraph<'a>, features: &'a [&'a CargoFeature]) -> Self {
-        Self { graph, features }
+    pub fn new(graph: &'a CodegenGraph<'a>, resources: &'a [ResourceGroup<'a>]) -> Self {
+        Self { graph, resources }
     }
 }
 
 impl ToTokens for CodegenClientModule<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        let mods = self.features.iter().map(|feature| {
-            let cfg = CfgFeature::for_resource_module(feature);
-            let mod_name = CodegenIdentUsage::Module(feature.as_ident());
-            quote! {
-                #cfg
-                pub mod #mod_name;
-            }
-        });
-
         let client_doc = self.graph.info().label().map(|label| {
             let doc = match label.version {
                 Some(version) => format!("API client for {} (version {version})", label.title),
@@ -39,6 +30,8 @@ impl ToTokens for CodegenClientModule<'_> {
             };
             quote! { #[doc = #doc] }
         });
+
+        let mods = ResourceModules(self.resources);
 
         tokens.append_all(quote! {
             #client_doc
@@ -170,7 +163,7 @@ impl ToTokens for CodegenClientModule<'_> {
                 }
             }
 
-            #(#mods)*
+            #mods
         });
     }
 }
@@ -180,5 +173,57 @@ impl IntoCode for CodegenClientModule<'_> {
 
     fn into_code(self) -> Self::Code {
         ("src/client/mod.rs", self.into_token_stream())
+    }
+}
+
+#[derive(Debug)]
+struct ResourceModules<'a>(&'a [ResourceGroup<'a>]);
+
+impl ToTokens for ResourceModules<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        tokens.append_all(self.0.iter().map(|ident| match ident {
+            ResourceGroup::Named(name) => {
+                let cfg = CfgFeature::Single(name);
+                let mod_name = CodegenIdentUsage::Module(name);
+                quote! {
+                    #cfg
+                    pub mod #mod_name;
+                }
+            }
+            ResourceGroup::Default => quote!(
+                pub mod default;
+            ),
+        }));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use ploidy_core::arena::Arena;
+    use pretty_assertions::assert_eq;
+    use syn::parse_quote;
+
+    use crate::naming::UniqueIdents;
+
+    #[test]
+    fn test_resource_modules_gates_named_resources_and_keeps_default_ungated() {
+        let arena = Arena::new();
+        let mut scope = UniqueIdents::new(&arena);
+        let resources = [
+            ResourceGroup::Default,
+            ResourceGroup::Named(scope.ident("customer_profiles")),
+        ];
+        let modules = ResourceModules(&resources);
+
+        let actual: syn::File = parse_quote!(#modules);
+        let expected: syn::File = parse_quote! {
+            pub mod default;
+
+            #[cfg(feature = "customer-profiles")]
+            pub mod customer_profiles;
+        };
+        assert_eq!(actual, expected);
     }
 }

--- a/ploidy-codegen-rust/src/enum_.rs
+++ b/ploidy-codegen-rust/src/enum_.rs
@@ -1,23 +1,21 @@
-use ploidy_core::ir::{EnumVariant, EnumView};
+use ploidy_core::ir::{EnumVariant, EnumView, HasTypeId};
 use proc_macro2::TokenStream;
 use quote::{ToTokens, TokenStreamExt, format_ident, quote};
-use syn::{Ident, parse_quote};
 
 use super::{
-    doc_attrs,
-    ext::EnumViewExt,
-    naming::{CodegenIdent, CodegenIdentUsage, CodegenTypeName},
+    doc_attrs, ext::EnumViewExt, graph::CodegenGraph, graph::IdentMapping,
+    naming::CodegenIdentUsage,
 };
 
 #[derive(Clone, Debug)]
 pub struct CodegenEnum<'a> {
-    name: CodegenTypeName<'a>,
+    graph: &'a CodegenGraph<'a>,
     ty: &'a EnumView<'a, 'a>,
 }
 
 impl<'a> CodegenEnum<'a> {
-    pub fn new(name: CodegenTypeName<'a>, ty: &'a EnumView<'a, 'a>) -> Self {
-        Self { name, ty }
+    pub fn new(graph: &'a CodegenGraph<'a>, ty: &'a EnumView<'a, 'a>) -> Self {
+        Self { graph, ty }
     }
 }
 
@@ -26,10 +24,7 @@ impl ToTokens for CodegenEnum<'_> {
         if !self.ty.representable() {
             // If any variant can't be represented as a Rust enum variant,
             // emit a type alias for the enum instead.
-            let type_name: Ident = {
-                let name = &self.name;
-                parse_quote!(#name)
-            };
+            let type_name = CodegenIdentUsage::Type(self.graph.ident(self.ty.id()));
             let doc_attrs = self.ty.description().map(doc_attrs);
             tokens.append_all(quote! {
                 #doc_attrs
@@ -44,8 +39,10 @@ impl ToTokens for CodegenEnum<'_> {
             for variant in self.ty.variants() {
                 match variant {
                     EnumVariant::String(name) => {
-                        let name_ident = CodegenIdent::new(name);
-                        let variant_name = CodegenIdentUsage::Variant(&name_ident);
+                        let variant_name = CodegenIdentUsage::Variant(
+                            self.graph
+                                .ident(IdentMapping::EnumVariant(self.ty.id(), name)),
+                        );
                         variants.push(quote! { #variant_name });
                         display_arms.push(quote! { Self::#variant_name => #name });
                         from_str_arms.push(quote! { #name => Self::#variant_name });
@@ -55,16 +52,13 @@ impl ToTokens for CodegenEnum<'_> {
             }
 
             // The catch-all `Other` variant comes last.
-            let type_name: Ident = {
-                let name = &self.name;
-                parse_quote!(#name)
-            };
+            let type_name = CodegenIdentUsage::Variant(self.graph.ident(self.ty.id()));
             let other_name = format_ident!("Other{}", type_name);
             variants.push(quote! { #other_name(String) });
             display_arms.push(quote! { Self::#other_name(s) => s.as_str() });
             from_str_arms.push(quote! { _ => Self::#other_name(s.to_owned()) });
 
-            let expecting = format!("a variant of `{type_name}`");
+            let expecting = format!("a variant of `{}`", type_name.display());
 
             let doc_attrs = self.ty.description().map(doc_attrs);
 
@@ -177,12 +171,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Status").unwrap();
-        let schema @ SchemaTypeView::Enum(_, enum_view) = &schema else {
+        let SchemaTypeView::Enum(_, enum_view) = schema else {
             panic!("expected enum `Status`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenEnum::new(name, enum_view);
+        let codegen = CodegenEnum::new(&graph, &enum_view);
 
         let actual: syn::File = parse_quote!(#codegen);
         let expected: syn::File = parse_quote! {
@@ -286,12 +279,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Priority").unwrap();
-        let schema @ SchemaTypeView::Enum(_, view) = &schema else {
+        let SchemaTypeView::Enum(_, view) = schema else {
             panic!("expected enum `Priority`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenEnum::new(name, view);
+        let codegen = CodegenEnum::new(&graph, &view);
 
         let actual: syn::Item = parse_quote!(#codegen);
         let expected: syn::Item = parse_quote! {

--- a/ploidy-codegen-rust/src/graph.rs
+++ b/ploidy-codegen-rust/src/graph.rs
@@ -1,48 +1,416 @@
-use std::ops::Deref;
+use std::{collections::BTreeSet, fmt::Write, ops::Deref};
 
 use ploidy_core::{
-    codegen::UniqueNames,
-    ir::{CookedGraph, ExtendableView, PrimitiveType},
+    ir::{
+        ContainerView, CookedGraph, EnumVariant, EnumView, HasResource, HasTypeId,
+        InlineTypePathRoot, InlineTypePathSegment, InlineTypePathView, InlineTypeView, OperationId,
+        OperationUsage, SchemaTypeView, StructFieldName, StructView, TaggedView, TypeId, TypeView,
+        UntaggedView, View,
+    },
+    parse::ParameterLocation,
+};
+use rustc_hash::FxHashMap;
+
+use super::{
+    config::{CodegenConfig, DateTimeFormat},
+    naming::{CodegenIdentUsage, ResourceGroup, UniqueIdent, UniqueIdents},
 };
 
-use super::{config::CodegenConfig, naming::CodegenIdentScope};
-
-/// Decorates a [`CookedGraph`] with Rust-specific information.
+/// A [`CookedGraph`] decorated with Rust-specific information.
 #[derive(Debug)]
-pub struct CodegenGraph<'a>(CookedGraph<'a>);
+pub struct CodegenGraph<'a> {
+    cooked: CookedGraph<'a>,
+    idents: IdentMap<'a>,
+    date_time_format: DateTimeFormat,
+}
 
 impl<'a> CodegenGraph<'a> {
     /// Wraps a type graph with the default configuration.
+    #[inline]
     pub fn new(cooked: CookedGraph<'a>) -> Self {
         Self::with_config(cooked, &CodegenConfig::default())
     }
 
     /// Wraps a type graph with the given configuration.
+    #[inline]
     pub fn with_config(cooked: CookedGraph<'a>, config: &CodegenConfig) -> Self {
-        // Decorate named schema types with their Rust identifier names.
-        let unique = UniqueNames::new();
-        let mut scope = CodegenIdentScope::new(&unique);
-        for mut view in cooked.schemas() {
-            let ident = scope.uniquify(view.name());
-            view.extensions_mut().insert(ident);
+        let idents = ident_map(&cooked);
+        Self {
+            cooked,
+            idents,
+            date_time_format: config.date_time_format,
         }
+    }
 
-        // Decorate `DateTime` primitives with the format.
-        for mut view in cooked
-            .primitives()
-            .filter(|view| matches!(view.ty(), PrimitiveType::DateTime))
-        {
-            view.extensions_mut().insert(config.date_time_format);
+    /// Returns the unique Rust identifier for a schema, operation, parameter,
+    /// field, or variant.
+    #[inline]
+    pub fn ident(&self, key: impl Into<IdentMapping<'a>>) -> &'a UniqueIdent {
+        use {IdentMapKey as Key, IdentMapping::*};
+        match key.into() {
+            Operation(op) => self.idents[&Key::Operation(op)],
+            Path(op, name) => self.idents[&Key::Parameter(op, ParameterLocation::Path, name)],
+            Query(op, name) => self.idents[&Key::Parameter(op, ParameterLocation::Query, name)],
+            Type(id) => match self.cooked.view(id) {
+                TypeView::Schema(s) => self.idents[&Key::Schema(s.name())],
+                TypeView::Inline(i) => self.idents[&Key::Inline(i.id())],
+            },
+            StructField(id, name) => self.idents[&Key::StructField(id, name)],
+            EnumVariant(id, name) => self.idents[&Key::EnumVariant(id, name)],
+            TaggedVariant(id, name) => self.idents[&Key::TaggedVariant(id, name)],
+            UntaggedVariant(id, index) => self.idents[&Key::UntaggedVariant(id, index)],
+            Resource(name) => self.idents[&IdentMapKey::Resource(name)],
         }
+    }
 
-        Self(cooked)
+    /// Returns the resource that contains the given view.
+    #[inline]
+    pub fn resource_for(&self, view: &impl HasResource<'a>) -> ResourceGroup<'a> {
+        view.resource()
+            .map(|name| ResourceGroup::Named(self.idents[&IdentMapKey::Resource(name)]))
+            .unwrap_or_default()
+    }
+
+    /// Returns the format to use for `date-time` types.
+    #[inline]
+    pub fn date_time_format(&self) -> DateTimeFormat {
+        self.date_time_format
     }
 }
 
 impl<'a> Deref for CodegenGraph<'a> {
     type Target = CookedGraph<'a>;
 
+    #[inline]
     fn deref(&self) -> &Self::Target {
-        &self.0
+        &self.cooked
     }
+}
+
+/// An item with a uniquified Rust identifier in a [`CodegenGraph`].
+pub enum IdentMapping<'a> {
+    /// A schema or inline type.
+    Type(TypeId),
+
+    /// An operation method.
+    Operation(&'a OperationId),
+
+    /// A path parameter for an operation.
+    Path(&'a OperationId, &'a str),
+
+    /// A query parameter for an operation.
+    Query(&'a OperationId, &'a str),
+
+    /// A struct field.
+    StructField(TypeId, StructFieldName<'a>),
+
+    /// A string enum variant.
+    EnumVariant(TypeId, &'a str),
+
+    /// A tagged union variant.
+    TaggedVariant(TypeId, &'a str),
+
+    /// An untagged union variant.
+    UntaggedVariant(TypeId, usize),
+
+    /// ...
+    Resource(&'a str),
+}
+
+impl<'a> From<&'a OperationId> for IdentMapping<'a> {
+    #[inline]
+    fn from(id: &'a OperationId) -> Self {
+        Self::Operation(id)
+    }
+}
+
+impl<'a> From<TypeId> for IdentMapping<'a> {
+    #[inline]
+    fn from(id: TypeId) -> Self {
+        Self::Type(id)
+    }
+}
+
+/// Builds the identifier table for every name that Rust code generation emits.
+///
+/// Names are assigned in dependency order. Schema, operation, parameter, field,
+/// and variant identifiers are uniquified first; inline type names are composed
+/// from those earlier identifiers.
+fn ident_map<'a>(cooked: &CookedGraph<'a>) -> IdentMap<'a> {
+    let mut idents = FxHashMap::default();
+    idents.extend({
+        let mut scope = UniqueIdents::new(cooked.arena());
+        cooked
+            .schemas()
+            .map(move |ty| (IdentMapKey::Schema(ty.name()), scope.ident(ty.name())))
+    });
+    idents.extend({
+        let mut scope = UniqueIdents::new(cooked.arena());
+        cooked
+            .operations()
+            .map(move |op| (IdentMapKey::Operation(op.id()), scope.ident(op.id())))
+    });
+    idents.extend({
+        let resources: BTreeSet<_> = cooked
+            .operations()
+            .filter_map(|op| op.resource())
+            .chain(cooked.schemas().filter_map(|ty| ty.resource()))
+            .collect();
+        // Resources become feature names; `default` is a special feature name.
+        let mut scope = UniqueIdents::with_reserved(cooked.arena(), &["default"]);
+        resources
+            .into_iter()
+            .map(move |name| (IdentMapKey::Resource(name), scope.ident(name)))
+    });
+    for op in cooked.operations() {
+        {
+            // Path parameters become arguments, so we need to reserve
+            // local variable and argument names that we use in the
+            // generated operation method body.
+            let mut scope = UniqueIdents::with_reserved(
+                cooked.arena(),
+                &["query", "request", "form", "url", "response"],
+            );
+            for param in op.path().params() {
+                let ident = scope.ident(param.name());
+                idents.insert(
+                    IdentMapKey::Parameter(op.id(), ParameterLocation::Path, param.name()),
+                    ident,
+                );
+            }
+        }
+        {
+            // Query parameters become regular struct fields.
+            let mut scope = UniqueIdents::new(cooked.arena());
+            for param in op.query() {
+                let ident = scope.ident(param.name());
+                idents.insert(
+                    IdentMapKey::Parameter(op.id(), ParameterLocation::Query, param.name()),
+                    ident,
+                );
+            }
+        }
+    }
+
+    {
+        let domains = cooked
+            .schemas()
+            .filter_map(MemberIdentDomain::from_schema_type)
+            .chain(
+                cooked
+                    .schemas()
+                    .flat_map(|s| s.inlines())
+                    .chain(cooked.operations().flat_map(|op| op.inlines()))
+                    .filter_map(MemberIdentDomain::from_inline_type),
+            );
+        for domain in domains {
+            match domain {
+                // Own, inherited, and synthesized struct fields.
+                MemberIdentDomain::Struct(id, view) => {
+                    let mut scope = UniqueIdents::new(cooked.arena());
+                    for field in view.fields() {
+                        let ident = match field.name() {
+                            StructFieldName::Name(n) => scope.ident(n),
+                            StructFieldName::Hint(hint) => scope.field_name_hint(hint),
+                        };
+                        idents.insert(IdentMapKey::StructField(id, field.name()), ident);
+                    }
+                }
+                // Common fields inherited by all untagged variants. The struct arm
+                // uniquifies them for fields; this arm uniquifies them for
+                // naming inline types.
+                MemberIdentDomain::Untagged(id, view) => {
+                    let mut scope = UniqueIdents::new(cooked.arena());
+                    for (index, variant) in view.variants().enumerate() {
+                        let ident = match variant.ty() {
+                            Some(variant) => scope.variant_name_hint(variant.hint),
+                            None => scope.ident("None"),
+                        };
+                        idents.insert(IdentMapKey::UntaggedVariant(id, index), ident);
+                    }
+                    let mut scope = UniqueIdents::new(cooked.arena());
+                    for field in view.fields() {
+                        let ident = match field.name() {
+                            StructFieldName::Name(n) => scope.ident(n),
+                            StructFieldName::Hint(hint) => scope.field_name_hint(hint),
+                        };
+                        idents.insert(IdentMapKey::StructField(id, field.name()), ident);
+                    }
+                }
+                // String enum variants.
+                MemberIdentDomain::Enum(id, view) => {
+                    let mut scope = UniqueIdents::new(cooked.arena());
+                    for variant in view.variants() {
+                        if let EnumVariant::String(name) = variant {
+                            let ident = scope.ident(name);
+                            idents.insert(IdentMapKey::EnumVariant(id, name), ident);
+                        }
+                    }
+                }
+                // Tagged variant names and common fields form different scopes:
+                // variant names must be unique within the generated enum;
+                // common fields are for naming inline types.
+                MemberIdentDomain::Tagged(id, view) => {
+                    let mut scope = UniqueIdents::new(cooked.arena());
+                    for variant in view.variants() {
+                        let ident = scope.ident(variant.name());
+                        idents.insert(IdentMapKey::TaggedVariant(id, variant.name()), ident);
+                    }
+                    let mut scope = UniqueIdents::new(cooked.arena());
+                    for field in view.fields() {
+                        let ident = match field.name() {
+                            StructFieldName::Name(n) => scope.ident(n),
+                            StructFieldName::Hint(hint) => scope.field_name_hint(hint),
+                        };
+                        idents.insert(IdentMapKey::StructField(id, field.name()), ident);
+                    }
+                }
+            }
+        }
+    }
+
+    // Inline type names depend on uniquified path segments, so build them after
+    // all schemas, operations, parameters, fields, and variants have names.
+    {
+        let inlines = cooked
+            .schemas()
+            .flat_map(|schema| schema.inlines())
+            .chain(cooked.operations().flat_map(|op| op.inlines()))
+            .filter(|ty| {
+                // Optional types are invisible for naming.
+                !matches!(ty, InlineTypeView::Container(_, ContainerView::Optional(_)))
+            });
+
+        let mut scopes = FxHashMap::default();
+        for inline in inlines {
+            let path = inline.path();
+            let domain = match path.root() {
+                InlineTypePathRoot::Schema(id) => InlineTypeIdentDomain::Schema(id),
+                InlineTypePathRoot::Operation { resource, .. } => InlineTypeIdentDomain::Resource(
+                    resource
+                        .map(|name| ResourceGroup::Named(idents[&IdentMapKey::Resource(name)]))
+                        .unwrap_or_default(),
+                ),
+            };
+            let name = inline_type_candidate_name(&idents, &path);
+            let scope = scopes
+                .entry(domain)
+                .or_insert_with(|| UniqueIdents::new(cooked.arena()));
+            idents.insert(IdentMapKey::Inline(inline.id()), scope.ident(&name));
+        }
+    }
+    idents
+}
+
+type IdentMap<'a> = FxHashMap<IdentMapKey<'a>, &'a UniqueIdent>;
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+enum IdentMapKey<'a> {
+    Schema(&'a str),
+    Inline(TypeId),
+    Operation(&'a OperationId),
+    Parameter(&'a OperationId, ParameterLocation, &'a str),
+    Resource(&'a str),
+    StructField(TypeId, StructFieldName<'a>),
+    EnumVariant(TypeId, &'a str),
+    TaggedVariant(TypeId, &'a str),
+    UntaggedVariant(TypeId, usize),
+}
+
+/// A uniqueness domain for inline type identifiers.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+enum InlineTypeIdentDomain<'a> {
+    Schema(TypeId),
+    Resource(ResourceGroup<'a>),
+}
+
+/// A uniqueness domain for field and variant identifiers.
+enum MemberIdentDomain<'graph, 'a> {
+    Struct(TypeId, StructView<'graph, 'a>),
+    Enum(TypeId, EnumView<'graph, 'a>),
+    Tagged(TypeId, TaggedView<'graph, 'a>),
+    Untagged(TypeId, UntaggedView<'graph, 'a>),
+}
+
+impl<'graph, 'a> MemberIdentDomain<'graph, 'a> {
+    fn from_schema_type(schema: SchemaTypeView<'graph, 'a>) -> Option<Self> {
+        let id = schema.id();
+        Some(match schema {
+            SchemaTypeView::Struct(_, v) => Self::Struct(id, v),
+            SchemaTypeView::Enum(_, v) => Self::Enum(id, v),
+            SchemaTypeView::Tagged(_, v) => Self::Tagged(id, v),
+            SchemaTypeView::Untagged(_, v) => Self::Untagged(id, v),
+            _ => return None,
+        })
+    }
+
+    fn from_inline_type(inline: InlineTypeView<'graph, 'a>) -> Option<Self> {
+        let id = inline.id();
+        Some(match inline {
+            InlineTypeView::Struct(_, v) => Self::Struct(id, v),
+            InlineTypeView::Enum(_, v) => Self::Enum(id, v),
+            InlineTypeView::Tagged(_, v) => Self::Tagged(id, v),
+            InlineTypeView::Untagged(_, v) => Self::Untagged(id, v),
+            _ => return None,
+        })
+    }
+}
+
+fn inline_type_candidate_name<'a>(
+    idents: &IdentMap<'a>,
+    path: &InlineTypePathView<'_, 'a>,
+) -> String {
+    let mut name = String::new();
+
+    match path.root() {
+        InlineTypePathRoot::Schema(_) => {}
+        InlineTypePathRoot::Operation { id, usage, .. } => {
+            let ident = idents[&IdentMapKey::Operation(id)];
+            write!(name, "{}", CodegenIdentUsage::Type(ident).display()).unwrap();
+
+            match usage {
+                OperationUsage::Path(param) => {
+                    let ident = idents[&IdentMapKey::Parameter(id, ParameterLocation::Path, param)];
+                    write!(name, "Path{}", CodegenIdentUsage::Type(ident).display()).unwrap();
+                }
+                OperationUsage::Query(param) => {
+                    let ident =
+                        idents[&IdentMapKey::Parameter(id, ParameterLocation::Query, param)];
+                    write!(name, "Query{}", CodegenIdentUsage::Type(ident).display()).unwrap();
+                }
+                OperationUsage::Request => name.push_str("Request"),
+                OperationUsage::Response => name.push_str("Response"),
+            }
+        }
+    }
+
+    for segment in path.segments() {
+        match segment {
+            InlineTypePathSegment::Field(parent, field_name) => {
+                let ident = idents[&IdentMapKey::StructField(parent, field_name)];
+                write!(name, "{}", CodegenIdentUsage::Type(ident).display()).unwrap();
+            }
+            InlineTypePathSegment::TaggedVariant(parent, variant_name) => {
+                let ident = idents[&IdentMapKey::TaggedVariant(parent, variant_name)];
+                write!(name, "{}", CodegenIdentUsage::Variant(ident).display()).unwrap();
+            }
+            InlineTypePathSegment::UntaggedVariant(index) => {
+                write!(name, "V{index}").unwrap();
+            }
+            InlineTypePathSegment::ArrayItem => name.push_str("Item"),
+            InlineTypePathSegment::MapValue => name.push_str("Value"),
+            InlineTypePathSegment::Optional => {
+                // Optional types are invisible for naming.
+            }
+            InlineTypePathSegment::Inherits(index) => {
+                write!(name, "P{index}").unwrap();
+            }
+        }
+    }
+
+    if name.is_empty() {
+        name.push_str("Value");
+    }
+
+    name
 }

--- a/ploidy-codegen-rust/src/inlines.rs
+++ b/ploidy-codegen-rust/src/inlines.rs
@@ -1,83 +1,85 @@
 use itertools::Itertools;
-use ploidy_core::ir::{InlineTypeView, OperationView, SchemaTypeView, View};
+use ploidy_core::ir::{HasTypeId, InlineTypeView};
 use proc_macro2::TokenStream;
 use quote::{ToTokens, TokenStreamExt, quote};
 
 use super::{
-    cfg::CfgFeature,
-    enum_::CodegenEnum,
-    naming::{CodegenTypeName, CodegenTypeNameSortKey},
-    struct_::CodegenStruct,
-    tagged::CodegenTagged,
-    untagged::CodegenUntagged,
+    cfg::CfgFeature, enum_::CodegenEnum, graph::CodegenGraph, naming::CodegenIdentUsage,
+    struct_::CodegenStruct, tagged::CodegenTagged, untagged::CodegenUntagged,
 };
 
-/// Generates an inline `mod types`, with definitions for all the inline types
-/// that are reachable from a resource or schema type.
-///
-/// Inline types nested _within_ referenced schemas are excluded; those are
-/// emitted by [`CodegenSchemaType`](crate::CodegenSchemaType) instead.
-#[derive(Clone, Copy, Debug)]
-pub enum CodegenInlines<'a> {
-    Resource(&'a [OperationView<'a, 'a>]),
-    Schema(&'a SchemaTypeView<'a, 'a>),
+/// Generates a `mod types` for inline structs, enums, and unions.
+#[derive(Debug)]
+pub struct CodegenInlines<'a> {
+    graph: &'a CodegenGraph<'a>,
+    inlines: Vec<InlineTypeView<'a, 'a>>,
+    cfg: bool,
 }
 
-impl ToTokens for CodegenInlines<'_> {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        match self {
-            Self::Resource(ops) => {
-                let items = CodegenInlineItems(IncludeCfgFeatures::Include, ops);
-                items.to_tokens(tokens);
-            }
-            &Self::Schema(ty) => {
-                let items = CodegenInlineItems(IncludeCfgFeatures::Omit, std::slice::from_ref(ty));
-                items.to_tokens(tokens);
-            }
+impl<'a> CodegenInlines<'a> {
+    /// Creates a codegen node for a schema module's inline types.
+    pub fn for_schema_inlines(
+        graph: &'a CodegenGraph<'a>,
+        inlines: Vec<InlineTypeView<'a, 'a>>,
+    ) -> Self {
+        Self {
+            graph,
+            inlines,
+            cfg: false,
+        }
+    }
+
+    /// Creates a codegen node for a resource module's inline types.
+    pub fn for_resource_inlines(
+        graph: &'a CodegenGraph<'a>,
+        inlines: Vec<InlineTypeView<'a, 'a>>,
+    ) -> Self {
+        Self {
+            graph,
+            inlines,
+            cfg: true,
         }
     }
 }
 
-#[derive(Debug)]
-struct CodegenInlineItems<'a, V>(IncludeCfgFeatures, &'a [V]);
-
-impl<'a, V> ToTokens for CodegenInlineItems<'a, V>
-where
-    V: View<'a, 'a>,
-{
+impl ToTokens for CodegenInlines<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        let mut inlines = self.1.iter().flat_map(|op| op.inlines()).collect_vec();
-        inlines.sort_by(|a, b| {
-            CodegenTypeNameSortKey::for_inline(a).cmp(&CodegenTypeNameSortKey::for_inline(b))
-        });
+        let graph = self.graph;
 
-        let mut items = inlines.into_iter().filter_map(|view| {
-            let name = CodegenTypeName::Inline(&view);
-            let ty = match &view {
-                InlineTypeView::Enum(_, view) => CodegenEnum::new(name, view).into_token_stream(),
-                InlineTypeView::Struct(_, view) => {
-                    CodegenStruct::new(name, view).into_token_stream()
-                }
-                InlineTypeView::Tagged(_, view) => {
-                    CodegenTagged::new(name, view).into_token_stream()
-                }
-                InlineTypeView::Untagged(_, view) => {
-                    CodegenUntagged::new(name, view).into_token_stream()
-                }
-                InlineTypeView::Container(..)
-                | InlineTypeView::Primitive(..)
-                | InlineTypeView::Any(..) => {
-                    // Container types, primitive types, and untyped values
-                    // are emitted directly; they don't need type aliases.
-                    return None;
-                }
-            };
-            Some(match self.0 {
-                IncludeCfgFeatures::Include => {
-                    // Wrap each type in an inner inline module, so that
-                    // the `#[cfg(...)]` applies to all items (types and `impl`s).
-                    let cfg = CfgFeature::for_inline_type(&view);
-                    let mod_name = name.into_module_name();
+        let mut items = self
+            .inlines
+            .iter()
+            .filter_map(|view| {
+                let (ident, ty) = match view {
+                    InlineTypeView::Struct(_, view) => (
+                        graph.ident(view.id()),
+                        CodegenStruct::new(graph, view).into_token_stream(),
+                    ),
+                    InlineTypeView::Enum(_, view) => (
+                        graph.ident(view.id()),
+                        CodegenEnum::new(graph, view).into_token_stream(),
+                    ),
+                    InlineTypeView::Tagged(_, view) => (
+                        graph.ident(view.id()),
+                        CodegenTagged::new(graph, view).into_token_stream(),
+                    ),
+                    InlineTypeView::Untagged(_, view) => (
+                        graph.ident(view.id()),
+                        CodegenUntagged::new(graph, view).into_token_stream(),
+                    ),
+                    InlineTypeView::Container(..)
+                    | InlineTypeView::Primitive(..)
+                    | InlineTypeView::Any(..) => {
+                        // Container types, primitive types, and untyped values
+                        // are emitted directly; they don't need type aliases.
+                        return None;
+                    }
+                };
+                let item = if self.cfg {
+                    // Wrap each type in an inner module, so that the
+                    // `#[cfg(...)]` applies to all items (types and `impl`s).
+                    let cfg = CfgFeature::for_inline_type(graph, view);
+                    let mod_name = CodegenIdentUsage::Module(ident);
                     quote! {
                         #cfg
                         mod #mod_name {
@@ -86,10 +88,15 @@ where
                         #cfg
                         pub use #mod_name::*;
                     }
-                }
-                IncludeCfgFeatures::Omit => ty,
+                } else {
+                    ty
+                };
+                Some((ident, item))
             })
-        });
+            .collect_vec();
+
+        items.sort_by_key(|&(ident, _)| ident);
+        let mut items = items.into_iter().map(|(_, item)| item);
 
         if let Some(first) = items.next() {
             tokens.append_all(quote! {
@@ -102,20 +109,13 @@ where
     }
 }
 
-#[derive(Clone, Copy, Debug)]
-enum IncludeCfgFeatures {
-    Include,
-    Omit,
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    use itertools::Itertools;
     use ploidy_core::{
         arena::Arena,
-        ir::{RawGraph, Spec},
+        ir::{RawGraph, Spec, View},
         parse::Document,
     };
     use pretty_assertions::assert_eq;
@@ -152,22 +152,163 @@ mod tests {
         let spec = Spec::from_doc(&arena, &doc).unwrap();
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
-        let ops = graph.operations().collect_vec();
-        let inlines = CodegenInlines::Resource(&ops);
+        let inlines = CodegenInlines::for_resource_inlines(
+            &graph,
+            graph.operations().flat_map(|op| op.inlines()).collect(),
+        );
 
         let actual: syn::File = parse_quote!(#inlines);
         let expected: syn::File = parse_quote! {
             pub mod types {
-                mod get_items_filter {
+                mod get_items_query_filter {
                     #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
                     #[serde(crate = "::ploidy_util::serde")]
                     #[ploidy(pointer(crate = "::ploidy_util::pointer"))]
-                    pub struct GetItemsFilter {
+                    pub struct GetItemsQueryFilter {
                         #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent")]
                         pub status: ::ploidy_util::absent::AbsentOr<::std::string::String>,
                     }
                 }
-                pub use get_items_filter::*;
+                pub use get_items_query_filter::*;
+            }
+        };
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_operation_parameter_inline_type_names_do_not_collide_across_roles() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths:
+              /things/{id}:
+                get:
+                  operationId: getThing
+                  parameters:
+                    - name: id
+                      in: path
+                      required: true
+                      schema:
+                        type: object
+                        properties:
+                          path_value:
+                            type: string
+                    - name: id
+                      in: query
+                      schema:
+                        type: object
+                        properties:
+                          query_value:
+                            type: string
+                    - name: request
+                      in: query
+                      schema:
+                        type: object
+                        properties:
+                          query_request_value:
+                            type: string
+                    - name: response
+                      in: query
+                      schema:
+                        type: object
+                        properties:
+                          query_response_value:
+                            type: string
+                  requestBody:
+                    content:
+                      application/json:
+                        schema:
+                          type: object
+                          properties:
+                            body_request_value:
+                              type: string
+                  responses:
+                    '200':
+                      description: OK
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                            properties:
+                              body_response_value:
+                                type: string
+        "})
+        .unwrap();
+
+        let arena = Arena::new();
+        let spec = Spec::from_doc(&arena, &doc).unwrap();
+        let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
+
+        let inlines = CodegenInlines::for_resource_inlines(
+            &graph,
+            graph.operations().flat_map(|op| op.inlines()).collect(),
+        );
+
+        let actual: syn::File = parse_quote!(#inlines);
+        let expected: syn::File = parse_quote! {
+            pub mod types {
+                mod get_thing_path_id {
+                    #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
+                    #[serde(crate = "::ploidy_util::serde")]
+                    #[ploidy(pointer(crate = "::ploidy_util::pointer"))]
+                    pub struct GetThingPathId {
+                        #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent")]
+                        pub path_value: ::ploidy_util::absent::AbsentOr<::std::string::String>,
+                    }
+                }
+                pub use get_thing_path_id::*;
+                mod get_thing_query_id {
+                    #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
+                    #[serde(crate = "::ploidy_util::serde")]
+                    #[ploidy(pointer(crate = "::ploidy_util::pointer"))]
+                    pub struct GetThingQueryId {
+                        #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent")]
+                        pub query_value: ::ploidy_util::absent::AbsentOr<::std::string::String>,
+                    }
+                }
+                pub use get_thing_query_id::*;
+                mod get_thing_query_request {
+                    #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
+                    #[serde(crate = "::ploidy_util::serde")]
+                    #[ploidy(pointer(crate = "::ploidy_util::pointer"))]
+                    pub struct GetThingQueryRequest {
+                        #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent")]
+                        pub query_request_value: ::ploidy_util::absent::AbsentOr<::std::string::String>,
+                    }
+                }
+                pub use get_thing_query_request::*;
+                mod get_thing_query_response {
+                    #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
+                    #[serde(crate = "::ploidy_util::serde")]
+                    #[ploidy(pointer(crate = "::ploidy_util::pointer"))]
+                    pub struct GetThingQueryResponse {
+                        #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent")]
+                        pub query_response_value: ::ploidy_util::absent::AbsentOr<::std::string::String>,
+                    }
+                }
+                pub use get_thing_query_response::*;
+                mod get_thing_request {
+                    #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
+                    #[serde(crate = "::ploidy_util::serde")]
+                    #[ploidy(pointer(crate = "::ploidy_util::pointer"))]
+                    pub struct GetThingRequest {
+                        #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent")]
+                        pub body_request_value: ::ploidy_util::absent::AbsentOr<::std::string::String>,
+                    }
+                }
+                pub use get_thing_request::*;
+                mod get_thing_response {
+                    #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
+                    #[serde(crate = "::ploidy_util::serde")]
+                    #[ploidy(pointer(crate = "::ploidy_util::pointer"))]
+                    pub struct GetThingResponse {
+                        #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent")]
+                        pub body_response_value: ::ploidy_util::absent::AbsentOr<::std::string::String>,
+                    }
+                }
+                pub use get_thing_response::*;
             }
         };
         assert_eq!(actual, expected);
@@ -211,8 +352,10 @@ mod tests {
         let spec = Spec::from_doc(&arena, &doc).unwrap();
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
-        let ops = graph.operations().collect_vec();
-        let inlines = CodegenInlines::Resource(&ops);
+        let inlines = CodegenInlines::for_resource_inlines(
+            &graph,
+            graph.operations().flat_map(|op| op.inlines()).collect(),
+        );
 
         // No inline types should be emitted, since the only inline (`Details`)
         // belongs to the referenced schema.
@@ -265,43 +408,45 @@ mod tests {
         let spec = Spec::from_doc(&arena, &doc).unwrap();
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
-        let ops = graph.operations().collect_vec();
-        let inlines = CodegenInlines::Resource(&ops);
+        let inlines = CodegenInlines::for_resource_inlines(
+            &graph,
+            graph.operations().flat_map(|op| op.inlines()).collect(),
+        );
 
         let actual: syn::File = parse_quote!(#inlines);
         // Types should be sorted: Apple, Mango, Zebra.
         let expected: syn::File = parse_quote! {
             pub mod types {
-                mod get_items_apple {
+                mod get_items_query_apple {
                     #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
                     #[serde(crate = "::ploidy_util::serde")]
                     #[ploidy(pointer(crate = "::ploidy_util::pointer"))]
-                    pub struct GetItemsApple {
+                    pub struct GetItemsQueryApple {
                         #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent")]
                         pub value: ::ploidy_util::absent::AbsentOr<::std::string::String>,
                     }
                 }
-                pub use get_items_apple::*;
-                mod get_items_mango {
+                pub use get_items_query_apple::*;
+                mod get_items_query_mango {
                     #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
                     #[serde(crate = "::ploidy_util::serde")]
                     #[ploidy(pointer(crate = "::ploidy_util::pointer"))]
-                    pub struct GetItemsMango {
+                    pub struct GetItemsQueryMango {
                         #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent")]
                         pub value: ::ploidy_util::absent::AbsentOr<::std::string::String>,
                     }
                 }
-                pub use get_items_mango::*;
-                mod get_items_zebra {
+                pub use get_items_query_mango::*;
+                mod get_items_query_zebra {
                     #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
                     #[serde(crate = "::ploidy_util::serde")]
                     #[ploidy(pointer(crate = "::ploidy_util::pointer"))]
-                    pub struct GetItemsZebra {
+                    pub struct GetItemsQueryZebra {
                         #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent")]
                         pub value: ::ploidy_util::absent::AbsentOr<::std::string::String>,
                     }
                 }
-                pub use get_items_zebra::*;
+                pub use get_items_query_zebra::*;
             }
         };
         assert_eq!(actual, expected);
@@ -333,8 +478,10 @@ mod tests {
         let spec = Spec::from_doc(&arena, &doc).unwrap();
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
-        let ops = graph.operations().collect_vec();
-        let inlines = CodegenInlines::Resource(&ops);
+        let inlines = CodegenInlines::for_resource_inlines(
+            &graph,
+            graph.operations().flat_map(|op| op.inlines()).collect(),
+        );
 
         let actual: syn::File = parse_quote!(#inlines);
         let expected: syn::File = parse_quote! {};
@@ -371,22 +518,24 @@ mod tests {
         let spec = Spec::from_doc(&arena, &doc).unwrap();
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
-        let ops = graph.operations().collect_vec();
-        let inlines = CodegenInlines::Resource(&ops);
+        let inlines = CodegenInlines::for_resource_inlines(
+            &graph,
+            graph.operations().flat_map(|op| op.inlines()).collect(),
+        );
 
         let actual: syn::File = parse_quote!(#inlines);
         let expected: syn::File = parse_quote! {
             pub mod types {
-                mod get_items_config {
+                mod get_items_query_config {
                     #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
                     #[serde(crate = "::ploidy_util::serde")]
                     #[ploidy(pointer(crate = "::ploidy_util::pointer"))]
-                    pub struct GetItemsConfig {
+                    pub struct GetItemsQueryConfig {
                         #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent")]
                         pub enabled: ::ploidy_util::absent::AbsentOr<bool>,
                     }
                 }
-                pub use get_items_config::*;
+                pub use get_items_query_config::*;
             }
         };
         assert_eq!(actual, expected);
@@ -423,22 +572,24 @@ mod tests {
         let spec = Spec::from_doc(&arena, &doc).unwrap();
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
-        let ops = graph.operations().collect_vec();
-        let inlines = CodegenInlines::Resource(&ops);
+        let inlines = CodegenInlines::for_resource_inlines(
+            &graph,
+            graph.operations().flat_map(|op| op.inlines()).collect(),
+        );
 
         let actual: syn::File = parse_quote!(#inlines);
         let expected: syn::File = parse_quote! {
             pub mod types {
-                mod get_items_filters_item {
+                mod get_items_query_filters_item {
                     #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
                     #[serde(crate = "::ploidy_util::serde")]
                     #[ploidy(pointer(crate = "::ploidy_util::pointer"))]
-                    pub struct GetItemsFiltersItem {
+                    pub struct GetItemsQueryFiltersItem {
                         #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent")]
                         pub field: ::ploidy_util::absent::AbsentOr<::std::string::String>,
                     }
                 }
-                pub use get_items_filters_item::*;
+                pub use get_items_query_filters_item::*;
             }
         };
         assert_eq!(actual, expected);
@@ -475,22 +626,24 @@ mod tests {
         let spec = Spec::from_doc(&arena, &doc).unwrap();
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
-        let ops = graph.operations().collect_vec();
-        let inlines = CodegenInlines::Resource(&ops);
+        let inlines = CodegenInlines::for_resource_inlines(
+            &graph,
+            graph.operations().flat_map(|op| op.inlines()).collect(),
+        );
 
         let actual: syn::File = parse_quote!(#inlines);
         let expected: syn::File = parse_quote! {
             pub mod types {
-                mod get_items_metadata_value {
+                mod get_items_query_metadata_value {
                     #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
                     #[serde(crate = "::ploidy_util::serde")]
                     #[ploidy(pointer(crate = "::ploidy_util::pointer"))]
-                    pub struct GetItemsMetadataValue {
+                    pub struct GetItemsQueryMetadataValue {
                         #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent")]
                         pub value: ::ploidy_util::absent::AbsentOr<::std::string::String>,
                     }
                 }
-                pub use get_items_metadata_value::*;
+                pub use get_items_query_metadata_value::*;
             }
         };
         assert_eq!(actual, expected);

--- a/ploidy-codegen-rust/src/lib.rs
+++ b/ploidy-codegen-rust/src/lib.rs
@@ -36,7 +36,6 @@ pub use cfg::*;
 pub use client::*;
 pub use config::*;
 pub use graph::*;
-pub use inlines::*;
 pub use naming::*;
 pub use operation::*;
 pub use primitive::*;
@@ -47,8 +46,8 @@ pub use statics::*;
 pub use types::*;
 
 pub fn write_types_to_disk(output: &Path, graph: &CodegenGraph<'_>) -> miette::Result<()> {
-    for view in graph.schemas() {
-        let code = CodegenSchemaType::new(&view).into_code();
+    for schema in graph.schemas() {
+        let code = CodegenSchemaType::new(graph, &schema).into_code();
         write_to_disk(output, code)?;
     }
 
@@ -58,29 +57,22 @@ pub fn write_types_to_disk(output: &Path, graph: &CodegenGraph<'_>) -> miette::R
 }
 
 pub fn write_client_to_disk(output: &Path, graph: &CodegenGraph<'_>) -> miette::Result<()> {
-    // Group operations by feature. All operations belong to a feature,
-    // or `default` for operations without a named resource.
-    let ops_by_feature = graph
-        .operations()
-        .fold(BTreeMap::<_, Vec<_>>::new(), |mut map, view| {
-            let feature = view
-                .resource()
-                .map(CargoFeature::from_name)
-                .unwrap_or_default();
-            map.entry(feature).or_default().push(view);
+    // Group operations by resource name.
+    let ops_by_resource: BTreeMap<_, Vec<_>> =
+        graph.operations().fold(BTreeMap::default(), |mut map, op| {
+            let resource = graph.resource_for(&op);
+            map.entry(resource).or_default().push(op);
             map
         });
 
-    // Write all operations for each feature into separate modules.
-    for (feature, ops) in &ops_by_feature {
-        let code = CodegenResource::new(feature, ops);
-        write_to_disk(output, code)?;
+    // Write a module per resource.
+    for (ident, ops) in &ops_by_resource {
+        write_to_disk(output, CodegenResource::new(graph, *ident, ops))?;
     }
 
     // Write the top-level client module.
-    let features = ops_by_feature.keys().collect_vec();
-    let mod_code = CodegenClientModule::new(graph, &features);
-    write_to_disk(output, mod_code)?;
+    let idents = ops_by_resource.keys().copied().collect_vec();
+    write_to_disk(output, CodegenClientModule::new(graph, &idents))?;
 
     Ok(())
 }

--- a/ploidy-codegen-rust/src/naming.rs
+++ b/ploidy-codegen-rust/src/naming.rs
@@ -192,11 +192,7 @@ impl<'a> UniqueIdents<'a> {
     pub fn with_reserved(arena: &'a Arena, reserved: &[&str]) -> Self {
         Self(UniqueNames::with_reserved(
             arena,
-            itertools::chain!(
-                reserved.iter().copied(),
-                KEYWORDS.iter().copied(),
-                std::iter::once("")
-            ),
+            reserved.iter().chain(KEYWORDS).copied(),
         ))
     }
 
@@ -260,7 +256,7 @@ impl<'a> UniqueIdents<'a> {
 #[inline]
 fn clean(s: &str) -> String {
     WordSegments::new(s)
-        .flat_map(|s| s.split(|c| !unicode_ident::is_xid_continue(c)))
+        .flat_map(|(_, s)| s.split(|c| !unicode_ident::is_xid_continue(c)))
         .join("_")
 }
 
@@ -399,7 +395,7 @@ mod tests {
         let mut scope = UniqueIdents::new(&arena);
 
         let ident = scope.variant_name_hint(UntaggedVariantNameHint::Index(0));
-        assert_eq!(&ident.0, "V0");
+        assert_eq!(&ident.0, "V");
 
         let ident = scope.variant_name_hint(UntaggedVariantNameHint::Index(42));
         assert_eq!(&ident.0, "V42");
@@ -414,13 +410,13 @@ mod tests {
         let ident0 = scope.field_name_hint(StructFieldNameHint::Index(0));
         let usage = CodegenIdentUsage::Field(ident0);
         let actual: syn::Ident = parse_quote!(#usage);
-        let expected: syn::Ident = parse_quote!(variant_0);
+        let expected: syn::Ident = parse_quote!(variant);
         assert_eq!(actual, expected);
 
         let ident5 = scope.field_name_hint(StructFieldNameHint::Index(5));
         let usage = CodegenIdentUsage::Field(ident5);
         let actual: syn::Ident = parse_quote!(#usage);
-        let expected: syn::Ident = parse_quote!(variant_5);
+        let expected: syn::Ident = parse_quote!(variant5);
         assert_eq!(actual, expected);
     }
 
@@ -448,7 +444,7 @@ mod tests {
 
         assert_eq!(clean("foo_bar"), "foo_bar");
         assert_eq!(clean("FooBar"), "Foo_Bar");
-        assert_eq!(clean("foo123"), "foo123");
+        assert_eq!(clean("foo123"), "foo_123");
         assert_eq!(clean("_foo"), "foo");
 
         assert_eq!(clean("_foo"), "foo");
@@ -478,12 +474,48 @@ mod tests {
 
         let usage = CodegenIdentUsage::Field(ident);
         let actual: syn::Ident = parse_quote!(#usage);
-        let expected: syn::Ident = parse_quote!(_2);
+        let expected: syn::Ident = parse_quote!(_1);
         assert_eq!(actual, expected);
 
         let usage = CodegenIdentUsage::Type(ident);
         let actual: syn::Ident = parse_quote!(#usage);
+        let expected: syn::Ident = parse_quote!(_1);
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_codegen_ident_scope_handles_numeric_names() {
+        let arena = Arena::new();
+        let mut scope = UniqueIdents::new(&arena);
+
+        let ident = scope.ident("0");
+        let usage = CodegenIdentUsage::Field(ident);
+        let actual: syn::Ident = parse_quote!(#usage);
+        let expected: syn::Ident = parse_quote!(_1);
+        assert_eq!(actual, expected);
+
+        let ident = scope.ident("1");
+        let usage = CodegenIdentUsage::Type(ident);
+        let actual: syn::Ident = parse_quote!(#usage);
         let expected: syn::Ident = parse_quote!(_2);
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_codegen_ident_scope_handles_reserved_suffixes() {
+        let arena = Arena::new();
+        let mut scope = UniqueIdents::new(&arena);
+
+        let ident = scope.ident("crate");
+        let usage = CodegenIdentUsage::Method(ident);
+        let actual: syn::Ident = parse_quote!(#usage);
+        let expected: syn::Ident = parse_quote!(crate2);
+        assert_eq!(actual, expected);
+
+        let ident = scope.ident("crate2");
+        let usage = CodegenIdentUsage::Method(ident);
+        let actual: syn::Ident = parse_quote!(#usage);
+        let expected: syn::Ident = parse_quote!(crate3);
         assert_eq!(actual, expected);
     }
 }

--- a/ploidy-codegen-rust/src/naming.rs
+++ b/ploidy-codegen-rust/src/naming.rs
@@ -1,22 +1,16 @@
 use std::{
-    borrow::{Borrow, Cow},
-    cmp::Ordering,
-    fmt::Display,
+    fmt::{Display, Write},
     ops::Deref,
 };
 
 use heck::{AsKebabCase, AsPascalCase, AsSnekCase};
 use itertools::Itertools;
 use ploidy_core::{
-    codegen::{
-        UniqueNames,
-        unique::{UniqueNamesScope, WordSegments},
-    },
-    ir::{
-        ExtendableView, InlineTypePathSegment, InlineTypeView, PrimitiveType, SchemaTypeView,
-        StructFieldName, StructFieldNameHint, UntaggedVariantNameHint,
-    },
+    arena::Arena,
+    codegen::{UniqueNames, unique::WordSegments},
+    ir::{PrimitiveType, StructFieldNameHint, UntaggedVariantNameHint},
 };
+
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{IdentFragment, ToTokens, TokenStreamExt};
 use ref_cast::{RefCastCustom, ref_cast_custom};
@@ -24,309 +18,40 @@ use ref_cast::{RefCastCustom, ref_cast_custom};
 // Keywords that can't be used as identifiers, even with `r#`.
 const KEYWORDS: &[&str] = &["crate", "self", "super", "Self"];
 
-/// A name for a schema or an inline type, used in generated Rust code.
-///
-/// [`CodegenTypeName`] is the high-level representation of a type name.
-/// For emitting arbitrary identifiers, like fields, parameters, and methods,
-/// use [`CodegenIdent`] and [`CodegenIdentUsage`] instead.
-///
-/// [`CodegenTypeName`] implements [`ToTokens`] to produce PascalCase identifiers
-/// (e.g., `Pet`, `GetItemsFilter`) in [`quote`] macros.
-/// Use [`into_module_name`](Self::into_module_name) for the corresponding module name,
-/// and [`into_sort_key`](Self::into_sort_key) for deterministic sorting.
-#[derive(Clone, Copy, Debug)]
-pub enum CodegenTypeName<'a> {
-    Schema(&'a SchemaTypeView<'a, 'a>),
-    Inline(&'a InlineTypeView<'a, 'a>),
-}
-
-impl<'a> CodegenTypeName<'a> {
-    #[inline]
-    pub fn into_module_name(self) -> CodegenModuleName<'a> {
-        CodegenModuleName(self)
-    }
-
-    #[inline]
-    pub fn into_sort_key(self) -> CodegenTypeNameSortKey<'a> {
-        CodegenTypeNameSortKey(self)
-    }
-}
-
-impl ToTokens for CodegenTypeName<'_> {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        match self {
-            Self::Schema(view) => {
-                let ident = view.extensions().get::<CodegenIdent>().unwrap();
-                CodegenIdentUsage::Type(&ident).to_tokens(tokens);
-            }
-            Self::Inline(view) => {
-                let ident = CodegenIdent::from_segments(view.path().segments);
-                CodegenIdentUsage::Type(&ident).to_tokens(tokens);
-            }
-        }
-    }
-}
-
-/// A module name derived from a [`CodegenTypeName`].
-///
-/// Implements [`ToTokens`] to produce a snake_case identifier. For
-/// string interpolation (e.g., file paths), use [`display`](Self::display),
-/// which returns an `impl Display` that can be used with `format!`.
-#[derive(Clone, Copy, Debug)]
-pub struct CodegenModuleName<'a>(CodegenTypeName<'a>);
-
-impl<'a> CodegenModuleName<'a> {
-    #[inline]
-    pub fn into_type_name(self) -> CodegenTypeName<'a> {
-        self.0
-    }
-
-    /// Returns a formattable representation of this module name.
-    ///
-    /// [`CodegenModuleName`] doesn't implement [`Display`] directly, to help catch
-    /// context mismatches: using `.display()` in a [`quote`] macro, or
-    /// `.to_token_stream()` in a [`format`] string, stands out during review.
-    pub fn display(&self) -> impl Display {
-        struct DisplayModuleName<'a>(CodegenTypeName<'a>);
-        impl Display for DisplayModuleName<'_> {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                match self.0 {
-                    CodegenTypeName::Schema(view) => {
-                        let ident = view.extensions().get::<CodegenIdent>().unwrap();
-                        write!(f, "{}", CodegenIdentUsage::Module(&ident).display())
-                    }
-                    CodegenTypeName::Inline(view) => {
-                        let ident = CodegenIdent::from_segments(view.path().segments);
-                        write!(f, "{}", CodegenIdentUsage::Module(&ident).display())
-                    }
-                }
-            }
-        }
-        DisplayModuleName(self.0)
-    }
-}
-
-impl ToTokens for CodegenModuleName<'_> {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        match self.0 {
-            CodegenTypeName::Schema(view) => {
-                let ident = view.extensions().get::<CodegenIdent>().unwrap();
-                CodegenIdentUsage::Module(&ident).to_tokens(tokens);
-            }
-            CodegenTypeName::Inline(view) => {
-                let ident = CodegenIdent::from_segments(view.path().segments);
-                CodegenIdentUsage::Module(&ident).to_tokens(tokens);
-            }
-        }
-    }
-}
-
-/// A sort key for deterministic ordering of [`CodegenTypeName`]s.
-///
-/// Sorts schema types before inline types, then lexicographically by name.
-/// This ensures that code generation produces stable output regardless of
-/// declaration order.
-#[derive(Clone, Copy, Debug)]
-pub struct CodegenTypeNameSortKey<'a>(CodegenTypeName<'a>);
-
-impl<'a> CodegenTypeNameSortKey<'a> {
-    #[inline]
-    pub fn for_schema(view: &'a SchemaTypeView<'a, 'a>) -> Self {
-        Self(CodegenTypeName::Schema(view))
-    }
-
-    #[inline]
-    pub fn for_inline(view: &'a InlineTypeView<'a, 'a>) -> Self {
-        Self(CodegenTypeName::Inline(view))
-    }
-
-    #[inline]
-    pub fn into_name(self) -> CodegenTypeName<'a> {
-        self.0
-    }
-}
-
-impl Eq for CodegenTypeNameSortKey<'_> {}
-
-impl Ord for CodegenTypeNameSortKey<'_> {
-    fn cmp(&self, other: &Self) -> Ordering {
-        match (&self.0, &other.0) {
-            (CodegenTypeName::Schema(a), CodegenTypeName::Schema(b)) => a.name().cmp(b.name()),
-            (CodegenTypeName::Inline(a), CodegenTypeName::Inline(b)) => a.path().cmp(&b.path()),
-            (CodegenTypeName::Schema(_), CodegenTypeName::Inline(_)) => Ordering::Less,
-            (CodegenTypeName::Inline(_), CodegenTypeName::Schema(_)) => Ordering::Greater,
-        }
-    }
-}
-
-impl PartialEq for CodegenTypeNameSortKey<'_> {
-    fn eq(&self, other: &Self) -> bool {
-        self.cmp(other).is_eq()
-    }
-}
-
-impl PartialOrd for CodegenTypeNameSortKey<'_> {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-/// A string that's statically guaranteed to be valid for any
-/// [`CodegenIdentUsage`].
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct CodegenIdent(String);
+/// A cleaned string that's valid for use as a Rust identifier.
+#[derive(Debug, Eq, Hash, Ord, PartialEq, PartialOrd, RefCastCustom)]
+#[repr(transparent)]
+pub struct CodegenIdent(str);
 
 impl CodegenIdent {
-    /// Creates an identifier for any usage.
-    pub fn new(s: &str) -> Self {
-        let s = clean(s);
-        if KEYWORDS.contains(&s.as_str()) {
-            Self(format!("_{s}"))
-        } else {
-            Self(s)
-        }
-    }
-
-    /// Creates an identifier from an inline type path.
-    pub fn from_segments(segments: &[InlineTypePathSegment<'_>]) -> Self {
-        Self(format!(
-            "{}",
-            segments
-                .iter()
-                .map(CodegenTypePathSegment)
-                .format_with("", |segment, f| f(&segment.display()))
-        ))
-    }
-}
-
-impl AsRef<CodegenIdentRef> for CodegenIdent {
-    fn as_ref(&self) -> &CodegenIdentRef {
-        self
-    }
-}
-
-impl Borrow<CodegenIdentRef> for CodegenIdent {
-    fn borrow(&self) -> &CodegenIdentRef {
-        self
-    }
-}
-
-impl Deref for CodegenIdent {
-    type Target = CodegenIdentRef;
-
-    fn deref(&self) -> &Self::Target {
-        CodegenIdentRef::new(&self.0)
-    }
-}
-
-/// A string slice that's guaranteed to be valid for any [`CodegenIdentUsage`].
-#[derive(Debug, Eq, Ord, PartialEq, PartialOrd, RefCastCustom)]
-#[repr(transparent)]
-pub struct CodegenIdentRef(str);
-
-impl CodegenIdentRef {
     #[ref_cast_custom]
     fn new(s: &str) -> &Self;
-
-    /// Returns a suitable identifier for a struct field,
-    /// before uniquification.
-    pub fn from_field_name_hint(hint: StructFieldNameHint) -> Cow<'static, Self> {
-        match hint {
-            StructFieldNameHint::Index(index) => {
-                Cow::Owned(CodegenIdent(format!("variant_{index}")))
-            }
-            StructFieldNameHint::AdditionalProperties => {
-                Cow::Borrowed(Self::new("additional_properties"))
-            }
-        }
-    }
-
-    /// Returns a suitable identifier for an untagged union variant,
-    /// before uniquification.
-    pub fn from_variant_name_hint(hint: UntaggedVariantNameHint) -> Cow<'static, Self> {
-        use {PrimitiveType::*, UntaggedVariantNameHint::*};
-        match hint {
-            Primitive(String) => Cow::Borrowed(Self::new("String")),
-            Primitive(I8) => Cow::Borrowed(Self::new("I8")),
-            Primitive(U8) => Cow::Borrowed(Self::new("U8")),
-            Primitive(I16) => Cow::Borrowed(Self::new("I16")),
-            Primitive(U16) => Cow::Borrowed(Self::new("U16")),
-            Primitive(I32) => Cow::Borrowed(Self::new("I32")),
-            Primitive(U32) => Cow::Borrowed(Self::new("U32")),
-            Primitive(I64) => Cow::Borrowed(Self::new("I64")),
-            Primitive(U64) => Cow::Borrowed(Self::new("U64")),
-            Primitive(F32) => Cow::Borrowed(Self::new("F32")),
-            Primitive(F64) => Cow::Borrowed(Self::new("F64")),
-            Primitive(Bool) => Cow::Borrowed(Self::new("Bool")),
-            Primitive(DateTime) => Cow::Borrowed(Self::new("DateTime")),
-            Primitive(UnixTime) => Cow::Borrowed(Self::new("UnixTime")),
-            Primitive(Date) => Cow::Borrowed(Self::new("Date")),
-            Primitive(Url) => Cow::Borrowed(Self::new("Url")),
-            Primitive(Uuid) => Cow::Borrowed(Self::new("Uuid")),
-            Primitive(Bytes) => Cow::Borrowed(Self::new("Bytes")),
-            Primitive(Binary) => Cow::Borrowed(Self::new("Binary")),
-            Array => Cow::Borrowed(Self::new("Array")),
-            Map => Cow::Borrowed(Self::new("Map")),
-            Index(index) => Cow::Owned(CodegenIdent(format!("V{index}"))),
-        }
-    }
 }
 
-impl ToOwned for CodegenIdentRef {
-    type Owned = CodegenIdent;
-
-    fn to_owned(&self) -> Self::Owned {
-        CodegenIdent(self.0.to_owned())
-    }
-}
-
-/// A Cargo feature for conditionally compiling generated code.
+/// An identifier that's unique within its [`UniqueIdents`] scope.
 ///
-/// Feature names appear in the `Cargo.toml` `[features]` table,
-/// and in `#[cfg(feature = "...")]` attributes. The special `default` feature
-/// enables all other features.
-#[derive(Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub enum CargoFeature {
-    #[default]
-    Default,
-    Named(CodegenIdent),
+/// Only a scope can construct these, ensuring that identifiers won't collide
+/// within that scope. Pass a [`UniqueIdent`] to a [`CodegenIdentUsage`] variant
+/// to emit it as an [`Ident`] token.
+#[derive(Debug, Eq, Hash, Ord, PartialEq, PartialOrd, RefCastCustom)]
+#[repr(transparent)]
+pub struct UniqueIdent(str);
+
+impl UniqueIdent {
+    #[ref_cast_custom]
+    fn new(s: &str) -> &Self;
 }
 
-impl CargoFeature {
-    #[inline]
-    pub fn from_name(name: &str) -> Self {
-        match name {
-            // `default` can't be used as a literal feature name; ignore it.
-            "default" => Self::Default,
-
-            // Cargo and crates.io limit which characters can appear in feature names;
-            // further, we use feature names as module names for operations, so
-            // the feature name needs to be usable as a Rust identifier.
-            name => Self::Named(CodegenIdent::new(name)),
-        }
-    }
+impl Deref for UniqueIdent {
+    type Target = CodegenIdent;
 
     #[inline]
-    pub fn as_ident(&self) -> &CodegenIdentRef {
-        match self {
-            Self::Named(name) => name,
-            Self::Default => CodegenIdentRef::new("default"),
-        }
-    }
-
-    #[inline]
-    pub fn display(&self) -> impl Display {
-        match self {
-            Self::Named(name) => AsKebabCase(name.0.as_str()),
-            Self::Default => AsKebabCase("default"),
-        }
+    fn deref(&self) -> &Self::Target {
+        CodegenIdent::new(&self.0)
     }
 }
 
-/// A context-aware wrapper for emitting a [`CodegenIdentRef`] as a Rust identifier.
-///
-/// [`CodegenIdentUsage`] is a lower-level building block for generating
-/// identifiers. For schema and inline types, prefer [`CodegenTypeName`] instead.
+/// Emits a [`CodegenIdent`] as an idiomatic Rust identifier.
 ///
 /// Each [`CodegenIdentUsage`] variant determines the case transformation
 /// applied to the identifier: module, field, parameter, and method names
@@ -336,15 +61,15 @@ impl CargoFeature {
 /// use [`display`](Self::display).
 #[derive(Clone, Copy, Debug)]
 pub enum CodegenIdentUsage<'a> {
-    Module(&'a CodegenIdentRef),
-    Type(&'a CodegenIdentRef),
-    Field(&'a CodegenIdentRef),
-    Variant(&'a CodegenIdentRef),
-    Param(&'a CodegenIdentRef),
-    Method(&'a CodegenIdentRef),
+    Module(&'a CodegenIdent),
+    Type(&'a CodegenIdent),
+    Field(&'a UniqueIdent),
+    Variant(&'a UniqueIdent),
+    Param(&'a UniqueIdent),
+    Method(&'a UniqueIdent),
 }
 
-impl CodegenIdentUsage<'_> {
+impl<'a> CodegenIdentUsage<'a> {
     /// Returns a formattable representation of this identifier.
     ///
     /// [`CodegenIdentUsage`] doesn't implement [`Display`] directly, to help catch
@@ -354,126 +79,185 @@ impl CodegenIdentUsage<'_> {
         struct DisplayUsage<'a>(CodegenIdentUsage<'a>);
         impl Display for DisplayUsage<'_> {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                use CodegenIdentUsage::*;
+                let s = self.0.as_str();
+                if !s.starts_with(unicode_ident::is_xid_start) {
+                    // `s` is an identifier fragment; ensure it starts with
+                    // `XID_Start` to make it a valid identifier.
+                    f.write_char('_')?;
+                }
                 match self.0 {
-                    Module(name) | Field(name) | Param(name) | Method(name) => {
-                        if name.0.starts_with(unicode_ident::is_xid_start) {
-                            write!(f, "{}", AsSnekCase(&name.0))
-                        } else {
-                            // `name` doesn't start with `XID_Start` (e.g., "1099KStatus"),
-                            // so prefix it with `_`; everything after is known to be
-                            // `XID_Continue`.
-                            write!(f, "_{}", AsSnekCase(&name.0))
-                        }
+                    CodegenIdentUsage::Type(_) | CodegenIdentUsage::Variant(_) => {
+                        write!(f, "{}", AsPascalCase(s))
                     }
-                    Type(name) | Variant(name) => {
-                        if name.0.starts_with(unicode_ident::is_xid_start) {
-                            write!(f, "{}", AsPascalCase(&name.0))
-                        } else {
-                            write!(f, "_{}", AsPascalCase(&name.0))
-                        }
-                    }
+                    CodegenIdentUsage::Module(_)
+                    | CodegenIdentUsage::Field(_)
+                    | CodegenIdentUsage::Param(_)
+                    | CodegenIdentUsage::Method(_) => write!(f, "{}", AsSnekCase(s)),
                 }
             }
         }
         DisplayUsage(self)
     }
+
+    #[inline]
+    fn as_str(&self) -> &str {
+        match self {
+            CodegenIdentUsage::Type(s) => &s.0,
+            CodegenIdentUsage::Variant(s) => &s.0,
+            CodegenIdentUsage::Module(s) => &s.0,
+            CodegenIdentUsage::Field(s) => &s.0,
+            CodegenIdentUsage::Param(s) => &s.0,
+            CodegenIdentUsage::Method(s) => &s.0,
+        }
+    }
 }
 
 impl IdentFragment for CodegenIdentUsage<'_> {
+    #[inline]
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", self.display())
     }
 }
 
 impl ToTokens for CodegenIdentUsage<'_> {
+    #[inline]
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let s = self.display().to_string();
+        // Assume `s` is a keyword that must be rendered as a raw identifier
+        // if `parse_str` fails. A string that's not a valid identifier here
+        // is a logic error.
         let ident = syn::parse_str(&s).unwrap_or_else(|_| Ident::new_raw(&s, Span::call_site()));
         tokens.append(ident);
     }
 }
 
+/// A key used to group a resource's operations into modules
+/// and derive Cargo features for resource operations and types.
+///
+/// [`Named`] wraps a uniquified resource name; [`Default`] represents
+/// operations and types without a resource name.
+///
+/// [`Named`]: Self::Named
+/// [`Default`]: Self::Default
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum ResourceGroup<'a> {
+    Named(&'a UniqueIdent),
+    #[default]
+    Default,
+}
+
+impl<'a> ResourceGroup<'a> {
+    /// Returns the resource name for a [`Named`][Self::Named] group.
+    #[inline]
+    pub fn name(self) -> Option<&'a UniqueIdent> {
+        match self {
+            Self::Named(name) => Some(name),
+            Self::Default => None,
+        }
+    }
+
+    /// Returns whether this group represents operations and types
+    /// without a resource name.
+    #[inline]
+    pub fn is_default(&self) -> bool {
+        matches!(self, Self::Default)
+    }
+}
+
+/// Formats a uniquified resource name as a Cargo feature name.
+#[derive(Clone, Copy, Debug)]
+pub struct AsFeatureName<'a>(pub &'a UniqueIdent);
+
+impl Display for AsFeatureName<'_> {
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", AsKebabCase(&self.0.0))
+    }
+}
+
 /// A scope for generating unique, valid Rust identifiers.
 #[derive(Debug)]
-pub struct CodegenIdentScope<'a>(UniqueNamesScope<'a>);
+pub struct UniqueIdents<'a>(UniqueNames<'a>);
 
-impl<'a> CodegenIdentScope<'a> {
+impl<'a> UniqueIdents<'a> {
     /// Creates a new identifier scope that's backed by the given arena.
-    pub fn new(arena: &'a UniqueNames) -> Self {
+    #[inline]
+    pub fn new(arena: &'a Arena) -> Self {
         Self::with_reserved(arena, &[])
     }
 
     /// Creates a new identifier scope that's backed by the given arena,
     /// with additional pre-reserved names.
-    pub fn with_reserved(arena: &'a UniqueNames, reserved: &[&str]) -> Self {
-        Self(arena.scope_with_reserved(itertools::chain!(
-            reserved.iter().copied(),
-            KEYWORDS.iter().copied(),
-            std::iter::once("")
-        )))
+    #[inline]
+    pub fn with_reserved(arena: &'a Arena, reserved: &[&str]) -> Self {
+        Self(UniqueNames::with_reserved(
+            arena,
+            itertools::chain!(
+                reserved.iter().copied(),
+                KEYWORDS.iter().copied(),
+                std::iter::once("")
+            ),
+        ))
     }
 
-    /// Cleans the input string and returns a name that's unique
-    /// within this scope, and valid for any [`CodegenIdentUsage`].
-    pub fn uniquify(&mut self, name: &str) -> CodegenIdent {
-        CodegenIdent(self.0.uniquify(&clean(name)).into_owned())
+    /// Cleans and uniquifies an identifier.
+    #[inline]
+    pub fn ident(&mut self, name: &str) -> &'a UniqueIdent {
+        UniqueIdent::new(self.0.uniquify(&clean(name)))
     }
 
-    /// Uniquifies an identifier within this scope.
-    pub fn uniquify_ident(&mut self, ident: &CodegenIdentRef) -> CodegenIdent {
-        CodegenIdent(self.0.uniquify(&ident.0).into_owned())
+    /// Uniquifies a struct field name from a [`StructFieldNameHint`].
+    #[inline]
+    pub fn field_name_hint(&mut self, hint: StructFieldNameHint) -> &'a UniqueIdent {
+        use StructFieldNameHint::*;
+        UniqueIdent::new(match hint {
+            Index(index) => self.0.uniquify(&format!("variant_{index}")),
+            AdditionalProperties => self.0.uniquify("additional_properties"),
+        })
+    }
+
+    /// Uniquifies an untagged union variant name from an
+    /// [`UntaggedVariantNameHint`].
+    #[inline]
+    pub fn variant_name_hint(&mut self, hint: UntaggedVariantNameHint) -> &'a UniqueIdent {
+        use {PrimitiveType::*, UntaggedVariantNameHint::*};
+        UniqueIdent::new(match hint {
+            Primitive(String) => self.0.uniquify("String"),
+            Primitive(I8) => self.0.uniquify("I8"),
+            Primitive(U8) => self.0.uniquify("U8"),
+            Primitive(I16) => self.0.uniquify("I16"),
+            Primitive(U16) => self.0.uniquify("U16"),
+            Primitive(I32) => self.0.uniquify("I32"),
+            Primitive(U32) => self.0.uniquify("U32"),
+            Primitive(I64) => self.0.uniquify("I64"),
+            Primitive(U64) => self.0.uniquify("U64"),
+            Primitive(F32) => self.0.uniquify("F32"),
+            Primitive(F64) => self.0.uniquify("F64"),
+            Primitive(Bool) => self.0.uniquify("Bool"),
+            Primitive(DateTime) => self.0.uniquify("DateTime"),
+            Primitive(UnixTime) => self.0.uniquify("UnixTime"),
+            Primitive(Date) => self.0.uniquify("Date"),
+            Primitive(Url) => self.0.uniquify("Url"),
+            Primitive(Uuid) => self.0.uniquify("Uuid"),
+            Primitive(Bytes) => self.0.uniquify("Bytes"),
+            Primitive(Binary) => self.0.uniquify("Binary"),
+            Array => self.0.uniquify("Array"),
+            Map => self.0.uniquify("Map"),
+            Index(index) => self.0.uniquify(&format!("V{index}")),
+        })
     }
 }
 
-#[derive(Clone, Copy, Debug)]
-pub struct CodegenTypePathSegment<'a>(&'a InlineTypePathSegment<'a>);
-
-impl<'a> CodegenTypePathSegment<'a> {
-    pub fn display(&self) -> impl Display {
-        struct DisplaySegment<'a>(&'a InlineTypePathSegment<'a>);
-        impl Display for DisplaySegment<'_> {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                use InlineTypePathSegment::*;
-                match self.0 {
-                    // Segments are always part of an identifier, never emitted directly;
-                    // so we don't need to check for `XID_Start`.
-                    Operation(name) => write!(f, "{}", AsPascalCase(clean(name))),
-                    Parameter(name) => write!(f, "{}", AsPascalCase(clean(name))),
-                    Request => f.write_str("Request"),
-                    Response => f.write_str("Response"),
-                    Field(StructFieldName::Name(name)) => {
-                        write!(f, "{}", AsPascalCase(clean(name)))
-                    }
-                    Field(StructFieldName::Hint(StructFieldNameHint::Index(index))) => {
-                        write!(f, "Variant{index}")
-                    }
-                    Field(StructFieldName::Hint(StructFieldNameHint::AdditionalProperties)) => {
-                        f.write_str("AdditionalProperties")
-                    }
-                    MapValue => f.write_str("Value"),
-                    ArrayItem => f.write_str("Item"),
-                    Variant(index) => write!(f, "V{index}"),
-                    Parent(index) => write!(f, "P{index}"),
-                    TaggedVariant(name) => write!(f, "{}", AsPascalCase(clean(name))),
-                }
-            }
-        }
-        DisplaySegment(self.0)
-    }
-}
-
-/// Makes a string suitable for inclusion within a Rust identifier.
+/// Makes a valid Rust identifier fragment from a string.
 ///
-/// Cleaning segments the string on word boundaries, collapses all
-/// non-`XID_Continue` characters into new boundaries, and
-/// reassembles the string. This makes the string resilient to
-/// case transformations, which also collapse boundaries, and so
-/// can produce duplicates in some cases.
+/// Cleaning segments the string on word boundaries and collapses all
+/// non-`XID_Continue` characters into new boundaries. This makes the fragment
+/// resilient to Heck's case transformations, which also collapse boundaries,
+/// and so can produce duplicates.
 ///
-/// Note that the result may not itself be a valid Rust identifier,
+/// The result is a valid identifier fragment, but may not be a valid [`Ident`],
 /// because Rust identifiers must start with `XID_Start`.
-/// This is checked and handled in [`CodegenIdentUsage`].
+#[inline]
 fn clean(s: &str) -> String {
     WordSegments::new(s)
         .flat_map(|s| s.split(|c| !unicode_ident::is_xid_continue(c)))
@@ -487,44 +271,14 @@ mod tests {
     use pretty_assertions::assert_eq;
     use syn::parse_quote;
 
-    // MARK: Cargo features
-
-    #[test]
-    fn test_feature_from_name() {
-        let feature = CargoFeature::from_name("customers");
-        assert_eq!(feature.display().to_string(), "customers");
-    }
-
-    #[test]
-    fn test_feature_default() {
-        let feature = CargoFeature::Default;
-        assert_eq!(feature.display().to_string(), "default");
-
-        let feature = CargoFeature::from_name("default");
-        assert_eq!(feature, CargoFeature::Default);
-    }
-
-    #[test]
-    fn test_features_from_multiple_words() {
-        let feature = CargoFeature::from_name("foo_bar");
-        assert_eq!(feature.display().to_string(), "foo-bar");
-
-        let feature = CargoFeature::from_name("foo.bar");
-        assert_eq!(feature.display().to_string(), "foo-bar");
-
-        let feature = CargoFeature::from_name("fooBar");
-        assert_eq!(feature.display().to_string(), "foo-bar");
-
-        let feature = CargoFeature::from_name("FooBar");
-        assert_eq!(feature.display().to_string(), "foo-bar");
-    }
-
     // MARK: Usages
 
     #[test]
     fn test_codegen_ident_type() {
-        let ident = CodegenIdent::new("pet_store");
-        let usage = CodegenIdentUsage::Type(&ident);
+        let arena = Arena::new();
+        let mut scope = UniqueIdents::new(&arena);
+        let ident = scope.ident("pet_store");
+        let usage = CodegenIdentUsage::Type(ident);
         let actual: syn::Ident = parse_quote!(#usage);
         let expected: syn::Ident = parse_quote!(PetStore);
         assert_eq!(actual, expected);
@@ -532,8 +286,10 @@ mod tests {
 
     #[test]
     fn test_codegen_ident_field() {
-        let ident = CodegenIdent::new("petStore");
-        let usage = CodegenIdentUsage::Field(&ident);
+        let arena = Arena::new();
+        let mut scope = UniqueIdents::new(&arena);
+        let ident = scope.ident("petStore");
+        let usage = CodegenIdentUsage::Field(ident);
         let actual: syn::Ident = parse_quote!(#usage);
         let expected: syn::Ident = parse_quote!(pet_store);
         assert_eq!(actual, expected);
@@ -541,8 +297,10 @@ mod tests {
 
     #[test]
     fn test_codegen_ident_module() {
-        let ident = CodegenIdent::new("MyModule");
-        let usage = CodegenIdentUsage::Module(&ident);
+        let arena = Arena::new();
+        let mut scope = UniqueIdents::new(&arena);
+        let ident = scope.ident("MyModule");
+        let usage = CodegenIdentUsage::Module(ident);
         let actual: syn::Ident = parse_quote!(#usage);
         let expected: syn::Ident = parse_quote!(my_module);
         assert_eq!(actual, expected);
@@ -550,8 +308,10 @@ mod tests {
 
     #[test]
     fn test_codegen_ident_variant() {
-        let ident = CodegenIdent::new("http_error");
-        let usage = CodegenIdentUsage::Variant(&ident);
+        let arena = Arena::new();
+        let mut scope = UniqueIdents::new(&arena);
+        let ident = scope.ident("http_error");
+        let usage = CodegenIdentUsage::Variant(ident);
         let actual: syn::Ident = parse_quote!(#usage);
         let expected: syn::Ident = parse_quote!(HttpError);
         assert_eq!(actual, expected);
@@ -559,8 +319,10 @@ mod tests {
 
     #[test]
     fn test_codegen_ident_param() {
-        let ident = CodegenIdent::new("userId");
-        let usage = CodegenIdentUsage::Param(&ident);
+        let arena = Arena::new();
+        let mut scope = UniqueIdents::new(&arena);
+        let ident = scope.ident("userId");
+        let usage = CodegenIdentUsage::Param(ident);
         let actual: syn::Ident = parse_quote!(#usage);
         let expected: syn::Ident = parse_quote!(user_id);
         assert_eq!(actual, expected);
@@ -568,8 +330,10 @@ mod tests {
 
     #[test]
     fn test_codegen_ident_method() {
-        let ident = CodegenIdent::new("getUserById");
-        let usage = CodegenIdentUsage::Method(&ident);
+        let arena = Arena::new();
+        let mut scope = UniqueIdents::new(&arena);
+        let ident = scope.ident("getUserById");
+        let usage = CodegenIdentUsage::Method(ident);
         let actual: syn::Ident = parse_quote!(#usage);
         let expected: syn::Ident = parse_quote!(get_user_by_id);
         assert_eq!(actual, expected);
@@ -579,8 +343,10 @@ mod tests {
 
     #[test]
     fn test_codegen_ident_handles_rust_keywords() {
-        let ident = CodegenIdent::new("type");
-        let usage = CodegenIdentUsage::Field(&ident);
+        let arena = Arena::new();
+        let mut scope = UniqueIdents::new(&arena);
+        let ident = scope.ident("type");
+        let usage = CodegenIdentUsage::Field(ident);
         let actual: syn::Ident = parse_quote!(#usage);
         let expected: syn::Ident = parse_quote!(r#type);
         assert_eq!(actual, expected);
@@ -588,8 +354,10 @@ mod tests {
 
     #[test]
     fn test_codegen_ident_handles_invalid_start_chars() {
-        let ident = CodegenIdent::new("123foo");
-        let usage = CodegenIdentUsage::Field(&ident);
+        let arena = Arena::new();
+        let mut scope = UniqueIdents::new(&arena);
+        let ident = scope.ident("123foo");
+        let usage = CodegenIdentUsage::Field(ident);
         let actual: syn::Ident = parse_quote!(#usage);
         let expected: syn::Ident = parse_quote!(_123_foo);
         assert_eq!(actual, expected);
@@ -597,8 +365,10 @@ mod tests {
 
     #[test]
     fn test_codegen_ident_handles_special_chars() {
-        let ident = CodegenIdent::new("foo-bar-baz");
-        let usage = CodegenIdentUsage::Field(&ident);
+        let arena = Arena::new();
+        let mut scope = UniqueIdents::new(&arena);
+        let ident = scope.ident("foo-bar-baz");
+        let usage = CodegenIdentUsage::Field(ident);
         let actual: syn::Ident = parse_quote!(#usage);
         let expected: syn::Ident = parse_quote!(foo_bar_baz);
         assert_eq!(actual, expected);
@@ -606,14 +376,16 @@ mod tests {
 
     #[test]
     fn test_codegen_ident_handles_number_prefix() {
-        let ident = CodegenIdent::new("1099KStatus");
+        let arena = Arena::new();
+        let mut scope = UniqueIdents::new(&arena);
+        let ident = scope.ident("1099KStatus");
 
-        let usage = CodegenIdentUsage::Field(&ident);
+        let usage = CodegenIdentUsage::Field(ident);
         let actual: syn::Ident = parse_quote!(#usage);
         let expected: syn::Ident = parse_quote!(_1099_k_status);
         assert_eq!(actual, expected);
 
-        let usage = CodegenIdentUsage::Type(&ident);
+        let usage = CodegenIdentUsage::Type(ident);
         let actual: syn::Ident = parse_quote!(#usage);
         let expected: syn::Ident = parse_quote!(_1099KStatus);
         assert_eq!(actual, expected);
@@ -623,25 +395,30 @@ mod tests {
 
     #[test]
     fn test_untagged_variant_name_index() {
-        let name = CodegenIdentRef::from_variant_name_hint(UntaggedVariantNameHint::Index(0));
-        assert_eq!(&*name, CodegenIdentRef::new("V0"));
+        let arena = Arena::new();
+        let mut scope = UniqueIdents::new(&arena);
 
-        let name = CodegenIdentRef::from_variant_name_hint(UntaggedVariantNameHint::Index(42));
-        assert_eq!(&*name, CodegenIdentRef::new("V42"));
+        let ident = scope.variant_name_hint(UntaggedVariantNameHint::Index(0));
+        assert_eq!(&ident.0, "V0");
+
+        let ident = scope.variant_name_hint(UntaggedVariantNameHint::Index(42));
+        assert_eq!(&ident.0, "V42");
     }
 
     // MARK: Struct field names
 
     #[test]
     fn test_struct_field_name_index() {
-        let field_name = CodegenIdentRef::from_field_name_hint(StructFieldNameHint::Index(0));
-        let usage = CodegenIdentUsage::Field(&field_name);
+        let arena = Arena::new();
+        let mut scope = UniqueIdents::new(&arena);
+        let ident0 = scope.field_name_hint(StructFieldNameHint::Index(0));
+        let usage = CodegenIdentUsage::Field(ident0);
         let actual: syn::Ident = parse_quote!(#usage);
         let expected: syn::Ident = parse_quote!(variant_0);
         assert_eq!(actual, expected);
 
-        let field_name = CodegenIdentRef::from_field_name_hint(StructFieldNameHint::Index(5));
-        let usage = CodegenIdentUsage::Field(&field_name);
+        let ident5 = scope.field_name_hint(StructFieldNameHint::Index(5));
+        let usage = CodegenIdentUsage::Field(ident5);
         let actual: syn::Ident = parse_quote!(#usage);
         let expected: syn::Ident = parse_quote!(variant_5);
         assert_eq!(actual, expected);
@@ -649,9 +426,10 @@ mod tests {
 
     #[test]
     fn test_struct_field_name_additional_properties() {
-        let field_name =
-            CodegenIdentRef::from_field_name_hint(StructFieldNameHint::AdditionalProperties);
-        let usage = CodegenIdentUsage::Field(&field_name);
+        let arena = Arena::new();
+        let mut scope = UniqueIdents::new(&arena);
+        let ident = scope.field_name_hint(StructFieldNameHint::AdditionalProperties);
+        let usage = CodegenIdentUsage::Field(ident);
         let actual: syn::Ident = parse_quote!(#usage);
         let expected: syn::Ident = parse_quote!(additional_properties);
         assert_eq!(actual, expected);
@@ -694,16 +472,16 @@ mod tests {
 
     #[test]
     fn test_codegen_ident_scope_handles_empty() {
-        let unique = UniqueNames::new();
-        let mut scope = CodegenIdentScope::new(&unique);
-        let ident = scope.uniquify("");
+        let arena = Arena::new();
+        let mut scope = UniqueIdents::new(&arena);
+        let ident = scope.ident("");
 
-        let usage = CodegenIdentUsage::Field(&ident);
+        let usage = CodegenIdentUsage::Field(ident);
         let actual: syn::Ident = parse_quote!(#usage);
         let expected: syn::Ident = parse_quote!(_2);
         assert_eq!(actual, expected);
 
-        let usage = CodegenIdentUsage::Type(&ident);
+        let usage = CodegenIdentUsage::Type(ident);
         let actual: syn::Ident = parse_quote!(#usage);
         let expected: syn::Ident = parse_quote!(_2);
         assert_eq!(actual, expected);

--- a/ploidy-codegen-rust/src/operation.rs
+++ b/ploidy-codegen-rust/src/operation.rs
@@ -1,7 +1,6 @@
 use itertools::Itertools;
 use ploidy_core::{
-    codegen::UniqueNames,
-    ir::{OperationView, ParameterView, PathParameter, RequestView, ResponseView},
+    ir::{OperationView, RequestView, ResponseView},
     parse::{Method, path::PathFragment},
 };
 use proc_macro2::{Span, TokenStream};
@@ -10,26 +9,25 @@ use syn::Ident;
 
 use super::{
     doc_attrs,
-    naming::{CodegenIdent, CodegenIdentScope, CodegenIdentUsage},
+    graph::{CodegenGraph, IdentMapping},
+    naming::CodegenIdentUsage,
     ref_::CodegenRef,
 };
 
 /// Generates a single client method for an API operation.
 pub struct CodegenOperation<'a> {
+    graph: &'a CodegenGraph<'a>,
     op: &'a OperationView<'a, 'a>,
 }
 
 impl<'a> CodegenOperation<'a> {
-    pub fn new(op: &'a OperationView<'a, 'a>) -> Self {
-        Self { op }
+    pub fn new(graph: &'a CodegenGraph<'a>, op: &'a OperationView<'a, 'a>) -> Self {
+        Self { graph, op }
     }
 
     /// Generates code to build and interpolate path parameters into
     /// the request URL.
-    fn url(
-        &self,
-        params: &[(CodegenIdent, ParameterView<'_, '_, '_, PathParameter>)],
-    ) -> TokenStream {
+    fn url(&self) -> TokenStream {
         let segments = self
             .op
             .path()
@@ -38,12 +36,10 @@ impl<'a> CodegenOperation<'a> {
                 [] => quote! { "" },
                 [PathFragment::Literal(text)] => quote! { #text },
                 [PathFragment::Param(name)] => {
-                    let (ident, _) = params
-                        .iter()
-                        .find(|(_, param)| param.name() == *name)
-                        .unwrap();
-                    let usage = CodegenIdentUsage::Param(ident);
-                    quote!(#usage)
+                    let param = CodegenIdentUsage::Param(
+                        self.graph.ident(IdentMapping::Path(self.op.id(), name)),
+                    );
+                    quote!(#param)
                 }
                 fragments => {
                     // Build a format string, with placeholders for parameter fragments.
@@ -66,11 +62,10 @@ impl<'a> CodegenOperation<'a> {
                             // `url::PathSegmentsMut::push` percent-encodes the
                             // full segment, so we can interpolate fragments
                             // directly.
-                            let (ident, _) = params
-                                .iter()
-                                .find(|(_, param)| param.name() == *name)
-                                .unwrap();
-                            CodegenIdentUsage::Param(ident)
+                            let param = CodegenIdentUsage::Param(
+                                self.graph.ident(IdentMapping::Path(self.op.id(), name)),
+                            );
+                            quote!(#param)
                         });
                     quote! { &format!(#format, #(#args),*) }
                 }
@@ -110,8 +105,10 @@ impl<'a> CodegenOperation<'a> {
     /// Generates code to serialize query parameters into the URL.
     fn query(&self) -> Option<TokenStream> {
         self.op.query().next().is_some().then(|| {
-            let op_ident = CodegenIdent::new(self.op.id());
-            let query_name = format_ident!("{}Query", CodegenIdentUsage::Type(&op_ident));
+            let query_name = format_ident!(
+                "{}Query",
+                CodegenIdentUsage::Type(self.graph.ident(self.op.id()))
+            );
             quote! {
                 let url = ::ploidy_util::serde::Serialize::serialize(
                     query,
@@ -127,41 +124,31 @@ impl<'a> CodegenOperation<'a> {
 
 impl ToTokens for CodegenOperation<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        let operation_id = CodegenIdent::new(self.op.id());
-        let method_name = CodegenIdentUsage::Method(&operation_id);
-
-        let unique = UniqueNames::new();
-        let mut scope = CodegenIdentScope::with_reserved(
-            &unique,
-            // `query`, `request`, and `form` are argument names;
-            // `url` and `response` are local variables.
-            &["query", "request", "form", "url", "response"],
-        );
         let mut params = vec![];
 
-        let paths = self
-            .op
-            .path()
-            .params()
-            .map(|param| (scope.uniquify(param.name()), param))
-            .collect_vec();
-        for (ident, _) in &paths {
-            let usage = CodegenIdentUsage::Param(ident);
-            params.push(quote! { #usage: &str });
+        let paths = self.op.path().params().collect_vec();
+        for param in &paths {
+            let param = CodegenIdentUsage::Param(
+                self.graph
+                    .ident(IdentMapping::Path(self.op.id(), param.name())),
+            );
+            params.push(quote! { #param: &str });
         }
 
         if self.op.query().next().is_some() {
             // Include the `query` argument if we have
             // at least one query parameter.
-            let op_ident = CodegenIdent::new(self.op.id());
-            let query_type_name = format_ident!("{}Query", CodegenIdentUsage::Type(&op_ident));
+            let query_type_name = format_ident!(
+                "{}Query",
+                CodegenIdentUsage::Type(self.graph.ident(self.op.id()))
+            );
             params.push(quote! { query: &parameters::#query_type_name });
         }
 
         if let Some(request) = self.op.request() {
             match request {
                 RequestView::Json(view) => {
-                    let param_type = CodegenRef::new(&view);
+                    let param_type = CodegenRef::new(self.graph, &view);
                     params.push(quote! { request: impl Into<#param_type> });
                 }
                 RequestView::Multipart => {
@@ -172,12 +159,12 @@ impl ToTokens for CodegenOperation<'_> {
 
         let return_type = match self.op.response() {
             Some(response) => match response {
-                ResponseView::Json(view) => CodegenRef::new(&view).into_token_stream(),
+                ResponseView::Json(view) => CodegenRef::new(self.graph, &view).into_token_stream(),
             },
             None => quote! { () },
         };
 
-        let build_url = self.url(&paths);
+        let build_url = self.url();
 
         let build_query = self.query();
 
@@ -227,6 +214,7 @@ impl ToTokens for CodegenOperation<'_> {
             }
         };
 
+        let method_name = CodegenIdentUsage::Method(self.graph.ident(self.op.id()));
         let doc = self.op.description().map(doc_attrs);
 
         tokens.append_all(quote! {
@@ -307,7 +295,7 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let op = graph.operations().next().unwrap();
-        let codegen = CodegenOperation::new(&op);
+        let codegen = CodegenOperation::new(&graph, &op);
 
         let actual: syn::ImplItemFn = parse_quote!(#codegen);
         let expected: syn::ImplItemFn = parse_quote! {
@@ -376,7 +364,7 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let op = graph.operations().next().unwrap();
-        let codegen = CodegenOperation::new(&op);
+        let codegen = CodegenOperation::new(&graph, &op);
 
         let actual: syn::ImplItemFn = parse_quote!(#codegen);
         let expected: syn::ImplItemFn = parse_quote! {
@@ -448,7 +436,7 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let op = graph.operations().next().unwrap();
-        let codegen = CodegenOperation::new(&op);
+        let codegen = CodegenOperation::new(&graph, &op);
 
         let actual: syn::ImplItemFn = parse_quote!(#codegen);
         let expected: syn::ImplItemFn = parse_quote! {
@@ -539,7 +527,7 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let op = graph.operations().next().unwrap();
-        let codegen = CodegenOperation::new(&op);
+        let codegen = CodegenOperation::new(&graph, &op);
 
         let actual: syn::ImplItemFn = parse_quote!(#codegen);
         let expected: syn::ImplItemFn = parse_quote! {
@@ -615,7 +603,7 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let op = graph.operations().next().unwrap();
-        let codegen = CodegenOperation::new(&op);
+        let codegen = CodegenOperation::new(&graph, &op);
 
         let actual: syn::ImplItemFn = parse_quote!(#codegen);
         let expected: syn::ImplItemFn = parse_quote! {
@@ -672,7 +660,7 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let op = graph.operations().next().unwrap();
-        let codegen = CodegenOperation::new(&op);
+        let codegen = CodegenOperation::new(&graph, &op);
 
         let actual: syn::ImplItemFn = parse_quote!(#codegen);
         let expected: syn::ImplItemFn = parse_quote! {
@@ -745,7 +733,7 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let op = graph.operations().next().unwrap();
-        let codegen = CodegenOperation::new(&op);
+        let codegen = CodegenOperation::new(&graph, &op);
 
         let actual: syn::ImplItemFn = parse_quote!(#codegen);
         let expected: syn::ImplItemFn = parse_quote! {
@@ -829,7 +817,7 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let op = graph.operations().next().unwrap();
-        let codegen = CodegenOperation::new(&op);
+        let codegen = CodegenOperation::new(&graph, &op);
 
         let actual: syn::ImplItemFn = parse_quote!(#codegen);
         let expected: syn::ImplItemFn = parse_quote! {
@@ -919,7 +907,7 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let op = graph.operations().next().unwrap();
-        let codegen = CodegenOperation::new(&op);
+        let codegen = CodegenOperation::new(&graph, &op);
 
         let actual: syn::ImplItemFn = parse_quote!(#codegen);
         let expected: syn::ImplItemFn = parse_quote! {

--- a/ploidy-codegen-rust/src/primitive.rs
+++ b/ploidy-codegen-rust/src/primitive.rs
@@ -1,17 +1,18 @@
-use ploidy_core::ir::{ExtendableView, PrimitiveType, PrimitiveView};
+use ploidy_core::ir::{PrimitiveType, PrimitiveView};
 use proc_macro2::TokenStream;
 use quote::{ToTokens, TokenStreamExt, quote};
 
-use super::config::DateTimeFormat;
+use super::{config::DateTimeFormat, graph::CodegenGraph};
 
 #[derive(Clone, Copy, Debug)]
 pub struct CodegenPrimitive<'a> {
+    graph: &'a CodegenGraph<'a>,
     ty: &'a PrimitiveView<'a, 'a>,
 }
 
 impl<'a> CodegenPrimitive<'a> {
-    pub fn new(ty: &'a PrimitiveView<'a, 'a>) -> Self {
-        Self { ty }
+    pub fn new(graph: &'a CodegenGraph<'a>, ty: &'a PrimitiveView<'a, 'a>) -> Self {
+        Self { graph, ty }
     }
 }
 
@@ -31,13 +32,7 @@ impl<'a> ToTokens for CodegenPrimitive<'a> {
             PrimitiveType::F64 => quote! { f64 },
             PrimitiveType::Bool => quote! { bool },
             PrimitiveType::DateTime => {
-                let format = self
-                    .ty
-                    .extensions()
-                    .get::<DateTimeFormat>()
-                    .as_deref()
-                    .copied()
-                    .unwrap_or_default();
+                let format = self.graph.date_time_format();
                 match format {
                     DateTimeFormat::Rfc3339 => {
                         quote! { ::ploidy_util::chrono::DateTime<::ploidy_util::chrono::Utc> }
@@ -102,7 +97,7 @@ mod tests {
         let [ty] = &*primitives else {
             panic!("expected string; got `{primitives:?}`");
         };
-        let p = CodegenPrimitive::new(ty);
+        let p = CodegenPrimitive::new(&graph, ty);
         let actual: syn::Type = parse_quote!(#p);
         let expected: syn::Type = parse_quote!(::std::string::String);
         assert_eq!(actual, expected);
@@ -134,7 +129,7 @@ mod tests {
         let [ty] = &*primitives else {
             panic!("expected i8; got `{primitives:?}`");
         };
-        let p = CodegenPrimitive::new(ty);
+        let p = CodegenPrimitive::new(&graph, ty);
         let actual: syn::Type = parse_quote!(#p);
         let expected: syn::Type = parse_quote!(i8);
         assert_eq!(actual, expected);
@@ -166,7 +161,7 @@ mod tests {
         let [ty] = &*primitives else {
             panic!("expected u8; got `{primitives:?}`");
         };
-        let p = CodegenPrimitive::new(ty);
+        let p = CodegenPrimitive::new(&graph, ty);
         let actual: syn::Type = parse_quote!(#p);
         let expected: syn::Type = parse_quote!(u8);
         assert_eq!(actual, expected);
@@ -198,7 +193,7 @@ mod tests {
         let [ty] = &*primitives else {
             panic!("expected i16; got `{primitives:?}`");
         };
-        let p = CodegenPrimitive::new(ty);
+        let p = CodegenPrimitive::new(&graph, ty);
         let actual: syn::Type = parse_quote!(#p);
         let expected: syn::Type = parse_quote!(i16);
         assert_eq!(actual, expected);
@@ -230,7 +225,7 @@ mod tests {
         let [ty] = &*primitives else {
             panic!("expected u16; got `{primitives:?}`");
         };
-        let p = CodegenPrimitive::new(ty);
+        let p = CodegenPrimitive::new(&graph, ty);
         let actual: syn::Type = parse_quote!(#p);
         let expected: syn::Type = parse_quote!(u16);
         assert_eq!(actual, expected);
@@ -262,7 +257,7 @@ mod tests {
         let [ty] = &*primitives else {
             panic!("expected string; got `{primitives:?}`");
         };
-        let p = CodegenPrimitive::new(ty);
+        let p = CodegenPrimitive::new(&graph, ty);
         let actual: syn::Type = parse_quote!(#p);
         let expected: syn::Type = parse_quote!(i32);
         assert_eq!(actual, expected);
@@ -294,7 +289,7 @@ mod tests {
         let [ty] = &*primitives else {
             panic!("expected u32; got `{primitives:?}`");
         };
-        let p = CodegenPrimitive::new(ty);
+        let p = CodegenPrimitive::new(&graph, ty);
         let actual: syn::Type = parse_quote!(#p);
         let expected: syn::Type = parse_quote!(u32);
         assert_eq!(actual, expected);
@@ -326,7 +321,7 @@ mod tests {
         let [ty] = &*primitives else {
             panic!("expected i64; got `{primitives:?}`");
         };
-        let p = CodegenPrimitive::new(ty);
+        let p = CodegenPrimitive::new(&graph, ty);
         let actual: syn::Type = parse_quote!(#p);
         let expected: syn::Type = parse_quote!(i64);
         assert_eq!(actual, expected);
@@ -358,7 +353,7 @@ mod tests {
         let [ty] = &*primitives else {
             panic!("expected u64; got `{primitives:?}`");
         };
-        let p = CodegenPrimitive::new(ty);
+        let p = CodegenPrimitive::new(&graph, ty);
         let actual: syn::Type = parse_quote!(#p);
         let expected: syn::Type = parse_quote!(u64);
         assert_eq!(actual, expected);
@@ -390,7 +385,7 @@ mod tests {
         let [ty] = &*primitives else {
             panic!("expected f32; got `{primitives:?}`");
         };
-        let p = CodegenPrimitive::new(ty);
+        let p = CodegenPrimitive::new(&graph, ty);
         let actual: syn::Type = parse_quote!(#p);
         let expected: syn::Type = parse_quote!(f32);
         assert_eq!(actual, expected);
@@ -422,7 +417,7 @@ mod tests {
         let [ty] = &*primitives else {
             panic!("expected f64; got `{primitives:?}`");
         };
-        let p = CodegenPrimitive::new(ty);
+        let p = CodegenPrimitive::new(&graph, ty);
         let actual: syn::Type = parse_quote!(#p);
         let expected: syn::Type = parse_quote!(f64);
         assert_eq!(actual, expected);
@@ -453,7 +448,7 @@ mod tests {
         let [ty] = &*primitives else {
             panic!("expected bool; got `{primitives:?}`");
         };
-        let p = CodegenPrimitive::new(ty);
+        let p = CodegenPrimitive::new(&graph, ty);
         let actual: syn::Type = parse_quote!(#p);
         let expected: syn::Type = parse_quote!(bool);
         assert_eq!(actual, expected);
@@ -486,7 +481,7 @@ mod tests {
         let [ty] = &*primitives else {
             panic!("expected datetime; got `{primitives:?}`");
         };
-        let p = CodegenPrimitive::new(ty);
+        let p = CodegenPrimitive::new(&graph, ty);
         let actual: syn::Type = parse_quote!(#p);
         let expected: syn::Type =
             parse_quote!(::ploidy_util::chrono::DateTime<::ploidy_util::chrono::Utc>);
@@ -524,7 +519,7 @@ mod tests {
         let [ty] = &*primitives else {
             panic!("expected datetime; got `{primitives:?}`");
         };
-        let p = CodegenPrimitive::new(ty);
+        let p = CodegenPrimitive::new(&graph, ty);
         let actual: syn::Type = parse_quote!(#p);
         let expected: syn::Type = parse_quote!(::ploidy_util::date_time::UnixMilliseconds);
         assert_eq!(actual, expected);
@@ -561,7 +556,7 @@ mod tests {
         let [ty] = &*primitives else {
             panic!("expected datetime; got `{primitives:?}`");
         };
-        let p = CodegenPrimitive::new(ty);
+        let p = CodegenPrimitive::new(&graph, ty);
         let actual: syn::Type = parse_quote!(#p);
         let expected: syn::Type = parse_quote!(::ploidy_util::date_time::UnixSeconds);
         assert_eq!(actual, expected);
@@ -598,7 +593,7 @@ mod tests {
         let [ty] = &*primitives else {
             panic!("expected datetime; got `{primitives:?}`");
         };
-        let p = CodegenPrimitive::new(ty);
+        let p = CodegenPrimitive::new(&graph, ty);
         let actual: syn::Type = parse_quote!(#p);
         let expected: syn::Type = parse_quote!(::ploidy_util::date_time::UnixMicroseconds);
         assert_eq!(actual, expected);
@@ -635,7 +630,7 @@ mod tests {
         let [ty] = &*primitives else {
             panic!("expected datetime; got `{primitives:?}`");
         };
-        let p = CodegenPrimitive::new(ty);
+        let p = CodegenPrimitive::new(&graph, ty);
         let actual: syn::Type = parse_quote!(#p);
         let expected: syn::Type = parse_quote!(::ploidy_util::date_time::UnixNanoseconds);
         assert_eq!(actual, expected);
@@ -667,7 +662,7 @@ mod tests {
         let [ty] = &*primitives else {
             panic!("expected date; got `{primitives:?}`");
         };
-        let p = CodegenPrimitive::new(ty);
+        let p = CodegenPrimitive::new(&graph, ty);
         let actual: syn::Type = parse_quote!(#p);
         let expected: syn::Type = parse_quote!(::ploidy_util::chrono::NaiveDate);
         assert_eq!(actual, expected);
@@ -699,7 +694,7 @@ mod tests {
         let [ty] = &*primitives else {
             panic!("expected url; got `{primitives:?}`");
         };
-        let p = CodegenPrimitive::new(ty);
+        let p = CodegenPrimitive::new(&graph, ty);
         let actual: syn::Type = parse_quote!(#p);
         let expected: syn::Type = parse_quote!(::ploidy_util::url::Url);
         assert_eq!(actual, expected);
@@ -731,7 +726,7 @@ mod tests {
         let [ty] = &*primitives else {
             panic!("expected uuid; got `{primitives:?}`");
         };
-        let p = CodegenPrimitive::new(ty);
+        let p = CodegenPrimitive::new(&graph, ty);
         let actual: syn::Type = parse_quote!(#p);
         let expected: syn::Type = parse_quote!(::ploidy_util::uuid::Uuid);
         assert_eq!(actual, expected);
@@ -763,7 +758,7 @@ mod tests {
         let [ty] = &*primitives else {
             panic!("expected bytes; got `{primitives:?}`");
         };
-        let p = CodegenPrimitive::new(ty);
+        let p = CodegenPrimitive::new(&graph, ty);
         let actual: syn::Type = parse_quote!(#p);
         let expected: syn::Type = parse_quote!(::ploidy_util::binary::Base64);
         assert_eq!(actual, expected);
@@ -795,7 +790,7 @@ mod tests {
         let [ty] = &*primitives else {
             panic!("expected binary; got `{primitives:?}`");
         };
-        let p = CodegenPrimitive::new(ty);
+        let p = CodegenPrimitive::new(&graph, ty);
         let actual: syn::Type = parse_quote!(#p);
         let expected: syn::Type = parse_quote!(::ploidy_util::serde_bytes::ByteBuf);
         assert_eq!(actual, expected);

--- a/ploidy-codegen-rust/src/query.rs
+++ b/ploidy-codegen-rust/src/query.rs
@@ -1,15 +1,12 @@
-use itertools::Itertools;
-use ploidy_core::{
-    codegen::UniqueNames,
-    ir::{OperationView, ParameterStyle, ParameterView, QueryParameter, View},
-};
+use ploidy_core::ir::{OperationView, ParameterStyle, ParameterView, QueryParameter, View};
 use proc_macro2::TokenStream;
 use quote::{ToTokens, TokenStreamExt, format_ident, quote};
 
 use super::{
     derives::ExtraDerive,
     ext::ParameterViewExt,
-    naming::{CodegenIdent, CodegenIdentScope, CodegenIdentUsage},
+    graph::{CodegenGraph, IdentMapping},
+    naming::CodegenIdentUsage,
     ref_::CodegenRef,
 };
 
@@ -21,21 +18,24 @@ use super::{
 /// with per-parameter serialization style overrides.
 #[derive(Debug)]
 pub struct CodegenQueryParameters<'a> {
+    graph: &'a CodegenGraph<'a>,
     op: &'a OperationView<'a, 'a>,
 }
 
 impl<'a> CodegenQueryParameters<'a> {
     /// Creates a new query parameter struct for the given operation.
     #[inline]
-    pub fn new(op: &'a OperationView<'a, 'a>) -> Self {
-        Self { op }
+    pub fn new(graph: &'a CodegenGraph<'a>, op: &'a OperationView<'a, 'a>) -> Self {
+        Self { graph, op }
     }
 }
 
 impl ToTokens for CodegenQueryParameters<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        let op_ident = CodegenIdent::new(self.op.id());
-        let query_name = format_ident!("{}Query", CodegenIdentUsage::Type(&op_ident));
+        let query_name = format_ident!(
+            "{}Query",
+            CodegenIdentUsage::Type(self.graph.ident(self.op.id()))
+        );
 
         let mut extra_derives = vec![];
 
@@ -57,26 +57,20 @@ impl ToTokens for CodegenQueryParameters<'_> {
             extra_derives.push(ExtraDerive::Default);
         }
 
-        let unique = UniqueNames::new();
-        let mut scope = CodegenIdentScope::new(&unique);
-
-        let params = self
-            .op
-            .query()
-            .map(|param| (scope.uniquify(param.name()), param))
-            .collect_vec();
-
-        let fields = params.iter().map(|(ident, param)| {
+        let fields = self.op.query().map(|param| {
+            let ident = self
+                .graph
+                .ident(IdentMapping::Query(self.op.id(), param.name()));
             let field_name = CodegenIdentUsage::Field(ident);
-            let serde_attr = SerdeQueryFieldAttr::new(field_name, param);
+            let serde_attr = SerdeQueryFieldAttr::new(field_name, &param);
 
             let ty = if param.optional() {
                 let view = param.ty();
-                let path = CodegenRef::new(&view);
+                let path = CodegenRef::new(self.graph, &view);
                 quote! { ::std::option::Option<#path> }
             } else {
                 let view = param.ty();
-                let path = CodegenRef::new(&view);
+                let path = CodegenRef::new(self.graph, &view);
                 quote!(#path)
             };
 
@@ -86,9 +80,10 @@ impl ToTokens for CodegenQueryParameters<'_> {
             }
         });
 
-        let styles = params
-            .iter()
-            .filter_map(|(_, param)| Some((param.name(), param.style()?)))
+        let styles = self
+            .op
+            .query()
+            .filter_map(|param| Some((param.name(), param.style()?)))
             .map(|(name, style)| {
                 let style = match style {
                     ParameterStyle::DeepObject => {
@@ -212,7 +207,7 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let op = graph.operations().next().unwrap();
-        let codegen = CodegenQueryParameters::new(&op);
+        let codegen = CodegenQueryParameters::new(&graph, &op);
 
         let actual: syn::File = parse_quote!(#codegen);
         let expected: syn::File = parse_quote! {
@@ -271,7 +266,7 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let op = graph.operations().next().unwrap();
-        let codegen = CodegenQueryParameters::new(&op);
+        let codegen = CodegenQueryParameters::new(&graph, &op);
 
         let actual: syn::File = parse_quote!(#codegen);
         let expected: syn::File = parse_quote! {
@@ -320,7 +315,7 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let op = graph.operations().next().unwrap();
-        let codegen = CodegenQueryParameters::new(&op);
+        let codegen = CodegenQueryParameters::new(&graph, &op);
 
         let actual: syn::File = parse_quote!(#codegen);
         let expected: syn::File = parse_quote! {
@@ -367,7 +362,7 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let op = graph.operations().next().unwrap();
-        let codegen = CodegenQueryParameters::new(&op);
+        let codegen = CodegenQueryParameters::new(&graph, &op);
 
         let actual: syn::File = parse_quote!(#codegen);
         let expected: syn::File = parse_quote! {
@@ -438,7 +433,7 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let op = graph.operations().next().unwrap();
-        let codegen = CodegenQueryParameters::new(&op);
+        let codegen = CodegenQueryParameters::new(&graph, &op);
 
         let actual: syn::File = parse_quote!(#codegen);
         let expected: syn::File = parse_quote! {
@@ -446,7 +441,7 @@ mod tests {
             #[serde(crate = "::ploidy_util::serde")]
             pub struct ListItemsQuery {
                 #[serde(default, skip_serializing_if = "Option::is_none")]
-                pub filter: ::std::option::Option<crate::client::default::types::ListItemsFilter>,
+                pub filter: ::std::option::Option<crate::client::default::types::ListItemsQueryFilter>,
                 #[serde(default, skip_serializing_if = "Option::is_none")]
                 pub tags: ::std::option::Option<::std::vec::Vec<::std::string::String>>,
                 #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -501,7 +496,7 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let op = graph.operations().next().unwrap();
-        let codegen = CodegenQueryParameters::new(&op);
+        let codegen = CodegenQueryParameters::new(&graph, &op);
 
         let actual: syn::File = parse_quote!(#codegen);
         let expected: syn::File = parse_quote! {

--- a/ploidy-codegen-rust/src/ref_.rs
+++ b/ploidy-codegen-rust/src/ref_.rs
@@ -1,23 +1,23 @@
-use ploidy_core::ir::{
-    ContainerView, ExtendableView, InlineTypePathRoot, InlineTypeView, TypeView,
-};
+use ploidy_core::ir::{ContainerView, HasTypeId, InlineTypePathRoot, InlineTypeView, TypeView};
 use proc_macro2::TokenStream;
 use quote::{ToTokens, TokenStreamExt, quote};
 use syn::parse_quote;
 
 use super::{
-    naming::{CargoFeature, CodegenIdent, CodegenIdentUsage, CodegenTypeName},
+    graph::{CodegenGraph, IdentMapping},
+    naming::CodegenIdentUsage,
     primitive::CodegenPrimitive,
 };
 
 #[derive(Clone, Copy, Debug)]
 pub struct CodegenRef<'a> {
+    graph: &'a CodegenGraph<'a>,
     ty: &'a TypeView<'a, 'a>,
 }
 
 impl<'a> CodegenRef<'a> {
-    pub fn new(ty: &'a TypeView<'a, 'a>) -> Self {
-        Self { ty }
+    pub fn new(graph: &'a CodegenGraph<'a>, ty: &'a TypeView<'a, 'a>) -> Self {
+        Self { graph, ty }
     }
 }
 
@@ -29,47 +29,47 @@ impl ToTokens for CodegenRef<'_> {
             // named schema containers are always emitted as references.
             TypeView::Inline(InlineTypeView::Container(_, ContainerView::Array(inner))) => {
                 let inner_ty = inner.ty();
-                let inner_ref = CodegenRef::new(&inner_ty);
+                let inner_ref = CodegenRef::new(self.graph, &inner_ty);
                 quote! { ::std::vec::Vec<#inner_ref> }
             }
             TypeView::Inline(InlineTypeView::Container(_, ContainerView::Map(inner))) => {
                 let inner_ty = inner.ty();
-                let inner_ref = CodegenRef::new(&inner_ty);
+                let inner_ref = CodegenRef::new(self.graph, &inner_ty);
                 quote! { ::std::collections::BTreeMap<::std::string::String, #inner_ref> }
             }
             TypeView::Inline(InlineTypeView::Container(_, ContainerView::Optional(inner))) => {
                 let inner_ty = inner.ty();
-                let inner_ref = CodegenRef::new(&inner_ty);
+                let inner_ref = CodegenRef::new(self.graph, &inner_ty);
                 quote! { ::std::option::Option<#inner_ref> }
             }
             TypeView::Inline(InlineTypeView::Primitive(_, view)) => {
-                let ty = CodegenPrimitive::new(view);
+                let ty = CodegenPrimitive::new(self.graph, view);
                 quote!(#ty)
             }
             TypeView::Inline(InlineTypeView::Any(_, _)) => {
                 quote! { ::ploidy_util::serde_json::Value }
             }
             TypeView::Inline(ty) => {
-                let path = ty.path();
-                let root: syn::Path = match path.root {
-                    InlineTypePathRoot::Resource(resource) => {
-                        let feature = resource.map(CargoFeature::from_name).unwrap_or_default();
-                        let mod_name = CodegenIdentUsage::Module(feature.as_ident());
-                        parse_quote!(crate::client::#mod_name::types)
-                    }
-                    InlineTypePathRoot::Type(name) => {
-                        let mod_ident = CodegenIdent::new(name);
-                        let mod_name = CodegenIdentUsage::Module(&mod_ident);
+                let root: syn::Path = match ty.path().root() {
+                    InlineTypePathRoot::Schema(id) => {
+                        let mod_name = CodegenIdentUsage::Module(self.graph.ident(id));
                         parse_quote!(crate::types::#mod_name::types)
                     }
+                    InlineTypePathRoot::Operation { resource, .. } => match resource {
+                        Some(resource) => {
+                            let mod_name = CodegenIdentUsage::Module(
+                                self.graph.ident(IdentMapping::Resource(resource)),
+                            );
+                            parse_quote!(crate::client::#mod_name::types)
+                        }
+                        None => parse_quote!(crate::client::default::types),
+                    },
                 };
-                let ty_name = CodegenTypeName::Inline(ty);
+                let ty_name = CodegenIdentUsage::Type(self.graph.ident(ty.id()));
                 parse_quote!(#root::#ty_name)
             }
             TypeView::Schema(ty) => {
-                let ext = ty.extensions();
-                let ty_ident = ext.get::<CodegenIdent>().unwrap();
-                let ty_name = CodegenIdentUsage::Type(&ty_ident);
+                let ty_name = CodegenIdentUsage::Type(self.graph.ident(ty.id()));
                 quote! { crate::types::#ty_name }
             }
         })
@@ -117,7 +117,7 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Container").unwrap();
-        let SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = schema else {
             panic!("expected struct `Container`; got `{schema:?}`");
         };
         let field = struct_view
@@ -125,9 +125,9 @@ mod tests {
             .find(|f| matches!(f.name(), StructFieldName::Name("data")))
             .unwrap();
         let ty = field.ty();
-        assert_matches!(ty, TypeView::Inline(InlineTypeView::Any(_, _)));
+        assert_matches!(ty, TypeView::Inline(InlineTypeView::Any(..)));
 
-        let ref_ = CodegenRef::new(&ty);
+        let ref_ = CodegenRef::new(&graph, &ty);
         let actual: syn::Type = parse_quote!(#ref_);
         let expected: syn::Type = parse_quote!(::ploidy_util::serde_json::Value);
         assert_eq!(actual, expected);
@@ -162,7 +162,7 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Container").unwrap();
-        let SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = schema else {
             panic!("expected struct `Container`; got `{schema:?}`");
         };
         let field = struct_view
@@ -170,7 +170,7 @@ mod tests {
             .find(|f| matches!(f.name(), StructFieldName::Name("items")))
             .unwrap();
         let ty = field.ty();
-        let ref_ = CodegenRef::new(&ty);
+        let ref_ = CodegenRef::new(&graph, &ty);
         let actual: syn::Type = parse_quote!(#ref_);
         let expected: syn::Type = parse_quote!(::std::vec::Vec<::std::string::String>);
         assert_eq!(actual, expected);
@@ -204,7 +204,7 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Container").unwrap();
-        let SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = schema else {
             panic!("expected struct `Container`; got `{schema:?}`");
         };
         let field = struct_view
@@ -212,7 +212,7 @@ mod tests {
             .find(|f| matches!(f.name(), StructFieldName::Name("numbers")))
             .unwrap();
         let ty = field.ty();
-        let ref_ = CodegenRef::new(&ty);
+        let ref_ = CodegenRef::new(&graph, &ty);
         let actual: syn::Type = parse_quote!(#ref_);
         let expected: syn::Type = parse_quote!(::std::vec::Vec<i32>);
         assert_eq!(actual, expected);
@@ -245,7 +245,7 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Container").unwrap();
-        let SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = schema else {
             panic!("expected struct `Container`; got `{schema:?}`");
         };
         let field = struct_view
@@ -253,7 +253,7 @@ mod tests {
             .find(|f| matches!(f.name(), StructFieldName::Name("metadata")))
             .unwrap();
         let ty = field.ty();
-        let ref_ = CodegenRef::new(&ty);
+        let ref_ = CodegenRef::new(&graph, &ty);
         let actual: syn::Type = parse_quote!(#ref_);
         let expected: syn::Type = parse_quote! {
             ::std::collections::BTreeMap<::std::string::String, ::std::string::String>
@@ -289,7 +289,7 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Container").unwrap();
-        let SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = schema else {
             panic!("expected struct `Container`; got `{schema:?}`");
         };
         let field = struct_view
@@ -297,7 +297,7 @@ mod tests {
             .find(|f| matches!(f.name(), StructFieldName::Name("counters")))
             .unwrap();
         let ty = field.ty();
-        let ref_ = CodegenRef::new(&ty);
+        let ref_ = CodegenRef::new(&graph, &ty);
         let actual: syn::Type = parse_quote!(#ref_);
         let expected: syn::Type = parse_quote! {
             ::std::collections::BTreeMap<::std::string::String, i64>
@@ -329,7 +329,7 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Container").unwrap();
-        let SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = schema else {
             panic!("expected struct `Container`; got `{schema:?}`");
         };
         let field = struct_view
@@ -342,7 +342,7 @@ mod tests {
             TypeView::Inline(InlineTypeView::Container(_, ContainerView::Optional(_)))
         );
 
-        let ref_ = CodegenRef::new(&ty);
+        let ref_ = CodegenRef::new(&graph, &ty);
         let actual: syn::Type = parse_quote!(#ref_);
         let expected: syn::Type = parse_quote!(::std::option::Option<::std::string::String>);
         assert_eq!(actual, expected);
@@ -373,7 +373,7 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Container").unwrap();
-        let SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = schema else {
             panic!("expected struct `Container`; got `{schema:?}`");
         };
         let field = struct_view
@@ -386,7 +386,7 @@ mod tests {
             TypeView::Inline(InlineTypeView::Container(_, ContainerView::Optional(_)))
         );
 
-        let ref_ = CodegenRef::new(&ty);
+        let ref_ = CodegenRef::new(&graph, &ty);
         let actual: syn::Type = parse_quote!(#ref_);
         let expected: syn::Type = parse_quote!(::std::option::Option<i32>);
         assert_eq!(actual, expected);
@@ -423,7 +423,7 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Container").unwrap();
-        let SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = schema else {
             panic!("expected struct `Container`; got `{schema:?}`");
         };
         let field = struct_view
@@ -432,7 +432,7 @@ mod tests {
             .unwrap();
         let ty = field.ty();
 
-        let ref_ = CodegenRef::new(&ty);
+        let ref_ = CodegenRef::new(&graph, &ty);
         let actual: syn::Type = parse_quote!(#ref_);
         let expected: syn::Type = parse_quote! {
             ::std::vec::Vec<::std::vec::Vec<i32>>
@@ -466,7 +466,7 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Container").unwrap();
-        let SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = schema else {
             panic!("expected struct `Container`; got `{schema:?}`");
         };
         let field = struct_view
@@ -479,7 +479,7 @@ mod tests {
             TypeView::Inline(InlineTypeView::Container(_, ContainerView::Optional(_)))
         );
 
-        let ref_ = CodegenRef::new(&ty);
+        let ref_ = CodegenRef::new(&graph, &ty);
         let actual: syn::Type = parse_quote!(#ref_);
         let expected: syn::Type = parse_quote! {
             ::std::option::Option<::std::vec::Vec<::std::string::String>>
@@ -515,7 +515,7 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Container").unwrap();
-        let SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = schema else {
             panic!("expected struct `Container`; got `{schema:?}`");
         };
         let field = struct_view
@@ -524,7 +524,7 @@ mod tests {
             .unwrap();
         let ty = field.ty();
 
-        let ref_ = CodegenRef::new(&ty);
+        let ref_ = CodegenRef::new(&graph, &ty);
         let actual: syn::Type = parse_quote!(#ref_);
         let expected: syn::Type = parse_quote! {
             ::std::collections::BTreeMap<::std::string::String, ::std::vec::Vec<bool>>
@@ -558,7 +558,7 @@ mod tests {
 
         let schema = graph.schema("Pet").expect("expected schema `Pet`");
         let ty = TypeView::Schema(schema);
-        let ref_ = CodegenRef::new(&ty);
+        let ref_ = CodegenRef::new(&graph, &ty);
         let actual: syn::Type = parse_quote!(#ref_);
         let expected: syn::Type = parse_quote!(crate::types::Pet);
         assert_eq!(actual, expected);
@@ -595,7 +595,7 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Container").unwrap();
-        let SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = schema else {
             panic!("expected struct `Container`; got `{schema:?}`");
         };
         let field = struct_view
@@ -604,7 +604,7 @@ mod tests {
             .unwrap();
         let ty = field.ty();
 
-        let ref_ = CodegenRef::new(&ty);
+        let ref_ = CodegenRef::new(&graph, &ty);
         let actual: syn::Type = parse_quote!(#ref_);
         let expected: syn::Type = parse_quote! {
             ::std::vec::Vec<crate::types::User>
@@ -638,7 +638,7 @@ mod tests {
 
         let schema = graph.schema("Tags").expect("expected schema `Tags`");
         let ty = TypeView::Schema(schema);
-        let ref_ = CodegenRef::new(&ty);
+        let ref_ = CodegenRef::new(&graph, &ty);
         let actual: syn::Type = parse_quote!(#ref_);
         let expected: syn::Type = parse_quote!(crate::types::Tags);
         assert_eq!(actual, expected);
@@ -674,7 +674,7 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Container").unwrap();
-        let SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = schema else {
             panic!("expected struct `Container`; got `{schema:?}`");
         };
         let field = struct_view
@@ -683,7 +683,7 @@ mod tests {
             .unwrap();
         let ty = field.ty();
 
-        let ref_ = CodegenRef::new(&ty);
+        let ref_ = CodegenRef::new(&graph, &ty);
         let actual: syn::Type = parse_quote!(#ref_);
         let expected: syn::Type = parse_quote!(crate::types::container::types::Nested);
         assert_eq!(actual, expected);
@@ -732,7 +732,7 @@ mod tests {
             );
         };
 
-        let ref_ = CodegenRef::new(&ty);
+        let ref_ = CodegenRef::new(&graph, &ty);
         let actual: syn::Type = parse_quote!(#ref_);
         let expected: syn::Type = parse_quote!(crate::client::pets::types::CreatePetRequest);
         assert_eq!(actual, expected);
@@ -782,7 +782,7 @@ mod tests {
 
         // Operations without a declared resource name
         // should use `default`.
-        let ref_ = CodegenRef::new(&ty);
+        let ref_ = CodegenRef::new(&graph, &ty);
         let actual: syn::Type = parse_quote!(#ref_);
         let expected: syn::Type = parse_quote!(crate::client::default::types::DoSomethingRequest);
         assert_eq!(actual, expected);

--- a/ploidy-codegen-rust/src/resource.rs
+++ b/ploidy-codegen-rust/src/resource.rs
@@ -1,11 +1,15 @@
-use ploidy_core::{codegen::IntoCode, ir::OperationView};
+use ploidy_core::{
+    codegen::IntoCode,
+    ir::{OperationView, View},
+};
 use proc_macro2::TokenStream;
 use quote::{ToTokens, TokenStreamExt, format_ident, quote};
 
 use super::{
     cfg::CfgFeature,
+    graph::CodegenGraph,
     inlines::CodegenInlines,
-    naming::{CargoFeature, CodegenIdent, CodegenIdentUsage},
+    naming::{CodegenIdentUsage, ResourceGroup},
     operation::CodegenOperation,
     query::CodegenQueryParameters,
 };
@@ -13,13 +17,22 @@ use super::{
 /// Generates an `impl Client` block for a feature-gated resource,
 /// with all its operations and inline types.
 pub struct CodegenResource<'a> {
-    feature: &'a CargoFeature,
+    graph: &'a CodegenGraph<'a>,
+    resource: ResourceGroup<'a>,
     ops: &'a [OperationView<'a, 'a>],
 }
 
 impl<'a> CodegenResource<'a> {
-    pub fn new(feature: &'a CargoFeature, ops: &'a [OperationView<'a, 'a>]) -> Self {
-        Self { feature, ops }
+    pub fn new(
+        graph: &'a CodegenGraph<'a>,
+        resource: ResourceGroup<'a>,
+        ops: &'a [OperationView<'a, 'a>],
+    ) -> Self {
+        Self {
+            graph,
+            resource,
+            ops,
+        }
     }
 }
 
@@ -29,16 +42,20 @@ impl ToTokens for CodegenResource<'_> {
         reason = "`filter_map` + `then` reads cleaner here"
     )]
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        // Each method gets its own `#[cfg(...)]` attribute.
-        let methods = self.ops.iter().map(|view| {
-            let cfg = CfgFeature::for_operation(view);
-            let method = CodegenOperation::new(view).into_token_stream();
+        let methods = self.ops.iter().map(|op| {
+            // Each method gets its own `#[cfg(...)]` attribute.
+            let cfg = CfgFeature::for_operation(self.graph, op);
+            let method = CodegenOperation::new(self.graph, op);
             quote! {
                 #cfg
                 #method
             }
         });
-        let inlines = CodegenInlines::Resource(self.ops);
+
+        let inlines = CodegenInlines::for_resource_inlines(
+            self.graph,
+            self.ops.iter().flat_map(|op| op.inlines()).collect(),
+        );
 
         let params = self
             .ops
@@ -47,10 +64,12 @@ impl ToTokens for CodegenResource<'_> {
                 // Collect query parameter structs for operations
                 // that have at least one query parameter.
                 op.query().next().is_some().then(|| {
-                    let cfg = CfgFeature::for_operation(op);
-                    let query = CodegenQueryParameters::new(op);
-                    let op_ident = CodegenIdent::new(op.id());
-                    let mod_name = format_ident!("{}_query", CodegenIdentUsage::Module(&op_ident));
+                    let cfg = CfgFeature::for_operation(self.graph, op);
+                    let query = CodegenQueryParameters::new(self.graph, op);
+                    let mod_name = format_ident!(
+                        "{}_query",
+                        CodegenIdentUsage::Module(self.graph.ident(op.id()))
+                    );
                     quote! {
                         #cfg
                         mod #mod_name {
@@ -85,10 +104,13 @@ impl IntoCode for CodegenResource<'_> {
 
     fn into_code(self) -> Self::Code {
         (
-            format!(
-                "src/client/{}.rs",
-                CodegenIdentUsage::Module(self.feature.as_ident()).display()
-            ),
+            match self.resource {
+                ResourceGroup::Named(name) => format!(
+                    "src/client/{}.rs",
+                    CodegenIdentUsage::Module(name).display()
+                ),
+                ResourceGroup::Default => "src/client/default.rs".to_owned(),
+            },
             self.into_token_stream(),
         )
     }
@@ -107,7 +129,7 @@ mod tests {
     use pretty_assertions::assert_eq;
     use syn::parse_quote;
 
-    use crate::{graph::CodegenGraph, naming::CargoFeature};
+    use crate::graph::CodegenGraph;
 
     // MARK: Feature gating
 
@@ -152,8 +174,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let ops = graph.operations().collect_vec();
-        let feature = CargoFeature::from_name("customer");
-        let resource = CodegenResource::new(&feature, &ops);
+        let [op] = &*ops else {
+            panic!("expected one operation; got `{ops:?}`");
+        };
+        let resource =
+            CodegenResource::new(&graph, graph.resource_for(op), std::slice::from_ref(op));
 
         // No `#[cfg(...)]` on the method because none of its
         // dependencies have an `x-resourceId`.
@@ -233,8 +258,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let ops = graph.operations().collect_vec();
-        let feature = CargoFeature::from_name("orders");
-        let resource = CodegenResource::new(&feature, &ops);
+        let [op] = &*ops else {
+            panic!("expected one operation; got `{ops:?}`");
+        };
+        let resource =
+            CodegenResource::new(&graph, graph.resource_for(op), std::slice::from_ref(op));
 
         // `#[cfg(feature = "customer")]` because `Order` depends on
         // `Customer`, which has `x-resourceId: customer`.
@@ -304,8 +332,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let ops = graph.operations().collect_vec();
-        let feature = CargoFeature::from_name("customer");
-        let resource = CodegenResource::new(&feature, &ops);
+        let [op] = &*ops else {
+            panic!("expected one operation; got `{ops:?}`");
+        };
+        let resource =
+            CodegenResource::new(&graph, graph.resource_for(op), std::slice::from_ref(op));
 
         let actual: syn::File = parse_quote!(#resource);
         let expected: syn::File = parse_quote! {
@@ -402,8 +433,12 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let ops = graph.operations().collect_vec();
-        let feature = CargoFeature::from_name("customer");
-        let resource = CodegenResource::new(&feature, &ops);
+        let resource = ops
+            .iter()
+            .map(|op| graph.resource_for(op))
+            .all_equal_value()
+            .unwrap();
+        let resource = CodegenResource::new(&graph, resource, &ops);
 
         let actual: syn::File = parse_quote!(#resource);
         let expected: syn::File = parse_quote! {
@@ -524,8 +559,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let ops = graph.operations().collect_vec();
-        let feature = CargoFeature::from_name("customer");
-        let resource = CodegenResource::new(&feature, &ops);
+        let [op] = &*ops else {
+            panic!("expected one operation; got `{ops:?}`");
+        };
+        let resource =
+            CodegenResource::new(&graph, graph.resource_for(op), std::slice::from_ref(op));
 
         let actual: syn::File = parse_quote!(#resource);
         let expected: syn::File = parse_quote! {

--- a/ploidy-codegen-rust/src/schema.rs
+++ b/ploidy-codegen-rust/src/schema.rs
@@ -1,76 +1,87 @@
-use ploidy_core::codegen::IntoCode;
-use ploidy_core::ir::{ContainerView, SchemaTypeView};
+use ploidy_core::{
+    codegen::IntoCode,
+    ir::{ContainerView, HasTypeId, SchemaTypeView, View},
+};
 use proc_macro2::TokenStream;
 use quote::{ToTokens, TokenStreamExt, quote};
 
 use super::{
-    doc_attrs, enum_::CodegenEnum, inlines::CodegenInlines, naming::CodegenTypeName,
-    primitive::CodegenPrimitive, ref_::CodegenRef, struct_::CodegenStruct, tagged::CodegenTagged,
-    untagged::CodegenUntagged,
+    doc_attrs, enum_::CodegenEnum, graph::CodegenGraph, inlines::CodegenInlines,
+    naming::CodegenIdentUsage, primitive::CodegenPrimitive, ref_::CodegenRef,
+    struct_::CodegenStruct, tagged::CodegenTagged, untagged::CodegenUntagged,
 };
 
 /// Generates a module for a named schema type.
 #[derive(Debug)]
 pub struct CodegenSchemaType<'a> {
+    graph: &'a CodegenGraph<'a>,
     ty: &'a SchemaTypeView<'a, 'a>,
 }
 
 impl<'a> CodegenSchemaType<'a> {
-    pub fn new(ty: &'a SchemaTypeView<'a, 'a>) -> Self {
-        Self { ty }
+    pub fn new(graph: &'a CodegenGraph<'a>, ty: &'a SchemaTypeView<'a, 'a>) -> Self {
+        Self { graph, ty }
     }
 }
 
 impl ToTokens for CodegenSchemaType<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        let name = CodegenTypeName::Schema(self.ty);
         let ty = match self.ty {
-            SchemaTypeView::Struct(_, view) => CodegenStruct::new(name, view).into_token_stream(),
-            SchemaTypeView::Enum(_, view) => CodegenEnum::new(name, view).into_token_stream(),
-            SchemaTypeView::Tagged(_, view) => CodegenTagged::new(name, view).into_token_stream(),
+            SchemaTypeView::Struct(_, view) => {
+                CodegenStruct::new(self.graph, view).into_token_stream()
+            }
+            SchemaTypeView::Enum(_, view) => CodegenEnum::new(self.graph, view).into_token_stream(),
+            SchemaTypeView::Tagged(_, view) => {
+                CodegenTagged::new(self.graph, view).into_token_stream()
+            }
             SchemaTypeView::Untagged(_, view) => {
-                CodegenUntagged::new(name, view).into_token_stream()
+                CodegenUntagged::new(self.graph, view).into_token_stream()
             }
             SchemaTypeView::Container(_, ContainerView::Array(inner)) => {
                 let doc_attrs = inner.description().map(doc_attrs);
+                let type_name = CodegenIdentUsage::Type(self.graph.ident(self.ty.id()));
                 let inner_ty = inner.ty();
-                let inner_ref = CodegenRef::new(&inner_ty);
+                let inner_ref = CodegenRef::new(self.graph, &inner_ty);
                 quote! {
                     #doc_attrs
-                    pub type #name = ::std::vec::Vec<#inner_ref>;
+                    pub type #type_name = ::std::vec::Vec<#inner_ref>;
                 }
             }
             SchemaTypeView::Container(_, ContainerView::Map(inner)) => {
                 let doc_attrs = inner.description().map(doc_attrs);
+                let type_name = CodegenIdentUsage::Type(self.graph.ident(self.ty.id()));
                 let inner_ty = inner.ty();
-                let inner_ref = CodegenRef::new(&inner_ty);
+                let inner_ref = CodegenRef::new(self.graph, &inner_ty);
                 quote! {
                     #doc_attrs
-                    pub type #name = ::std::collections::BTreeMap<::std::string::String, #inner_ref>;
+                    pub type #type_name = ::std::collections::BTreeMap<::std::string::String, #inner_ref>;
                 }
             }
             SchemaTypeView::Container(_, ContainerView::Optional(inner)) => {
                 let doc_attrs = inner.description().map(doc_attrs);
+                let type_name = CodegenIdentUsage::Type(self.graph.ident(self.ty.id()));
                 let inner_ty = inner.ty();
-                let inner_ref = CodegenRef::new(&inner_ty);
+                let inner_ref = CodegenRef::new(self.graph, &inner_ty);
                 quote! {
                     #doc_attrs
-                    pub type #name = ::std::option::Option<#inner_ref>;
+                    pub type #type_name = ::std::option::Option<#inner_ref>;
                 }
             }
             SchemaTypeView::Primitive(_, view) => {
-                let primitive = CodegenPrimitive::new(view);
+                let type_name = CodegenIdentUsage::Type(self.graph.ident(self.ty.id()));
+                let primitive = CodegenPrimitive::new(self.graph, view);
                 quote! {
-                    pub type #name = #primitive;
+                    pub type #type_name = #primitive;
                 }
             }
             SchemaTypeView::Any(_, _) => {
+                let type_name = CodegenIdentUsage::Type(self.graph.ident(self.ty.id()));
                 quote! {
-                    pub type #name = ::ploidy_util::serde_json::Value;
+                    pub type #type_name = ::ploidy_util::serde_json::Value;
                 }
             }
         };
-        let inlines = CodegenInlines::Schema(self.ty);
+        let inlines = CodegenInlines::for_schema_inlines(self.graph, self.ty.inlines().collect());
         tokens.append_all(quote! {
             #ty
             #inlines
@@ -82,9 +93,9 @@ impl IntoCode for CodegenSchemaType<'_> {
     type Code = (String, TokenStream);
 
     fn into_code(self) -> Self::Code {
-        let name = CodegenTypeName::Schema(self.ty);
+        let mod_name = CodegenIdentUsage::Module(self.graph.ident(self.ty.id()));
         (
-            format!("src/types/{}.rs", name.into_module_name().display()),
+            format!("src/types/{}.rs", mod_name.display()),
             self.into_token_stream(),
         )
     }
@@ -142,11 +153,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Container").unwrap();
-        let schema @ SchemaTypeView::Struct(_, _) = &schema else {
+        let SchemaTypeView::Struct(_, _) = &schema else {
             panic!("expected struct `Container`; got `{schema:?}`");
         };
 
-        let codegen = CodegenSchemaType::new(schema);
+        let codegen = CodegenSchemaType::new(&graph, &schema);
 
         let actual: syn::File = parse_quote!(#codegen);
         // The struct fields remain in their original order (`zebra`, `mango`, `apple`),
@@ -223,11 +234,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("InvalidParameters").unwrap();
-        let schema @ SchemaTypeView::Container(_, _) = &schema else {
+        let SchemaTypeView::Container(_, _) = &schema else {
             panic!("expected container `InvalidParameters`; got `{schema:?}`");
         };
 
-        let codegen = CodegenSchemaType::new(schema);
+        let codegen = CodegenSchemaType::new(&graph, &schema);
 
         let actual: syn::File = parse_quote!(#codegen);
         let expected: syn::File = parse_quote! {
@@ -268,11 +279,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Tags").unwrap();
-        let schema @ SchemaTypeView::Container(_, _) = &schema else {
+        let SchemaTypeView::Container(_, _) = &schema else {
             panic!("expected container `Tags`; got `{schema:?}`");
         };
 
-        let codegen = CodegenSchemaType::new(schema);
+        let codegen = CodegenSchemaType::new(&graph, &schema);
 
         let actual: syn::File = parse_quote!(#codegen);
         let expected: syn::File = parse_quote! {
@@ -303,11 +314,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Metadata").unwrap();
-        let schema @ SchemaTypeView::Container(_, _) = &schema else {
+        let SchemaTypeView::Container(_, _) = &schema else {
             panic!("expected container `Metadata`; got `{schema:?}`");
         };
 
-        let codegen = CodegenSchemaType::new(schema);
+        let codegen = CodegenSchemaType::new(&graph, &schema);
 
         let actual: syn::File = parse_quote!(#codegen);
         let expected: syn::File = parse_quote! {
@@ -352,10 +363,10 @@ mod tests {
 
         // `type: ["string", "null"]` becomes `Option<String>`.
         let schema = graph.schema("NullableString").unwrap();
-        let schema @ SchemaTypeView::Container(_, _) = &schema else {
+        let SchemaTypeView::Container(_, _) = &schema else {
             panic!("expected container `NullableString`; got `{schema:?}`");
         };
-        let codegen = CodegenSchemaType::new(schema);
+        let codegen = CodegenSchemaType::new(&graph, &schema);
         let actual: syn::File = parse_quote!(#codegen);
         let expected: syn::File = parse_quote! {
             pub type NullableString = ::std::option::Option<::std::string::String>;
@@ -364,10 +375,10 @@ mod tests {
 
         // `type: ["array", "null"]` becomes `Option<Vec<String>>`.
         let schema = graph.schema("NullableArray").unwrap();
-        let schema @ SchemaTypeView::Container(_, _) = &schema else {
+        let SchemaTypeView::Container(_, _) = &schema else {
             panic!("expected container `NullableArray`; got `{schema:?}`");
         };
-        let codegen = CodegenSchemaType::new(schema);
+        let codegen = CodegenSchemaType::new(&graph, &schema);
         let actual: syn::File = parse_quote!(#codegen);
         let expected: syn::File = parse_quote! {
             pub type NullableArray = ::std::option::Option<::std::vec::Vec<::std::string::String>>;
@@ -377,10 +388,10 @@ mod tests {
         // `type: ["object", "null"]` with `additionalProperties` becomes
         // `Option<BTreeMap<String, String>>`.
         let schema = graph.schema("NullableMap").unwrap();
-        let schema @ SchemaTypeView::Container(_, _) = &schema else {
+        let SchemaTypeView::Container(_, _) = &schema else {
             panic!("expected container `NullableMap`; got `{schema:?}`");
         };
-        let codegen = CodegenSchemaType::new(schema);
+        let codegen = CodegenSchemaType::new(&graph, &schema);
         let actual: syn::File = parse_quote!(#codegen);
         let expected: syn::File = parse_quote! {
             pub type NullableMap = ::std::option::Option<::std::collections::BTreeMap<::std::string::String, ::std::string::String>>;
@@ -390,20 +401,77 @@ mod tests {
         // `oneOf` with an inline schema and `null` becomes an `Option<InlineStruct>`,
         // with the inline struct definition emitted in `mod types`.
         let schema = graph.schema("NullableOneOf").unwrap();
-        let schema @ SchemaTypeView::Container(_, _) = &schema else {
+        let SchemaTypeView::Container(_, _) = &schema else {
             panic!("expected container `NullableOneOf`; got `{schema:?}`");
         };
-        let codegen = CodegenSchemaType::new(schema);
+        let codegen = CodegenSchemaType::new(&graph, &schema);
         let actual: syn::File = parse_quote!(#codegen);
         let expected: syn::File = parse_quote! {
-            pub type NullableOneOf = ::std::option::Option<crate::types::nullable_one_of::types::V1>;
+            pub type NullableOneOf = ::std::option::Option<crate::types::nullable_one_of::types::Value>;
             pub mod types {
                 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
                 #[serde(crate = "::ploidy_util::serde")]
                 #[ploidy(pointer(crate = "::ploidy_util::pointer"))]
-                pub struct V1 {
+                pub struct Value {
                     #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent")]
                     pub value: ::ploidy_util::absent::AbsentOr<::std::string::String>,
+                }
+            }
+        };
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_nullable_schema_value_name_collision() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.1.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                NullableThing:
+                  oneOf:
+                    - type: object
+                      properties:
+                        value:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                    - type: 'null'
+        "})
+        .unwrap();
+
+        let arena = Arena::new();
+        let spec = Spec::from_doc(&arena, &doc).unwrap();
+        let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
+
+        let schema = graph.schema("NullableThing").unwrap();
+        let SchemaTypeView::Container(_, _) = &schema else {
+            panic!("expected container `NullableThing`; got `{schema:?}`");
+        };
+
+        let codegen = CodegenSchemaType::new(&graph, &schema);
+
+        let actual: syn::File = parse_quote!(#codegen);
+        let expected: syn::File = parse_quote! {
+            pub type NullableThing = ::std::option::Option<crate::types::nullable_thing::types::Value>;
+            pub mod types {
+                #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
+                #[serde(crate = "::ploidy_util::serde")]
+                #[ploidy(pointer(crate = "::ploidy_util::pointer"))]
+                pub struct Value {
+                    #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent")]
+                    pub value: ::ploidy_util::absent::AbsentOr<crate::types::nullable_thing::types::Value2>,
+                }
+                #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
+                #[serde(crate = "::ploidy_util::serde")]
+                #[ploidy(pointer(crate = "::ploidy_util::pointer"))]
+                pub struct Value2 {
+                    #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent")]
+                    pub id: ::ploidy_util::absent::AbsentOr<::std::string::String>,
                 }
             }
         };
@@ -433,16 +501,241 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Tags").unwrap();
-        let schema @ SchemaTypeView::Container(_, _) = &schema else {
+        let SchemaTypeView::Container(_, _) = &schema else {
             panic!("expected container `Tags`; got `{schema:?}`");
         };
 
-        let codegen = CodegenSchemaType::new(schema);
+        let codegen = CodegenSchemaType::new(&graph, &schema);
 
         let actual: syn::File = parse_quote!(#codegen);
         let expected: syn::File = parse_quote! {
             #[doc = "A list of tags."]
             pub type Tags = ::std::vec::Vec<::std::string::String>;
+        };
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_case_colliding_fields_uniquify_inline_type_names() {
+        // `fooBar` and `foo_bar` both normalize to `foo_bar` in Rust,
+        // so the field names — and their inline type names — must be
+        // uniquified to avoid collisions.
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Qux:
+                  type: object
+                  properties:
+                    fooBar:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          zoom:
+                            type: string
+                    foo_bar:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          blagh:
+                            type: string
+        "})
+        .unwrap();
+
+        let arena = Arena::new();
+        let spec = Spec::from_doc(&arena, &doc).unwrap();
+        let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
+
+        let schema = graph.schema("Qux").unwrap();
+        let SchemaTypeView::Struct(_, _) = &schema else {
+            panic!("expected struct `Qux`; got `{schema:?}`");
+        };
+
+        let codegen = CodegenSchemaType::new(&graph, &schema);
+
+        let actual: syn::File = parse_quote!(#codegen);
+        let expected: syn::File = parse_quote! {
+            #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
+            #[serde(crate = "::ploidy_util::serde")]
+            #[ploidy(pointer(crate = "::ploidy_util::pointer"))]
+            pub struct Qux {
+                #[serde(rename = "fooBar", default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent")]
+                #[ploidy(pointer(rename = "fooBar"))]
+                pub foo_bar: ::ploidy_util::absent::AbsentOr<::std::vec::Vec<crate::types::qux::types::FooBarItem>>,
+                #[serde(rename = "foo_bar", default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent")]
+                #[ploidy(pointer(rename = "foo_bar"))]
+                pub foo_bar2: ::ploidy_util::absent::AbsentOr<::std::vec::Vec<crate::types::qux::types::FooBar2Item>>,
+            }
+            pub mod types {
+                #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
+                #[serde(crate = "::ploidy_util::serde")]
+                #[ploidy(pointer(crate = "::ploidy_util::pointer"))]
+                pub struct FooBar2Item {
+                    #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent")]
+                    pub blagh: ::ploidy_util::absent::AbsentOr<::std::string::String>,
+                }
+                #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
+                #[serde(crate = "::ploidy_util::serde")]
+                #[ploidy(pointer(crate = "::ploidy_util::pointer"))]
+                pub struct FooBarItem {
+                    #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent")]
+                    pub zoom: ::ploidy_util::absent::AbsentOr<::std::string::String>,
+                }
+            }
+        };
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_colliding_inline_paths_uniquify_inline_type_names() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Collision API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Qux:
+                  type: object
+                  properties:
+                    fooItem:
+                      type: object
+                      properties:
+                        direct:
+                          type: string
+                    foo:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          nested:
+                            type: string
+        "})
+        .unwrap();
+
+        let arena = Arena::new();
+        let spec = Spec::from_doc(&arena, &doc).unwrap();
+        let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
+
+        let schema = graph.schema("Qux").unwrap();
+        let SchemaTypeView::Struct(_, _) = &schema else {
+            panic!("expected struct `Qux`; got `{schema:?}`");
+        };
+
+        let codegen = CodegenSchemaType::new(&graph, &schema);
+
+        let actual: syn::File = parse_quote!(#codegen);
+        let expected: syn::File = parse_quote! {
+            #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
+            #[serde(crate = "::ploidy_util::serde")]
+            #[ploidy(pointer(crate = "::ploidy_util::pointer"))]
+            pub struct Qux {
+                #[serde(rename = "fooItem", default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent")]
+                #[ploidy(pointer(rename = "fooItem"))]
+                pub foo_item: ::ploidy_util::absent::AbsentOr<crate::types::qux::types::FooItem>,
+                #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent")]
+                pub foo: ::ploidy_util::absent::AbsentOr<::std::vec::Vec<crate::types::qux::types::FooItem2>>,
+            }
+            pub mod types {
+                #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
+                #[serde(crate = "::ploidy_util::serde")]
+                #[ploidy(pointer(crate = "::ploidy_util::pointer"))]
+                pub struct FooItem {
+                    #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent")]
+                    pub direct: ::ploidy_util::absent::AbsentOr<::std::string::String>,
+                }
+                #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
+                #[serde(crate = "::ploidy_util::serde")]
+                #[ploidy(pointer(crate = "::ploidy_util::pointer"))]
+                pub struct FooItem2 {
+                    #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent")]
+                    pub nested: ::ploidy_util::absent::AbsentOr<::std::string::String>,
+                }
+            }
+        };
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_tagged_common_inline_field_codegen() {
+        // `metadata` is a common field on the tagged union itself.
+        // Its inline object type is reached through a `Field` edge
+        // whose parent is a tagged view, not a struct view.
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Dog:
+                  type: object
+                  properties:
+                    kind:
+                      type: string
+                    bark:
+                      type: string
+                Pet:
+                  oneOf:
+                    - $ref: '#/components/schemas/Dog'
+                  discriminator:
+                    propertyName: kind
+                    mapping:
+                      dog: '#/components/schemas/Dog'
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        source:
+                          type: string
+        "})
+        .unwrap();
+
+        let arena = Arena::new();
+        let spec = Spec::from_doc(&arena, &doc).unwrap();
+        let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
+
+        let schema = graph.schema("Pet").unwrap();
+        let SchemaTypeView::Tagged(_, _) = &schema else {
+            panic!("expected tagged `Pet`; got `{schema:?}`");
+        };
+
+        let codegen = CodegenSchemaType::new(&graph, &schema);
+
+        let actual: syn::File = parse_quote!(#codegen);
+        let expected: syn::File = parse_quote! {
+            #[derive(Debug, Clone, PartialEq, Eq, Hash, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
+            #[serde(crate = "::ploidy_util::serde", tag = "kind")]
+            #[ploidy(pointer(crate = "::ploidy_util::pointer", tag = "kind"))]
+            pub enum Pet {
+                #[serde(rename = "dog")]
+                #[ploidy(pointer(rename = "dog"))]
+                Dog(crate::types::Dog),
+            }
+
+            impl ::std::convert::From<crate::types::Dog> for Pet {
+                fn from(value: crate::types::Dog) -> Self {
+                    Self::Dog(value)
+                }
+            }
+
+            pub mod types {
+                #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
+                #[serde(crate = "::ploidy_util::serde")]
+                #[ploidy(pointer(crate = "::ploidy_util::pointer"))]
+                pub struct Metadata {
+                    #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent")]
+                    pub source: ::ploidy_util::absent::AbsentOr<::std::string::String>,
+                }
+            }
         };
         assert_eq!(actual, expected);
     }

--- a/ploidy-codegen-rust/src/struct_.rs
+++ b/ploidy-codegen-rust/src/struct_.rs
@@ -1,35 +1,27 @@
 use itertools::Itertools;
-use ploidy_core::{
-    codegen::UniqueNames,
-    ir::{Required, StructFieldName, StructFieldView, StructView, View},
-};
+use ploidy_core::ir::{HasTypeId, Required, StructFieldName, StructFieldView, StructView, View};
 use proc_macro2::TokenStream;
 use quote::{ToTokens, TokenStreamExt, quote};
 
 use super::{
-    derives::ExtraDerive,
-    doc_attrs,
-    ext::FieldViewExt,
-    naming::{CodegenIdentRef, CodegenIdentScope, CodegenIdentUsage, CodegenTypeName},
-    ref_::CodegenRef,
+    derives::ExtraDerive, doc_attrs, ext::FieldViewExt, graph::CodegenGraph, graph::IdentMapping,
+    naming::CodegenIdentUsage, ref_::CodegenRef,
 };
 
 #[derive(Clone, Debug)]
 pub struct CodegenStruct<'a> {
-    name: CodegenTypeName<'a>,
+    graph: &'a CodegenGraph<'a>,
     ty: &'a StructView<'a, 'a>,
 }
 
 impl<'a> CodegenStruct<'a> {
-    pub fn new(name: CodegenTypeName<'a>, ty: &'a StructView<'a, 'a>) -> Self {
-        Self { name, ty }
+    pub fn new(graph: &'a CodegenGraph<'a>, ty: &'a StructView<'a, 'a>) -> Self {
+        Self { graph, ty }
     }
 }
 
 impl ToTokens for CodegenStruct<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        let unique = UniqueNames::new();
-        let mut scope = CodegenIdentScope::new(&unique);
         let fields = self
             .ty
             .fields()
@@ -37,15 +29,12 @@ impl ToTokens for CodegenStruct<'_> {
             .map(|field| {
                 let doc_attrs = field.description().map(doc_attrs);
 
-                let name = match field.name() {
-                    StructFieldName::Name(n) => scope.uniquify(n),
-                    StructFieldName::Hint(hint) => {
-                        scope.uniquify_ident(&CodegenIdentRef::from_field_name_hint(hint))
-                    }
-                };
-                let field_name = CodegenIdentUsage::Field(&name);
+                let field_name = CodegenIdentUsage::Field(
+                    self.graph
+                        .ident(IdentMapping::StructField(self.ty.id(), field.name())),
+                );
                 let field_attrs = StructFieldAttrs::new(field_name, &field);
-                let ty = CodegenField::new(&field);
+                let ty = CodegenField::new(self.graph, &field);
 
                 quote! {
                     #doc_attrs
@@ -69,7 +58,7 @@ impl ToTokens for CodegenStruct<'_> {
             extra_derives.push(ExtraDerive::Default);
         }
 
-        let type_name = &self.name;
+        let type_name = CodegenIdentUsage::Type(self.graph.ident(self.ty.id()));
         let doc_attrs = self.ty.description().map(doc_attrs);
 
         tokens.append_all(quote! {
@@ -87,19 +76,20 @@ impl ToTokens for CodegenStruct<'_> {
 /// A field in a struct, ready for code generation.
 #[derive(Debug)]
 struct CodegenField<'view, 'a> {
+    graph: &'a CodegenGraph<'a>,
     field: &'a StructFieldView<'view, 'a, 'a>,
 }
 
 impl<'view, 'a> CodegenField<'view, 'a> {
-    fn new(field: &'a StructFieldView<'view, 'a, 'a>) -> Self {
-        Self { field }
+    fn new(graph: &'a CodegenGraph<'a>, field: &'a StructFieldView<'view, 'a, 'a>) -> Self {
+        Self { graph, field }
     }
 }
 
 impl ToTokens for CodegenField<'_, '_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let ty = self.field.inner();
-        let ref_ = CodegenRef::new(&ty);
+        let ref_ = CodegenRef::new(self.graph, &ty);
         let boxed = if self.field.needs_box() {
             quote! { ::std::boxed::Box<#ref_> }
         } else {
@@ -224,12 +214,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Pet").unwrap();
-        let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = &schema else {
             panic!("expected struct `Pet`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenStruct::new(name, struct_view);
+        let codegen = CodegenStruct::new(&graph, struct_view);
 
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         // `name` is a required string field, which implements `Default`,
@@ -284,12 +273,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Animal").unwrap();
-        let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = &schema else {
             panic!("expected struct `Animal`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenStruct::new(name, struct_view);
+        let codegen = CodegenStruct::new(&graph, struct_view);
 
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         // `name` is a required string field, which implements `Default`,
@@ -335,12 +323,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Record").unwrap();
-        let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = &schema else {
             panic!("expected struct `Record`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenStruct::new(name, struct_view);
+        let codegen = CodegenStruct::new(&graph, struct_view);
 
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         // Required nullable field uses `Option<T>`, not `AbsentOr<T>`,
@@ -387,12 +374,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Record").unwrap();
-        let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = &schema else {
             panic!("expected struct `Record`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenStruct::new(name, struct_view);
+        let codegen = CodegenStruct::new(&graph, struct_view);
 
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         // OpenAPI 3.1 `type: [T, 'null']` syntax should behave identically to
@@ -440,12 +426,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Record").unwrap();
-        let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = &schema else {
             panic!("expected struct `Record`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenStruct::new(name, struct_view);
+        let codegen = CodegenStruct::new(&graph, struct_view);
 
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         // Optional nullable field uses `AbsentOr<T>` with `#[serde(...)]` attributes.
@@ -494,12 +479,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Record").unwrap();
-        let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = &schema else {
             panic!("expected struct `Record`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenStruct::new(name, struct_view);
+        let codegen = CodegenStruct::new(&graph, struct_view);
 
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         // The field should be `AbsentOr<String>`, not `AbsentOr<NullableString>`
@@ -545,12 +529,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("User").unwrap();
-        let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = &schema else {
             panic!("expected struct `User`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenStruct::new(name, struct_view);
+        let codegen = CodegenStruct::new(&graph, struct_view);
 
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         // `id` is a required string field, which implements `Default`,
@@ -597,12 +580,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Measurement").unwrap();
-        let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = &schema else {
             panic!("expected struct `Measurement`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenStruct::new(name, struct_view);
+        let codegen = CodegenStruct::new(&graph, struct_view);
 
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         // `value` and `unit` are required primitive fields. `f64` prevents `Eq`
@@ -666,12 +648,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("TextAction").unwrap();
-        let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = &schema else {
             panic!("expected struct `TextAction`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenStruct::new(name, struct_view);
+        let codegen = CodegenStruct::new(&graph, struct_view);
 
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         let expected: syn::ItemStruct = parse_quote! {
@@ -727,12 +708,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("TextAction").unwrap();
-        let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = &schema else {
             panic!("expected struct `TextAction`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenStruct::new(name, struct_view);
+        let codegen = CodegenStruct::new(&graph, struct_view);
 
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         let expected: syn::ItemStruct = parse_quote! {
@@ -801,12 +781,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("TextAction").unwrap();
-        let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = &schema else {
             panic!("expected struct `TextAction`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenStruct::new(name, struct_view);
+        let codegen = CodegenStruct::new(&graph, struct_view);
 
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         let expected: syn::ItemStruct = parse_quote! {
@@ -868,12 +847,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("TextAction").unwrap();
-        let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = &schema else {
             panic!("expected struct `TextAction`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenStruct::new(name, struct_view);
+        let codegen = CodegenStruct::new(&graph, struct_view);
 
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         let expected: syn::ItemStruct = parse_quote! {
@@ -971,12 +949,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("TextAction").unwrap();
-        let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = &schema else {
             panic!("expected struct `TextAction`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenStruct::new(name, struct_view);
+        let codegen = CodegenStruct::new(&graph, struct_view);
 
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         let expected: syn::ItemStruct = parse_quote! {
@@ -1043,12 +1020,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("N").unwrap();
-        let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = &schema else {
             panic!("expected struct `N`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenStruct::new(name, struct_view);
+        let codegen = CodegenStruct::new(&graph, struct_view);
 
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         let expected: syn::ItemStruct = parse_quote! {
@@ -1110,12 +1086,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("X").unwrap();
-        let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = &schema else {
             panic!("expected struct `X`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenStruct::new(name, struct_view);
+        let codegen = CodegenStruct::new(&graph, struct_view);
 
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         let expected: syn::ItemStruct = parse_quote! {
@@ -1182,12 +1157,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("B").unwrap();
-        let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = &schema else {
             panic!("expected struct `B`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenStruct::new(name, struct_view);
+        let codegen = CodegenStruct::new(&graph, struct_view);
 
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         let expected: syn::ItemStruct = parse_quote! {
@@ -1256,13 +1230,13 @@ mod tests {
         let actual: syn::File = syn::parse2(
             graph
                 .schemas()
-                .filter(|s| matches!(s.name(), "A" | "N" | "T"))
+                .filter(|schema| matches!(schema.name(), "A" | "N" | "T"))
                 .map(|schema| {
-                    let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+                    let SchemaTypeView::Struct(_, struct_view) = &schema else {
                         panic!("expected struct; got `{schema:?}`");
                     };
-                    let name = CodegenTypeName::Schema(schema);
-                    let codegen = CodegenStruct::new(name, struct_view);
+
+                    let codegen = CodegenStruct::new(&graph, struct_view);
                     quote!(#codegen)
                 })
                 .reduce(|a, b| quote! { #a #b })
@@ -1321,12 +1295,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Options").unwrap();
-        let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = &schema else {
             panic!("expected struct `Options`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenStruct::new(name, struct_view);
+        let codegen = CodegenStruct::new(&graph, struct_view);
 
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         let expected: syn::ItemStruct = parse_quote! {
@@ -1371,12 +1344,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Outer").unwrap();
-        let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = &schema else {
             panic!("expected struct `Outer`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenStruct::new(name, struct_view);
+        let codegen = CodegenStruct::new(&graph, struct_view);
 
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         // Both `Outer` and `Inner` have all optional fields,
@@ -1425,12 +1397,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Outer").unwrap();
-        let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = &schema else {
             panic!("expected struct `Outer`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenStruct::new(name, struct_view);
+        let codegen = CodegenStruct::new(&graph, struct_view);
 
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         // `Outer.inner` is required, and `Inner` has a required field (`id`),
@@ -1489,12 +1460,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Owner").unwrap();
-        let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = &schema else {
             panic!("expected struct `Owner`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenStruct::new(name, struct_view);
+        let codegen = CodegenStruct::new(&graph, struct_view);
 
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         // `Pet` is a tagged union, but `Owner.pet` is optional (`AbsentOr<Pet>`),
@@ -1539,12 +1509,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Container").unwrap();
-        let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = &schema else {
             panic!("expected struct `Container`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenStruct::new(name, struct_view);
+        let codegen = CodegenStruct::new(&graph, struct_view);
 
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         // `StringOrInt` is an untagged union, but `Container.value` is optional
@@ -1605,12 +1574,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Owner").unwrap();
-        let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = &schema else {
             panic!("expected struct `Owner`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenStruct::new(name, struct_view);
+        let codegen = CodegenStruct::new(&graph, struct_view);
 
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         // `Pet` is a required field, so `Owner` can't derive `Default`.
@@ -1655,12 +1623,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Outer").unwrap();
-        let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = &schema else {
             panic!("expected struct `Outer`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenStruct::new(name, struct_view);
+        let codegen = CodegenStruct::new(&graph, struct_view);
 
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         // `Outer.inner` is optional, so `Outer` can derive `Default` even though
@@ -1701,12 +1668,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Container").unwrap();
-        let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = &schema else {
             panic!("expected struct `Container`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenStruct::new(name, struct_view);
+        let codegen = CodegenStruct::new(&graph, struct_view);
 
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         // `data` is a required `Any` field. Since `serde_json::Value` implements
@@ -1754,12 +1720,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Defaults").unwrap();
-        let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = &schema else {
             panic!("expected struct `Defaults`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenStruct::new(name, struct_view);
+        let codegen = CodegenStruct::new(&graph, struct_view);
 
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         // Primitives like `String`, `i32`, and `bool` implement `Default`,
@@ -1803,12 +1768,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Resource").unwrap();
-        let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = &schema else {
             panic!("expected struct `Resource`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenStruct::new(name, struct_view);
+        let codegen = CodegenStruct::new(&graph, struct_view);
 
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         // `Url` doesn't implement `Default`, so the struct can't derive it.
@@ -1851,12 +1815,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Resource").unwrap();
-        let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = &schema else {
             panic!("expected struct `Resource`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenStruct::new(name, struct_view);
+        let codegen = CodegenStruct::new(&graph, struct_view);
 
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         let expected: syn::ItemStruct = parse_quote! {
@@ -1904,12 +1867,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Container").unwrap();
-        let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = &schema else {
             panic!("expected struct `Container`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenStruct::new(name, struct_view);
+        let codegen = CodegenStruct::new(&graph, struct_view);
 
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         // `Tags` is a type alias for `Vec<String>`, which implements `Default`,
@@ -1974,12 +1936,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Corgi").unwrap();
-        let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = &schema else {
             panic!("expected struct `Corgi`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenStruct::new(name, struct_view);
+        let codegen = CodegenStruct::new(&graph, struct_view);
 
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         // `Corgi` inherits from the tagged union `Animal` via `allOf`.
@@ -2055,12 +2016,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Child").unwrap();
-        let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = &schema else {
             panic!("expected struct `Child`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenStruct::new(name, struct_view);
+        let codegen = CodegenStruct::new(&graph, struct_view);
 
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         // `Child` inherits non-defaultable `source` from `Base`.
@@ -2126,12 +2086,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("TextAction").unwrap();
-        let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = &schema else {
             panic!("expected struct `TextAction`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenStruct::new(name, struct_view);
+        let codegen = CodegenStruct::new(&graph, struct_view);
 
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         let expected: syn::ItemStruct = parse_quote! {
@@ -2187,12 +2146,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("TextAction").unwrap();
-        let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = &schema else {
             panic!("expected struct `TextAction`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenStruct::new(name, struct_view);
+        let codegen = CodegenStruct::new(&graph, struct_view);
 
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         let expected: syn::ItemStruct = parse_quote! {
@@ -2237,12 +2195,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Node").unwrap();
-        let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = &schema else {
             panic!("expected struct `Node`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenStruct::new(name, struct_view);
+        let codegen = CodegenStruct::new(&graph, struct_view);
 
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         // `next` is required and recursive, so it should be boxed.
@@ -2287,12 +2244,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Node").unwrap();
-        let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = &schema else {
             panic!("expected struct `Node`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenStruct::new(name, struct_view);
+        let codegen = CodegenStruct::new(&graph, struct_view);
 
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         // `next` is optional and recursive. The box should be inside `AbsentOr`,
@@ -2341,12 +2297,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Node").unwrap();
-        let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = &schema else {
             panic!("expected struct `Node`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenStruct::new(name, struct_view);
+        let codegen = CodegenStruct::new(&graph, struct_view);
 
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         // `children` is an array of recursive elements, but arrays (`Vec`)
@@ -2393,12 +2348,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Node").unwrap();
-        let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = &schema else {
             panic!("expected struct `Node`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenStruct::new(name, struct_view);
+        let codegen = CodegenStruct::new(&graph, struct_view);
 
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         // `children` is an optional array of recursive elements. Arrays provide
@@ -2458,12 +2412,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Person").unwrap();
-        let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = &schema else {
             panic!("expected struct `Person`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenStruct::new(name, struct_view);
+        let codegen = CodegenStruct::new(&graph, struct_view);
 
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         // Inherited fields from inline `allOf` parents should appear first
@@ -2510,12 +2463,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Config").unwrap();
-        let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = &schema else {
             panic!("expected struct `Config`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenStruct::new(name, struct_view);
+        let codegen = CodegenStruct::new(&graph, struct_view);
 
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         let expected: syn::ItemStruct = parse_quote! {
@@ -2579,12 +2531,11 @@ mod tests {
         let graph = CodegenGraph::new(raw.cook());
 
         let schema = graph.schema("Dog").unwrap();
-        let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = &schema else {
             panic!("expected struct `Dog`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenStruct::new(name, struct_view);
+        let codegen = CodegenStruct::new(&graph, struct_view);
 
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         // Both `kind` and `bark` should be present. After inlining, the
@@ -2637,12 +2588,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Pet").unwrap();
-        let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = &schema else {
             panic!("expected struct `Pet`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenStruct::new(name, struct_view);
+        let codegen = CodegenStruct::new(&graph, struct_view);
 
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         let expected: syn::ItemStruct = parse_quote! {
@@ -2689,12 +2639,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Pet").unwrap();
-        let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = &schema else {
             panic!("expected struct `Pet`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenStruct::new(name, struct_view);
+        let codegen = CodegenStruct::new(&graph, struct_view);
 
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         let expected: syn::ItemStruct = parse_quote! {
@@ -2741,12 +2690,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Pet").unwrap();
-        let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = &schema else {
             panic!("expected struct `Pet`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenStruct::new(name, struct_view);
+        let codegen = CodegenStruct::new(&graph, struct_view);
 
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         let expected: syn::ItemStruct = parse_quote! {
@@ -2795,12 +2743,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Pet").unwrap();
-        let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = &schema else {
             panic!("expected struct `Pet`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenStruct::new(name, struct_view);
+        let codegen = CodegenStruct::new(&graph, struct_view);
 
         // Required nullable enum fields become `Option<T>` without
         // `skip_serializing_if`, since their type is
@@ -2848,12 +2795,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Config").unwrap();
-        let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = &schema else {
             panic!("expected struct `Config`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenStruct::new(name, struct_view);
+        let codegen = CodegenStruct::new(&graph, struct_view);
 
         let actual: syn::ItemStruct = parse_quote!(#codegen);
         let expected: syn::ItemStruct = parse_quote! {
@@ -2906,12 +2852,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Pet").unwrap();
-        let schema @ SchemaTypeView::Struct(_, struct_view) = &schema else {
+        let SchemaTypeView::Struct(_, struct_view) = &schema else {
             panic!("expected struct `Pet`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenStruct::new(name, struct_view);
+        let codegen = CodegenStruct::new(&graph, struct_view);
 
         // Unrepresentable enums become `String` type aliases,
         // so no `skip_serializing_if` is added.

--- a/ploidy-codegen-rust/src/tagged.rs
+++ b/ploidy-codegen-rust/src/tagged.rs
@@ -1,26 +1,24 @@
 use itertools::Itertools;
-use ploidy_core::{
-    codegen::UniqueNames,
-    ir::{TaggedView, View},
-};
+use ploidy_core::ir::{HasTypeId, TaggedView, View};
 use proc_macro2::TokenStream;
 use quote::{ToTokens, TokenStreamExt, quote};
 
-use crate::{CodegenIdentScope, CodegenTypeName};
-
-use super::{derives::ExtraDerive, doc_attrs, naming::CodegenIdentUsage, ref_::CodegenRef};
+use super::{
+    derives::ExtraDerive, doc_attrs, graph::CodegenGraph, graph::IdentMapping,
+    naming::CodegenIdentUsage, ref_::CodegenRef,
+};
 
 /// Generates a tagged union as a Rust enum, with `#[serde(tag = ...)]`
 /// and associated data for each variant.
 #[derive(Clone, Debug)]
 pub struct CodegenTagged<'a> {
-    name: CodegenTypeName<'a>,
+    graph: &'a CodegenGraph<'a>,
     ty: &'a TaggedView<'a, 'a>,
 }
 
 impl<'a> CodegenTagged<'a> {
-    pub fn new(name: CodegenTypeName<'a>, ty: &'a TaggedView<'a, 'a>) -> Self {
-        Self { name, ty }
+    pub fn new(graph: &'a CodegenGraph<'a>, ty: &'a TaggedView<'a, 'a>) -> Self {
+        Self { graph, ty }
     }
 }
 
@@ -34,15 +32,16 @@ impl ToTokens for CodegenTagged<'_> {
             extra_derives.push(ExtraDerive::Hash);
         }
 
-        let unique = UniqueNames::new();
-        let mut scope = CodegenIdentScope::new(&unique);
         let variants = self
             .ty
             .variants()
             .map(|variant| {
                 // Look up the proper Rust type name.
                 let view = variant.ty();
-                let variant_name = CodegenIdentUsage::Variant(&scope.uniquify(variant.name()));
+                let variant_name = CodegenIdentUsage::Variant(
+                    self.graph
+                        .ident(IdentMapping::TaggedVariant(self.ty.id(), variant.name())),
+                );
 
                 // Add `#[serde(alias = ...)]` attributes for multiple
                 // discriminator values that map to the same type.
@@ -67,14 +66,14 @@ impl ToTokens for CodegenTagged<'_> {
                     quote! { #[ploidy(pointer(rename = #primary))] }
                 });
 
-                let rust_type_name = CodegenRef::new(&view);
+                let rust_type_name = CodegenRef::new(self.graph, &view);
                 let v = quote! {
                     #serde_attr
                     #pointer_attr
                     #variant_name(#rust_type_name),
                 };
 
-                let type_name = &self.name;
+                let type_name = CodegenIdentUsage::Type(self.graph.ident(self.ty.id()));
                 let from_impl = quote! {
                     impl ::std::convert::From<#rust_type_name> for #type_name {
                         fn from(value: #rust_type_name) -> Self {
@@ -93,7 +92,7 @@ impl ToTokens for CodegenTagged<'_> {
 
         let vs = variants.iter().map(|(variant, _)| variant);
         let fs = variants.iter().map(|(_, from_impl)| from_impl);
-        let type_name = &self.name;
+        let type_name = CodegenIdentUsage::Type(self.graph.ident(self.ty.id()));
         let main = quote! {
             #doc_attrs
             #[derive(Debug, Clone, PartialEq, #(#extra_derives,)* ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
@@ -122,7 +121,7 @@ mod tests {
     use pretty_assertions::assert_eq;
     use syn::parse_quote;
 
-    use crate::{CodegenGraph, CodegenTypeName};
+    use crate::CodegenGraph;
 
     #[test]
     fn test_tagged_union_serde_tag_attr() {
@@ -160,12 +159,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Pet").unwrap();
-        let schema @ SchemaTypeView::Tagged(_, tagged) = &schema else {
+        let SchemaTypeView::Tagged(_, tagged) = schema else {
             panic!("expected tagged union `Pet`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenTagged::new(name, tagged);
+        let codegen = CodegenTagged::new(&graph, &tagged);
 
         let actual: syn::File = parse_quote!(#codegen);
         let expected: syn::File = parse_quote! {
@@ -230,12 +228,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Pet").unwrap();
-        let schema @ SchemaTypeView::Tagged(_, tagged) = &schema else {
+        let SchemaTypeView::Tagged(_, tagged) = &schema else {
             panic!("expected tagged union `Pet`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenTagged::new(name, tagged);
+        let codegen = CodegenTagged::new(&graph, tagged);
 
         let actual: syn::File = parse_quote!(#codegen);
         let expected: syn::File = parse_quote! {
@@ -295,12 +292,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Pet").unwrap();
-        let schema @ SchemaTypeView::Tagged(_, tagged) = &schema else {
+        let SchemaTypeView::Tagged(_, tagged) = &schema else {
             panic!("expected tagged union `Pet`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenTagged::new(name, tagged);
+        let codegen = CodegenTagged::new(&graph, tagged);
 
         let actual: syn::File = parse_quote!(#codegen);
         let expected: syn::File = parse_quote! {
@@ -358,12 +354,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Pet").unwrap();
-        let schema @ SchemaTypeView::Tagged(_, tagged) = &schema else {
+        let SchemaTypeView::Tagged(_, tagged) = &schema else {
             panic!("expected tagged union `Pet`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenTagged::new(name, tagged);
+        let codegen = CodegenTagged::new(&graph, tagged);
 
         let actual: syn::File = parse_quote!(#codegen);
         let expected: syn::File = parse_quote! {
@@ -426,12 +421,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Pet").unwrap();
-        let schema @ SchemaTypeView::Tagged(_, tagged) = &schema else {
+        let SchemaTypeView::Tagged(_, tagged) = &schema else {
             panic!("expected tagged union `Pet`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenTagged::new(name, tagged);
+        let codegen = CodegenTagged::new(&graph, tagged);
 
         let actual: syn::File = parse_quote!(#codegen);
         let expected: syn::File = parse_quote! {
@@ -506,12 +500,11 @@ mod tests {
         let graph = CodegenGraph::new(raw.cook());
 
         let schema = graph.schema("Pet").unwrap();
-        let schema @ SchemaTypeView::Tagged(_, tagged) = &schema else {
+        let SchemaTypeView::Tagged(_, tagged) = &schema else {
             panic!("expected tagged union `Pet`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenTagged::new(name, tagged);
+        let codegen = CodegenTagged::new(&graph, tagged);
 
         let actual: syn::File = parse_quote!(#codegen);
         let expected: syn::File = parse_quote! {
@@ -563,12 +556,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Pet").unwrap();
-        let schema @ SchemaTypeView::Tagged(_, tagged) = &schema else {
+        let SchemaTypeView::Tagged(_, tagged) = &schema else {
             panic!("expected tagged union `Pet`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenTagged::new(name, tagged);
+        let codegen = CodegenTagged::new(&graph, tagged);
 
         let actual: syn::File = parse_quote!(#codegen);
         let expected: syn::File = parse_quote! {
@@ -638,12 +630,11 @@ mod tests {
         let graph = CodegenGraph::new(raw.cook());
 
         let schema = graph.schema("Pet").unwrap();
-        let schema @ SchemaTypeView::Tagged(_, tagged) = &schema else {
+        let SchemaTypeView::Tagged(_, tagged) = &schema else {
             panic!("expected tagged union `Pet`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let codegen = CodegenTagged::new(name, tagged);
+        let codegen = CodegenTagged::new(&graph, tagged);
 
         let actual: syn::File = parse_quote!(#codegen);
         // `Dog` is inlined, so `Pet::Dog` holds the inline type.

--- a/ploidy-codegen-rust/src/types.rs
+++ b/ploidy-codegen-rust/src/types.rs
@@ -1,13 +1,9 @@
 use itertools::Itertools;
-use ploidy_core::codegen::IntoCode;
+use ploidy_core::{codegen::IntoCode, ir::HasTypeId};
 use proc_macro2::TokenStream;
 use quote::{ToTokens, TokenStreamExt, quote};
 
-use super::{
-    cfg::CfgFeature,
-    graph::CodegenGraph,
-    naming::{CodegenTypeName, CodegenTypeNameSortKey},
-};
+use super::{cfg::CfgFeature, graph::CodegenGraph, naming::CodegenIdentUsage};
 
 /// Generates the `types/mod.rs` module.
 pub struct CodegenTypesModule<'a> {
@@ -23,22 +19,21 @@ impl<'a> CodegenTypesModule<'a> {
 impl ToTokens for CodegenTypesModule<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let mut tys = self.graph.schemas().collect_vec();
-        tys.sort_by(|a, b| {
-            CodegenTypeNameSortKey::for_schema(a).cmp(&CodegenTypeNameSortKey::for_schema(b))
-        });
+        tys.sort_by_key(|s| self.graph.ident(s.id()));
 
-        let mods = tys.iter().map(|ty| {
-            let cfg = CfgFeature::for_schema_type(ty);
-            let mod_name = CodegenTypeName::Schema(ty).into_module_name();
+        let mods = tys.iter().map(|schema| {
+            let cfg = CfgFeature::for_schema_type(self.graph, schema);
+            let mod_name = CodegenIdentUsage::Module(self.graph.ident(schema.id()));
             quote! {
                 #cfg
                 pub mod #mod_name;
             }
         });
-        let uses = tys.iter().map(|ty| {
-            let cfg = CfgFeature::for_schema_type(ty);
-            let ty_name = CodegenTypeName::Schema(ty);
-            let mod_name = ty_name.into_module_name();
+        let uses = tys.iter().map(|schema| {
+            let cfg = CfgFeature::for_schema_type(self.graph, schema);
+            let ident = self.graph.ident(schema.id());
+            let ty_name = CodegenIdentUsage::Type(ident);
+            let mod_name = CodegenIdentUsage::Module(ident);
             quote! {
                 #cfg
                 pub use #mod_name::#ty_name;

--- a/ploidy-codegen-rust/src/untagged.rs
+++ b/ploidy-codegen-rust/src/untagged.rs
@@ -1,53 +1,44 @@
-use ploidy_core::{
-    codegen::UniqueNames,
-    ir::{UntaggedView, View},
-};
+use ploidy_core::ir::{HasTypeId, UntaggedView, View};
 use proc_macro2::TokenStream;
 use quote::{ToTokens, TokenStreamExt, quote};
 
 use super::{
     derives::ExtraDerive,
     doc_attrs,
-    naming::{CodegenIdentRef, CodegenIdentScope, CodegenIdentUsage, CodegenTypeName},
+    graph::{CodegenGraph, IdentMapping},
+    naming::CodegenIdentUsage,
     ref_::CodegenRef,
 };
 
 #[derive(Clone, Debug)]
 pub struct CodegenUntagged<'a> {
-    name: CodegenTypeName<'a>,
+    graph: &'a CodegenGraph<'a>,
     ty: &'a UntaggedView<'a, 'a>,
 }
 
 impl<'a> CodegenUntagged<'a> {
-    pub fn new(name: CodegenTypeName<'a>, ty: &'a UntaggedView<'a, 'a>) -> Self {
-        Self { name, ty }
+    pub fn new(graph: &'a CodegenGraph<'a>, ty: &'a UntaggedView<'a, 'a>) -> Self {
+        Self { graph, ty }
     }
 }
 
 impl ToTokens for CodegenUntagged<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        let unique = UniqueNames::new();
-        let mut scope = CodegenIdentScope::new(&unique);
-        let mut variants = Vec::new();
-
-        for variant in self.ty.variants() {
+        let variants = self.ty.variants().enumerate().map(|(index, variant)| {
+            let variant_name = CodegenIdentUsage::Variant(
+                self.graph
+                    .ident(IdentMapping::UntaggedVariant(self.ty.id(), index)),
+            );
             match variant.ty() {
                 Some(variant) => {
-                    let base = CodegenIdentRef::from_variant_name_hint(variant.hint);
-                    let ident = scope.uniquify_ident(&base);
-                    let variant_name = CodegenIdentUsage::Variant(&ident);
-                    let rust_type = CodegenRef::new(&variant.view);
-                    variants.push(quote! { #variant_name(#rust_type) });
+                    let rust_type = CodegenRef::new(self.graph, &variant.view);
+                    quote! { #variant_name(#rust_type) }
                 }
-                None => {
-                    let ident = scope.uniquify("None");
-                    let variant_name = CodegenIdentUsage::Variant(&ident);
-                    variants.push(quote! { #variant_name });
-                }
+                None => quote! { #variant_name },
             }
-        }
+        });
 
-        let type_name_ident = &self.name;
+        let type_name_ident = CodegenIdentUsage::Type(self.graph.ident(self.ty.id()));
         let doc_attrs = self.ty.description().map(doc_attrs);
 
         let mut extra_derives = vec![];
@@ -107,12 +98,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("StringOrInt").unwrap();
-        let schema @ SchemaTypeView::Untagged(_, untagged_view) = &schema else {
+        let SchemaTypeView::Untagged(_, untagged_view) = &schema else {
             panic!("expected untagged union `StringOrInt`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let untagged = CodegenUntagged::new(name, untagged_view);
+        let untagged = CodegenUntagged::new(&graph, untagged_view);
 
         let actual: syn::ItemEnum = parse_quote!(#untagged);
         let expected: syn::ItemEnum = parse_quote! {
@@ -148,12 +138,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("DateOrUnix").unwrap();
-        let schema @ SchemaTypeView::Untagged(_, untagged_view) = &schema else {
+        let SchemaTypeView::Untagged(_, untagged_view) = &schema else {
             panic!("expected untagged union `DateOrUnix`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let untagged = CodegenUntagged::new(name, untagged_view);
+        let untagged = CodegenUntagged::new(&graph, untagged_view);
 
         let actual: syn::ItemEnum = parse_quote!(#untagged);
         let expected: syn::ItemEnum = parse_quote! {
@@ -200,12 +189,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Animal").unwrap();
-        let schema @ SchemaTypeView::Untagged(_, untagged_view) = &schema else {
+        let SchemaTypeView::Untagged(_, untagged_view) = &schema else {
             panic!("expected untagged union `Animal`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let untagged = CodegenUntagged::new(name, untagged_view);
+        let untagged = CodegenUntagged::new(&graph, untagged_view);
 
         let actual: syn::ItemEnum = parse_quote!(#untagged);
         let expected: syn::ItemEnum = parse_quote! {
@@ -244,12 +232,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("StringOrInt").unwrap();
-        let schema @ SchemaTypeView::Untagged(_, untagged_view) = &schema else {
+        let SchemaTypeView::Untagged(_, untagged_view) = &schema else {
             panic!("expected untagged union `StringOrInt`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let untagged = CodegenUntagged::new(name, untagged_view);
+        let untagged = CodegenUntagged::new(&graph, untagged_view);
 
         let actual: syn::ItemEnum = parse_quote!(#untagged);
         let expected: syn::ItemEnum = parse_quote! {
@@ -288,12 +275,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("StringOrFloat").unwrap();
-        let schema @ SchemaTypeView::Untagged(_, untagged_view) = &schema else {
+        let SchemaTypeView::Untagged(_, untagged_view) = &schema else {
             panic!("expected untagged union `StringOrFloat`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let untagged = CodegenUntagged::new(name, untagged_view);
+        let untagged = CodegenUntagged::new(&graph, untagged_view);
 
         let actual: syn::ItemEnum = parse_quote!(#untagged);
         let expected: syn::ItemEnum = parse_quote! {
@@ -331,12 +317,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("StringOrDouble").unwrap();
-        let schema @ SchemaTypeView::Untagged(_, untagged_view) = &schema else {
+        let SchemaTypeView::Untagged(_, untagged_view) = &schema else {
             panic!("expected untagged union `StringOrDouble`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let untagged = CodegenUntagged::new(name, untagged_view);
+        let untagged = CodegenUntagged::new(&graph, untagged_view);
 
         let actual: syn::ItemEnum = parse_quote!(#untagged);
         let expected: syn::ItemEnum = parse_quote! {
@@ -383,12 +368,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Input").unwrap();
-        let schema @ SchemaTypeView::Untagged(_, untagged_view) = &schema else {
+        let SchemaTypeView::Untagged(_, untagged_view) = &schema else {
             panic!("expected untagged union `Input`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let untagged = CodegenUntagged::new(name, untagged_view);
+        let untagged = CodegenUntagged::new(&graph, untagged_view);
 
         let actual: syn::ItemEnum = parse_quote!(#untagged);
         let expected: syn::ItemEnum = parse_quote! {
@@ -427,12 +411,11 @@ mod tests {
         let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
 
         let schema = graph.schema("Weird").unwrap();
-        let schema @ SchemaTypeView::Untagged(_, untagged_view) = &schema else {
+        let SchemaTypeView::Untagged(_, untagged_view) = &schema else {
             panic!("expected untagged union `Weird`; got `{schema:?}`");
         };
 
-        let name = CodegenTypeName::Schema(schema);
-        let untagged = CodegenUntagged::new(name, untagged_view);
+        let untagged = CodegenUntagged::new(&graph, untagged_view);
 
         let actual: syn::ItemEnum = parse_quote!(#untagged);
         let expected: syn::ItemEnum = parse_quote! {

--- a/ploidy-core/Cargo.toml
+++ b/ploidy-core/Cargo.toml
@@ -28,7 +28,7 @@ prettyplease = { version = "0.2", optional = true }
 proc-macro2 = { version = "1", default-features = false, optional = true }
 quote = { version = "1", default-features = false, optional = true }
 ref-cast = { workspace = true }
-rustc-hash = "2"
+rustc-hash = { workspace = true }
 syn = { version = "2", default-features = false, optional = true }
 thiserror = "2"
 unicase = "2"

--- a/ploidy-core/src/arena.rs
+++ b/ploidy-core/src/arena.rs
@@ -1,3 +1,5 @@
+use std::sync::atomic::AtomicUsize;
+
 use bumpalo::{
     Bump,
     collections::{CollectIn, Vec as BumpVec},
@@ -21,6 +23,12 @@ impl Arena {
     #[inline]
     pub(crate) fn alloc<T: Copy>(&self, value: T) -> &mut T {
         self.0.alloc(value)
+    }
+
+    /// Allocates and returns a mutable reference to an atomic primitive.
+    #[inline]
+    pub(crate) fn alloc_atomic<T: ToAtomic>(&self, value: T) -> &mut T::Atomic {
+        self.0.alloc(value.to_atomic())
     }
 
     /// Copies and returns a mutable reference to a slice.
@@ -57,5 +65,23 @@ impl Arena {
     #[inline]
     pub(crate) fn alloc_str(&self, s: &str) -> &mut str {
         self.0.alloc_str(s)
+    }
+}
+
+// Atomics aren't `Copy`, but are trivially droppable, and so OK to allocate
+// in an arena directly. We can replace this trait with `Atomic<T>` once
+// the `generic_atomic` feature stabilizes.
+pub(crate) trait ToAtomic {
+    type Atomic;
+
+    fn to_atomic(self) -> Self::Atomic;
+}
+
+impl ToAtomic for usize {
+    type Atomic = AtomicUsize;
+
+    #[inline]
+    fn to_atomic(self) -> Self::Atomic {
+        AtomicUsize::new(self)
     }
 }

--- a/ploidy-core/src/codegen/unique.rs
+++ b/ploidy-core/src/codegen/unique.rs
@@ -1,6 +1,7 @@
-use std::{collections::hash_map::Entry, iter::Peekable, str::CharIndices};
+use std::{iter::Peekable, str::CharIndices};
 
-use rustc_hash::FxHashMap;
+use itertools::Itertools;
+use rustc_hash::{FxHashMap, FxHashSet};
 use unicase::UniCase;
 
 use crate::arena::Arena;
@@ -9,7 +10,7 @@ use crate::arena::Arena;
 #[derive(Debug)]
 pub struct UniqueNames<'a> {
     arena: &'a Arena,
-    space: FxHashMap<&'a [UniCase<&'a str>], usize>,
+    space: FxHashMap<&'a [UniCase<&'a str>], FxHashSet<usize>>,
 }
 
 impl<'a> UniqueNames<'a> {
@@ -24,21 +25,16 @@ impl<'a> UniqueNames<'a> {
         arena: &'a Arena,
         reserved: impl IntoIterator<Item = S>,
     ) -> Self {
-        let space = reserved
-            .into_iter()
-            .map(|name| arena.alloc_str(name.as_ref()))
-            .map(|name| arena.alloc_slice(WordSegments::new(name).map(UniCase::new)))
-            .fold(FxHashMap::default(), |mut names, segments| {
-                // Setting the count to 1 automatically filters out duplicates.
-                names.insert(&*segments, 1);
-                names
-            });
-        Self { arena, space }
+        let mut names = Self::new(arena);
+        for name in reserved {
+            names.reserve(name.as_ref());
+        }
+        names
     }
 
-    /// Adds a name to this scope. If the name doesn't exist within this scope
-    /// yet, returns the name as-is; otherwise, returns the name with a
-    /// unique numeric suffix.
+    /// Adds a name to this scope and returns a unique form.
+    ///
+    /// Names without word content use numeric forms starting at `1`.
     ///
     /// # Examples
     ///
@@ -49,50 +45,97 @@ impl<'a> UniqueNames<'a> {
     /// assert_eq!(names.uniquify("HTTPResponse"), "HTTPResponse");
     /// assert_eq!(names.uniquify("HTTP_Response"), "HTTP_Response2");
     /// assert_eq!(names.uniquify("httpResponse"), "httpResponse3");
+    /// assert_eq!(names.uniquify("http_response_2"), "http_response4");
     /// ```
     pub fn uniquify(&mut self, name: &str) -> &'a str {
-        match self.space.entry(self.arena.alloc_slice(
-            WordSegments::new(name).map(|name| UniCase::new(&*self.arena.alloc_str(name))),
-        )) {
-            Entry::Occupied(mut entry) => {
-                let count = entry.get_mut();
-                *count += 1;
-                self.arena.alloc_str(&format!("{name}{count}"))
+        let parsed = ParsedName::parse(name);
+        let segments = self.arena.alloc_slice_exact(
+            parsed
+                .segments()
+                .iter()
+                .map(|(_, segment)| UniCase::new(&*self.arena.alloc_str(segment))),
+        );
+        let occupied = self.space.entry(segments).or_default();
+
+        let suffix = if occupied.insert(parsed.suffix()) {
+            parsed.suffix()
+        } else {
+            let mut suffix = parsed.min_suffix();
+            while !occupied.insert(suffix) {
+                suffix = suffix.checked_add(1).unwrap();
             }
-            Entry::Vacant(entry) => {
-                entry.insert(1);
-                self.arena.alloc_str(name)
+            suffix
+        };
+
+        match parsed {
+            ParsedName::Empty | ParsedName::Numeric(_) => self.arena.alloc_str(&suffix.to_string()),
+            ParsedName::Stemmed { stem, .. } if suffix > 0 => {
+                self.arena.alloc_str(&format!("{stem}{suffix}"))
             }
+            ParsedName::Stemmed { stem, .. } => self.arena.alloc_str(stem),
         }
+    }
+
+    fn reserve(&mut self, name: &str) {
+        let parsed = ParsedName::parse(name);
+        let segments = self.arena.alloc_slice_exact(
+            parsed
+                .segments()
+                .iter()
+                .map(|(_, segment)| UniCase::new(&*self.arena.alloc_str(segment))),
+        );
+        self.space
+            .entry(segments)
+            .or_default()
+            .insert(parsed.reserved_suffix());
     }
 }
 
-/// Segments a string into words, detecting word boundaries for
-/// case transformation.
+/// Segments a string into words and their byte offsets,
+/// detecting word boundaries for case transformations.
 ///
 /// Word boundaries occur on:
 ///
 /// * Non-alphanumeric characters: underscores, hyphens, etc.
 /// * Lowercase-to-uppercase transitions (`httpResponse`).
 /// * Uppercase-to-lowercase after an uppercase run (`XMLHttp`).
-/// * Digit-to-letter transitions (`1099KStatus`, `250g`).
+/// * Letter-to-digit and digit-to-letter transitions (`Response2`, `250g`).
 ///
-/// The digit-to-letter rule is stricter than Heck's segmentation,
-/// to ensure that names like `1099KStatus` and `1099_K_Status` collide.
-/// Without this rule, these cases would produce similar-but-distinct names
-/// differing only in their internal capitalization.
+/// The digit transition rules are stricter than Heck's segmentation,
+/// to ensure that names like (`Response2`, `Response_2`) and
+/// (`1099KStatus`, `1099_K_Status`) collide. Without this rule, these cases
+/// would produce similar-but-distinct names differing only in their
+/// internal capitalization.
 ///
 /// # Examples
 ///
 /// ```
 /// # use itertools::Itertools;
 /// # use ploidy_core::codegen::WordSegments;
-/// assert_eq!(WordSegments::new("HTTPResponse").collect_vec(), vec!["HTTP", "Response"]);
-/// assert_eq!(WordSegments::new("HTTP_Response").collect_vec(), vec!["HTTP", "Response"]);
-/// assert_eq!(WordSegments::new("httpResponse").collect_vec(), vec!["http", "Response"]);
-/// assert_eq!(WordSegments::new("XMLHttpRequest").collect_vec(), vec!["XML", "Http", "Request"]);
-/// assert_eq!(WordSegments::new("1099KStatus").collect_vec(), vec!["1099", "K", "Status"]);
-/// assert_eq!(WordSegments::new("250g").collect_vec(), vec!["250", "g"]);
+/// assert_eq!(
+///     WordSegments::new("HTTPResponse").collect_vec(),
+///     vec![(0, "HTTP"), (4, "Response")]
+/// );
+/// assert_eq!(
+///     WordSegments::new("HTTP_Response").collect_vec(),
+///     vec![(0, "HTTP"), (5, "Response")]
+/// );
+/// assert_eq!(
+///     WordSegments::new("httpResponse").collect_vec(),
+///     vec![(0, "http"), (4, "Response")]
+/// );
+/// assert_eq!(
+///     WordSegments::new("XMLHttpRequest").collect_vec(),
+///     vec![(0, "XML"), (3, "Http"), (7, "Request")]
+/// );
+/// assert_eq!(
+///     WordSegments::new("Response2").collect_vec(),
+///     vec![(0, "Response"), (8, "2")]
+/// );
+/// assert_eq!(
+///     WordSegments::new("250g").collect_vec(),
+///     vec![(0, "250"), (3, "g")]
+/// );
 /// ```
 pub struct WordSegments<'a> {
     input: &'a str,
@@ -114,18 +157,18 @@ impl<'a> WordSegments<'a> {
 }
 
 impl<'a> Iterator for WordSegments<'a> {
-    type Item = &'a str;
+    type Item = (usize, &'a str);
 
     fn next(&mut self) -> Option<Self::Item> {
         while let Some((index, c)) = self.chars.next() {
             if c.is_uppercase() {
                 match self.mode {
-                    WordMode::Boundary => {
+                    WordMode::Boundary | WordMode::Digit => {
                         // Start a new word with this uppercase character.
                         let start = self.current_word_starts_at.replace(index);
                         self.mode = WordMode::Uppercase;
                         if let Some(start) = start {
-                            return Some(&self.input[start..index]);
+                            return Some((start, &self.input[start..index]));
                         }
                     }
                     WordMode::Lowercase => {
@@ -134,7 +177,7 @@ impl<'a> Iterator for WordSegments<'a> {
                         let start = self.current_word_starts_at.replace(index);
                         self.mode = WordMode::Uppercase;
                         if let Some(start) = start {
-                            return Some(&self.input[start..index]);
+                            return Some((start, &self.input[start..index]));
                         }
                     }
                     WordMode::Uppercase => {
@@ -147,19 +190,19 @@ impl<'a> Iterator for WordSegments<'a> {
                             // `XMLHttp` case; start a new word with this uppercase
                             // character (the "H" in "Http").
                             self.current_word_starts_at = Some(index);
-                            return Some(&self.input[start..index]);
+                            return Some((start, &self.input[start..index]));
                         }
                         // (Stay in uppercase mode).
                     }
                 }
             } else if c.is_lowercase() {
                 match self.mode {
-                    WordMode::Boundary => {
+                    WordMode::Boundary | WordMode::Digit => {
                         // Start a new word with this lowercase character.
                         let start = self.current_word_starts_at.replace(index);
                         self.mode = WordMode::Lowercase;
                         if let Some(start) = start {
-                            return Some(&self.input[start..index]);
+                            return Some((start, &self.input[start..index]));
                         }
                     }
                     WordMode::Lowercase | WordMode::Uppercase => {
@@ -170,15 +213,31 @@ impl<'a> Iterator for WordSegments<'a> {
                         self.mode = WordMode::Lowercase;
                     }
                 }
+            } else if c.is_ascii_digit() {
+                match self.mode {
+                    WordMode::Boundary | WordMode::Digit => {
+                        if self.current_word_starts_at.is_none() {
+                            self.current_word_starts_at = Some(index);
+                        }
+                        self.mode = WordMode::Digit;
+                    }
+                    WordMode::Lowercase | WordMode::Uppercase => {
+                        let start = self.current_word_starts_at.replace(index);
+                        self.mode = WordMode::Digit;
+                        if let Some(start) = start {
+                            return Some((start, &self.input[start..index]));
+                        }
+                    }
+                }
             } else if !c.is_alphanumeric() {
                 // Start a new word at this non-alphanumeric character.
                 let start = std::mem::take(&mut self.current_word_starts_at);
                 self.mode = WordMode::Boundary;
                 if let Some(start) = start {
-                    return Some(&self.input[start..index]);
+                    return Some((start, &self.input[start..index]));
                 }
             } else {
-                // Digit or other character: continue the current word.
+                // Other alphanumeric character: continue the current word.
                 if self.current_word_starts_at.is_none() {
                     self.current_word_starts_at = Some(index);
                 }
@@ -186,7 +245,7 @@ impl<'a> Iterator for WordSegments<'a> {
         }
         if let Some(start) = std::mem::take(&mut self.current_word_starts_at) {
             // Trailing word.
-            return Some(&self.input[start..]);
+            return Some((start, &self.input[start..]));
         }
         None
     }
@@ -202,6 +261,80 @@ enum WordMode {
     Lowercase,
     /// Currently in an uppercase segment.
     Uppercase,
+    /// Currently in a digit segment.
+    Digit,
+}
+
+enum ParsedName<'a> {
+    Empty,
+    Numeric(usize),
+    Stemmed {
+        segments: Vec<(usize, &'a str)>,
+        stem: &'a str,
+        suffix: usize,
+    },
+}
+
+impl<'a> ParsedName<'a> {
+    fn parse(name: &'a str) -> Self {
+        let mut segments = WordSegments::new(name).collect_vec();
+        if segments.is_empty() {
+            return Self::Empty;
+        }
+
+        let Some((suffix_start, suffix)) = segments
+            .iter()
+            .last()
+            .and_then(|&(offset, segment)| Some((offset, segment.parse::<usize>().ok()?)))
+        else {
+            return Self::Stemmed {
+                segments,
+                stem: name,
+                suffix: 0,
+            };
+        };
+
+        segments.pop();
+        if segments.is_empty() {
+            return Self::Numeric(suffix);
+        }
+
+        let stem = name[..suffix_start].trim_end_matches(|c: char| !c.is_alphanumeric());
+        Self::Stemmed {
+            segments,
+            stem,
+            suffix,
+        }
+    }
+
+    fn segments(&self) -> &[(usize, &'a str)] {
+        match self {
+            Self::Empty | Self::Numeric(_) => &[],
+            Self::Stemmed { segments, .. } => segments,
+        }
+    }
+
+    fn suffix(&self) -> usize {
+        match self {
+            Self::Empty | Self::Numeric(0) => 1,
+            &(Self::Numeric(suffix) | Self::Stemmed { suffix, .. }) => suffix,
+        }
+    }
+
+    fn reserved_suffix(&self) -> usize {
+        match self {
+            Self::Empty | Self::Numeric(0) => 0,
+            &(Self::Numeric(suffix) | Self::Stemmed { suffix, .. }) => suffix,
+        }
+    }
+
+    fn min_suffix(&self) -> usize {
+        match self {
+            Self::Empty => 1,
+            &Self::Numeric(suffix) => suffix.max(1),
+            &Self::Stemmed { suffix, .. } => suffix.max(2),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -213,11 +346,11 @@ mod tests {
     fn test_segment_camel_case() {
         assert_eq!(
             WordSegments::new("camelCase").collect_vec(),
-            vec!["camel", "Case"]
+            vec![(0, "camel"), (5, "Case")]
         );
         assert_eq!(
             WordSegments::new("httpResponse").collect_vec(),
-            vec!["http", "Response"]
+            vec![(0, "http"), (4, "Response")]
         );
     }
 
@@ -225,11 +358,11 @@ mod tests {
     fn test_segment_pascal_case() {
         assert_eq!(
             WordSegments::new("PascalCase").collect_vec(),
-            vec!["Pascal", "Case"]
+            vec![(0, "Pascal"), (6, "Case")]
         );
         assert_eq!(
             WordSegments::new("HttpResponse").collect_vec(),
-            vec!["Http", "Response"]
+            vec![(0, "Http"), (4, "Response")]
         );
     }
 
@@ -237,11 +370,11 @@ mod tests {
     fn test_segment_snake_case() {
         assert_eq!(
             WordSegments::new("snake_case").collect_vec(),
-            vec!["snake", "case"]
+            vec![(0, "snake"), (6, "case")]
         );
         assert_eq!(
             WordSegments::new("http_response").collect_vec(),
-            vec!["http", "response"]
+            vec![(0, "http"), (5, "response")]
         );
     }
 
@@ -249,11 +382,11 @@ mod tests {
     fn test_segment_screaming_snake() {
         assert_eq!(
             WordSegments::new("SCREAMING_SNAKE").collect_vec(),
-            vec!["SCREAMING", "SNAKE"]
+            vec![(0, "SCREAMING"), (10, "SNAKE")]
         );
         assert_eq!(
             WordSegments::new("HTTP_RESPONSE").collect_vec(),
-            vec!["HTTP", "RESPONSE"]
+            vec![(0, "HTTP"), (5, "RESPONSE")]
         );
     }
 
@@ -261,52 +394,55 @@ mod tests {
     fn test_segment_consecutive_uppercase() {
         assert_eq!(
             WordSegments::new("XMLHttpRequest").collect_vec(),
-            vec!["XML", "Http", "Request"]
+            vec![(0, "XML"), (3, "Http"), (7, "Request")]
         );
         assert_eq!(
             WordSegments::new("HTTPResponse").collect_vec(),
-            vec!["HTTP", "Response"]
+            vec![(0, "HTTP"), (4, "Response")]
         );
         assert_eq!(
             WordSegments::new("HTTP_Response").collect_vec(),
-            vec!["HTTP", "Response"]
+            vec![(0, "HTTP"), (5, "Response")]
         );
-        assert_eq!(WordSegments::new("ALLCAPS").collect_vec(), vec!["ALLCAPS"]);
+        assert_eq!(
+            WordSegments::new("ALLCAPS").collect_vec(),
+            vec![(0, "ALLCAPS")]
+        );
     }
 
     #[test]
     fn test_segment_with_numbers() {
         assert_eq!(
             WordSegments::new("Response2").collect_vec(),
-            vec!["Response2"]
+            vec![(0, "Response"), (8, "2")]
         );
         assert_eq!(
             WordSegments::new("response_2").collect_vec(),
-            vec!["response", "2"]
+            vec![(0, "response"), (9, "2")]
         );
         assert_eq!(
             WordSegments::new("HTTP2Protocol").collect_vec(),
-            vec!["HTTP2", "Protocol"]
+            vec![(0, "HTTP"), (4, "2"), (5, "Protocol")]
         );
         assert_eq!(
             WordSegments::new("OAuth2Token").collect_vec(),
-            vec!["O", "Auth2", "Token"]
+            vec![(0, "O"), (1, "Auth"), (5, "2"), (6, "Token")]
         );
         assert_eq!(
             WordSegments::new("HTTP2XML").collect_vec(),
-            vec!["HTTP2XML"]
+            vec![(0, "HTTP"), (4, "2"), (5, "XML")]
         );
         assert_eq!(
             WordSegments::new("1099KStatus").collect_vec(),
-            vec!["1099", "K", "Status"]
+            vec![(0, "1099"), (4, "K"), (5, "Status")]
         );
         assert_eq!(
             WordSegments::new("123abc").collect_vec(),
-            vec!["123", "abc"]
+            vec![(0, "123"), (3, "abc")]
         );
         assert_eq!(
             WordSegments::new("123ABC").collect_vec(),
-            vec!["123", "ABC"]
+            vec![(0, "123"), (3, "ABC")]
         );
     }
 
@@ -314,19 +450,19 @@ mod tests {
     fn test_segment_empty_and_special() {
         assert!(WordSegments::new("").collect_vec().is_empty());
         assert!(WordSegments::new("___").collect_vec().is_empty());
-        assert_eq!(WordSegments::new("a").collect_vec(), vec!["a"]);
-        assert_eq!(WordSegments::new("A").collect_vec(), vec!["A"]);
+        assert_eq!(WordSegments::new("a").collect_vec(), vec![(0, "a")]);
+        assert_eq!(WordSegments::new("A").collect_vec(), vec![(0, "A")]);
     }
 
     #[test]
     fn test_segment_mixed_separators() {
         assert_eq!(
             WordSegments::new("foo-bar_baz").collect_vec(),
-            vec!["foo", "bar", "baz"]
+            vec![(0, "foo"), (4, "bar"), (8, "baz")]
         );
         assert_eq!(
             WordSegments::new("foo--bar").collect_vec(),
-            vec!["foo", "bar"]
+            vec![(0, "foo"), (5, "bar")]
         );
     }
 
@@ -378,7 +514,11 @@ mod tests {
         let mut names = UniqueNames::new(&arena);
 
         assert_eq!(names.uniquify("Response2"), "Response2");
-        assert_eq!(names.uniquify("response_2"), "response_2");
+        assert_eq!(names.uniquify("response_2"), "response3");
+
+        // `0` becomes the bare stem.
+        assert_eq!(names.uniquify("Response0"), "Response");
+        assert_eq!(names.uniquify("response"), "response4");
 
         // Digit-to-uppercase collisions.
         assert_eq!(names.uniquify("1099KStatus"), "1099KStatus");
@@ -392,13 +532,67 @@ mod tests {
     }
 
     #[test]
-    fn test_with_reserved_underscore() {
+    fn test_deduplication_numeric_suffixes() {
+        let arena = Arena::new();
+        let mut names = UniqueNames::new(&arena);
+
+        assert_eq!(names.uniquify("OAuth2"), "OAuth2");
+        assert_eq!(names.uniquify("OAuth_2"), "OAuth3");
+        assert_eq!(names.uniquify("OAuth"), "OAuth");
+        assert_eq!(names.uniquify("OAuth0"), "OAuth4");
+    }
+
+    #[test]
+    fn test_deduplication_empty_names_start_at_one() {
+        let arena = Arena::new();
+        let mut names = UniqueNames::new(&arena);
+
+        assert_eq!(names.uniquify(""), "1");
+        assert_eq!(names.uniquify("_"), "2");
+        assert_eq!(names.uniquify("---"), "3");
+    }
+
+    #[test]
+    fn test_deduplication_numeric_names_share_empty_stem() {
+        let arena = Arena::new();
+        let mut names = UniqueNames::new(&arena);
+
+        assert_eq!(names.uniquify("2"), "2");
+        assert_eq!(names.uniquify(""), "1");
+        assert_eq!(names.uniquify("2"), "3");
+
+        let arena = Arena::new();
+        let mut names = UniqueNames::new(&arena);
+
+        assert_eq!(names.uniquify("0"), "1");
+        assert_eq!(names.uniquify(""), "2");
+    }
+
+    #[test]
+    fn test_with_reserved_empty_stem_uses_zero_slot() {
+        let arena = Arena::new();
+        let mut names = UniqueNames::with_reserved(&arena, [""]);
+
+        assert_eq!(names.uniquify(""), "1");
+        assert_eq!(names.uniquify(""), "2");
+
+        let arena = Arena::new();
+        let mut names = UniqueNames::with_reserved(&arena, [""]);
+
+        assert_eq!(names.uniquify("0"), "1");
+        assert_eq!(names.uniquify(""), "2");
+
+        let arena = Arena::new();
+        let mut names = UniqueNames::with_reserved(&arena, ["0"]);
+
+        assert_eq!(names.uniquify("0"), "1");
+        assert_eq!(names.uniquify(""), "2");
+
         let arena = Arena::new();
         let mut names = UniqueNames::with_reserved(&arena, ["_"]);
 
-        // `_` is reserved, so the first use gets a suffix.
-        assert_eq!(names.uniquify("_"), "_2");
-        assert_eq!(names.uniquify("_"), "_3");
+        assert_eq!(names.uniquify("_"), "1");
+        assert_eq!(names.uniquify("_"), "2");
     }
 
     #[test]
@@ -406,17 +600,17 @@ mod tests {
         let arena = Arena::new();
         let mut names = UniqueNames::with_reserved(&arena, ["_", "reserved"]);
 
-        assert_eq!(names.uniquify("_"), "_2");
+        assert_eq!(names.uniquify("_"), "1");
         assert_eq!(names.uniquify("reserved"), "reserved2");
         assert_eq!(names.uniquify("other"), "other");
     }
 
     #[test]
-    fn test_with_reserved_empty() {
+    fn test_with_reserved_numeric_suffixes() {
         let arena = Arena::new();
-        let mut names = UniqueNames::with_reserved(&arena, [""]);
+        let mut names = UniqueNames::with_reserved(&arena, ["crate"]);
 
-        assert_eq!(names.uniquify(""), "2");
-        assert_eq!(names.uniquify(""), "3");
+        assert_eq!(names.uniquify("crate"), "crate2");
+        assert_eq!(names.uniquify("crate2"), "crate3");
     }
 }

--- a/ploidy-core/src/codegen/unique.rs
+++ b/ploidy-core/src/codegen/unique.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, collections::hash_map::Entry, iter::Peekable, str::CharIndices};
+use std::{collections::hash_map::Entry, iter::Peekable, str::CharIndices};
 
 use rustc_hash::FxHashMap;
 use unicase::UniCase;
@@ -6,71 +6,21 @@ use unicase::UniCase;
 use crate::arena::Arena;
 
 /// Deduplicates names across case conventions.
-#[derive(Debug, Default)]
-pub struct UniqueNames(Arena);
-
-impl UniqueNames {
-    /// Creates a new arena for deduplicating names.
-    #[inline]
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Creates a new, empty scope that's backed by this arena.
-    ///
-    /// A scope produces names that will never collide with other names
-    /// within the same scope, even when converted to a different case.
-    ///
-    /// This is useful for disambiguating type and property names that are
-    /// distinct in the source spec, but collide when transformed
-    /// to a different case. For example, `HTTP_Response` and `HTTPResponse`
-    /// are distinct, but both become `http_response` in snake case.
-    #[inline]
-    pub fn scope(&self) -> UniqueNamesScope<'_> {
-        UniqueNamesScope::new(&self.0)
-    }
-
-    /// Creates a new scope that's backed by this arena, and that
-    /// reserves the given names.
-    ///
-    /// This is useful for reserving variable names in generated code, or
-    /// reserving placeholder names that would be invalid identifiers
-    /// on their own.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use ploidy_core::codegen::UniqueNames;
-    /// let unique = UniqueNames::new();
-    /// let mut scope = unique.scope_with_reserved(["_"]);
-    /// assert_eq!(scope.uniquify("_"), "_2");
-    /// assert_eq!(scope.uniquify("_"), "_3");
-    /// ```
-    #[inline]
-    pub fn scope_with_reserved<S: AsRef<str>>(
-        &self,
-        reserved: impl IntoIterator<Item = S>,
-    ) -> UniqueNamesScope<'_> {
-        UniqueNamesScope::with_reserved(&self.0, reserved)
-    }
-}
-
-/// A scope for unique names.
 #[derive(Debug)]
-pub struct UniqueNamesScope<'a> {
+pub struct UniqueNames<'a> {
     arena: &'a Arena,
     space: FxHashMap<&'a [UniCase<&'a str>], usize>,
 }
 
-impl<'a> UniqueNamesScope<'a> {
-    fn new(arena: &'a Arena) -> Self {
+impl<'a> UniqueNames<'a> {
+    pub fn new(arena: &'a Arena) -> Self {
         Self {
             arena,
             space: FxHashMap::default(),
         }
     }
 
-    fn with_reserved<S: AsRef<str>>(
+    pub fn with_reserved<S: AsRef<str>>(
         arena: &'a Arena,
         reserved: impl IntoIterator<Item = S>,
     ) -> Self {
@@ -93,25 +43,25 @@ impl<'a> UniqueNamesScope<'a> {
     /// # Examples
     ///
     /// ```
-    /// # use ploidy_core::codegen::UniqueNames;
-    /// let unique = UniqueNames::new();
-    /// let mut scope = unique.scope();
-    /// assert_eq!(scope.uniquify("HTTPResponse"), "HTTPResponse");
-    /// assert_eq!(scope.uniquify("HTTP_Response"), "HTTP_Response2");
-    /// assert_eq!(scope.uniquify("httpResponse"), "httpResponse3");
+    /// # use ploidy_core::{arena::Arena, codegen::UniqueNames};
+    /// let arena = Arena::new();
+    /// let mut names = UniqueNames::new(&arena);
+    /// assert_eq!(names.uniquify("HTTPResponse"), "HTTPResponse");
+    /// assert_eq!(names.uniquify("HTTP_Response"), "HTTP_Response2");
+    /// assert_eq!(names.uniquify("httpResponse"), "httpResponse3");
     /// ```
-    pub fn uniquify<'b>(&mut self, name: &'b str) -> Cow<'b, str> {
+    pub fn uniquify(&mut self, name: &str) -> &'a str {
         match self.space.entry(self.arena.alloc_slice(
             WordSegments::new(name).map(|name| UniCase::new(&*self.arena.alloc_str(name))),
         )) {
             Entry::Occupied(mut entry) => {
                 let count = entry.get_mut();
                 *count += 1;
-                format!("{name}{count}").into()
+                self.arena.alloc_str(&format!("{name}{count}"))
             }
             Entry::Vacant(entry) => {
                 entry.insert(1);
-                name.into()
+                self.arena.alloc_str(name)
             }
         }
     }
@@ -382,91 +332,91 @@ mod tests {
 
     #[test]
     fn test_deduplication_http_response_collision() {
-        let unique = UniqueNames::new();
-        let mut scope = unique.scope();
+        let arena = Arena::new();
+        let mut names = UniqueNames::new(&arena);
 
-        assert_eq!(scope.uniquify("HTTPResponse"), "HTTPResponse");
-        assert_eq!(scope.uniquify("HTTP_Response"), "HTTP_Response2");
-        assert_eq!(scope.uniquify("httpResponse"), "httpResponse3");
-        assert_eq!(scope.uniquify("http_response"), "http_response4");
+        assert_eq!(names.uniquify("HTTPResponse"), "HTTPResponse");
+        assert_eq!(names.uniquify("HTTP_Response"), "HTTP_Response2");
+        assert_eq!(names.uniquify("httpResponse"), "httpResponse3");
+        assert_eq!(names.uniquify("http_response"), "http_response4");
         // `HTTPRESPONSE` isn't a collision; it's a single word.
-        assert_eq!(scope.uniquify("HTTPRESPONSE"), "HTTPRESPONSE");
+        assert_eq!(names.uniquify("HTTPRESPONSE"), "HTTPRESPONSE");
     }
 
     #[test]
     fn test_deduplication_xml_http_request() {
-        let unique = UniqueNames::new();
-        let mut scope = unique.scope();
+        let arena = Arena::new();
+        let mut names = UniqueNames::new(&arena);
 
-        assert_eq!(scope.uniquify("XMLHttpRequest"), "XMLHttpRequest");
-        assert_eq!(scope.uniquify("xml_http_request"), "xml_http_request2");
-        assert_eq!(scope.uniquify("XmlHttpRequest"), "XmlHttpRequest3");
+        assert_eq!(names.uniquify("XMLHttpRequest"), "XMLHttpRequest");
+        assert_eq!(names.uniquify("xml_http_request"), "xml_http_request2");
+        assert_eq!(names.uniquify("XmlHttpRequest"), "XmlHttpRequest3");
     }
 
     #[test]
     fn test_deduplication_preserves_original_casing() {
-        let unique = UniqueNames::new();
-        let mut scope = unique.scope();
+        let arena = Arena::new();
+        let mut names = UniqueNames::new(&arena);
 
-        assert_eq!(scope.uniquify("HTTP_Response"), "HTTP_Response");
-        assert_eq!(scope.uniquify("httpResponse"), "httpResponse2");
+        assert_eq!(names.uniquify("HTTP_Response"), "HTTP_Response");
+        assert_eq!(names.uniquify("httpResponse"), "httpResponse2");
     }
 
     #[test]
     fn test_deduplication_same_prefix() {
-        let unique = UniqueNames::new();
-        let mut scope = unique.scope();
+        let arena = Arena::new();
+        let mut names = UniqueNames::new(&arena);
 
-        assert_eq!(scope.uniquify("HttpRequest"), "HttpRequest");
-        assert_eq!(scope.uniquify("HttpResponse"), "HttpResponse");
-        assert_eq!(scope.uniquify("HttpError"), "HttpError");
+        assert_eq!(names.uniquify("HttpRequest"), "HttpRequest");
+        assert_eq!(names.uniquify("HttpResponse"), "HttpResponse");
+        assert_eq!(names.uniquify("HttpError"), "HttpError");
     }
 
     #[test]
     fn test_deduplication_with_numbers() {
-        let unique = UniqueNames::new();
-        let mut scope = unique.scope();
+        let arena = Arena::new();
+        let mut names = UniqueNames::new(&arena);
 
-        assert_eq!(scope.uniquify("Response2"), "Response2");
-        assert_eq!(scope.uniquify("response_2"), "response_2");
+        assert_eq!(names.uniquify("Response2"), "Response2");
+        assert_eq!(names.uniquify("response_2"), "response_2");
 
         // Digit-to-uppercase collisions.
-        assert_eq!(scope.uniquify("1099KStatus"), "1099KStatus");
-        assert_eq!(scope.uniquify("1099K_Status"), "1099K_Status2");
-        assert_eq!(scope.uniquify("1099KStatus"), "1099KStatus3");
-        assert_eq!(scope.uniquify("1099_K_Status"), "1099_K_Status4");
+        assert_eq!(names.uniquify("1099KStatus"), "1099KStatus");
+        assert_eq!(names.uniquify("1099K_Status"), "1099K_Status2");
+        assert_eq!(names.uniquify("1099KStatus"), "1099KStatus3");
+        assert_eq!(names.uniquify("1099_K_Status"), "1099_K_Status4");
 
         // Digit-to-lowercase collisions.
-        assert_eq!(scope.uniquify("123abc"), "123abc");
-        assert_eq!(scope.uniquify("123_abc"), "123_abc2");
+        assert_eq!(names.uniquify("123abc"), "123abc");
+        assert_eq!(names.uniquify("123_abc"), "123_abc2");
     }
 
     #[test]
     fn test_with_reserved_underscore() {
-        let unique = UniqueNames::new();
-        let mut scope = unique.scope_with_reserved(["_"]);
+        let arena = Arena::new();
+        let mut names = UniqueNames::with_reserved(&arena, ["_"]);
 
         // `_` is reserved, so the first use gets a suffix.
-        assert_eq!(scope.uniquify("_"), "_2");
-        assert_eq!(scope.uniquify("_"), "_3");
+        assert_eq!(names.uniquify("_"), "_2");
+        assert_eq!(names.uniquify("_"), "_3");
     }
 
     #[test]
     fn test_with_reserved_multiple() {
-        let unique = UniqueNames::new();
-        let mut scope = unique.scope_with_reserved(["_", "reserved"]);
+        let arena = Arena::new();
+        let mut names = UniqueNames::with_reserved(&arena, ["_", "reserved"]);
 
-        assert_eq!(scope.uniquify("_"), "_2");
-        assert_eq!(scope.uniquify("reserved"), "reserved2");
-        assert_eq!(scope.uniquify("other"), "other");
+        assert_eq!(names.uniquify("_"), "_2");
+        assert_eq!(names.uniquify("reserved"), "reserved2");
+        assert_eq!(names.uniquify("other"), "other");
     }
 
     #[test]
     fn test_with_reserved_empty() {
-        let unique = UniqueNames::new();
-        let mut scope = unique.scope_with_reserved([""]);
+        let arena = Arena::new();
+        let mut names = UniqueNames::with_reserved(&arena, [""]);
 
-        assert_eq!(scope.uniquify(""), "2");
-        assert_eq!(scope.uniquify(""), "3");
+        assert_eq!(names.uniquify(""), "2");
+        assert_eq!(names.uniquify(""), "3");
     }
 }

--- a/ploidy-core/src/ir/graph.rs
+++ b/ploidy-core/src/ir/graph.rs
@@ -1,5 +1,5 @@
 use std::{
-    any::{Any, TypeId},
+    any::{Any, TypeId as StdTypeId},
     collections::VecDeque,
     fmt::Debug,
 };
@@ -12,31 +12,27 @@ use petgraph::{
     adj::UnweightedList,
     algo::{TarjanScc, tred},
     data::Build,
-    graph::{DiGraph, NodeIndex},
+    graph::{DiGraph, EdgeIndex, NodeIndex},
     stable_graph::StableDiGraph,
     visit::{
-        DfsPostOrder, EdgeFiltered, EdgeRef, IntoNeighbors, IntoNeighborsDirected,
-        IntoNodeIdentifiers, NodeCount, NodeIndexable,
+        DfsPostOrder, EdgeFiltered, EdgeRef, GraphRef, IntoEdges, IntoNeighbors,
+        IntoNeighborsDirected, IntoNodeIdentifiers, NodeCount, NodeIndexable, VisitMap, Visitable,
     },
 };
 use rustc_hash::{FxBuildHasher, FxHashMap};
 
-use crate::{
-    arena::Arena,
-    ir::{SchemaTypeInfo, UntaggedVariantMeta},
-    parse::Info,
-};
+use crate::{arena::Arena, ir::TypeView, parse::Info};
 
 use super::{
     spec::{ResolvedSpecType, Spec},
     types::{
         FieldMeta, GraphContainer, GraphInlineType, GraphOperation, GraphSchemaType, GraphStruct,
-        GraphTagged, GraphType, InlineTypePath, InlineTypePathRoot, InlineTypePathSegment,
+        GraphTagged, GraphType, InlineTypeId, InlineTypeIds, InlineTypePathRoot, OperationUsage,
         PrimitiveType, SpecInlineType, SpecSchemaType, SpecType, SpecUntaggedVariant,
-        StructFieldName, TaggedVariantMeta, VariantMeta,
+        StructFieldName, TaggedVariantMeta, UntaggedVariantMeta, VariantMeta,
         shape::{Operation, Parameter, ParameterInfo, Request, Response},
     },
-    views::{operation::OperationView, primitive::PrimitiveView, schema::SchemaTypeView},
+    views::{TypeId, operation::OperationView, primitive::PrimitiveView, schema::SchemaTypeView},
 };
 
 /// The mutable, sparse graph used for transformations.
@@ -62,6 +58,7 @@ pub struct RawGraph<'a> {
     graph: RawDiGraph<'a>,
     schemas: FxHashMap<&'a str, NodeIndex<usize>>,
     ops: &'a [&'a GraphOperation<'a>],
+    ids: InlineTypeIds<'a>,
 }
 
 impl<'a> RawGraph<'a> {
@@ -181,6 +178,7 @@ impl<'a> RawGraph<'a> {
             graph,
             schemas,
             ops,
+            ids: spec.ids,
         }
     }
 
@@ -216,17 +214,10 @@ impl<'a> RawGraph<'a> {
         for InlinableVariant { tagged, variant } in inlinables {
             // Duplicate the variant struct as an inline type,
             // with its original metadata.
+            let id = self.ids.next();
             let index = self
                 .graph
-                .add_node(GraphType::Inline(GraphInlineType::Struct(
-                    InlineTypePath {
-                        root: InlineTypePathRoot::Type(tagged.info.name),
-                        segments: self.arena.alloc_slice_copy(&[
-                            InlineTypePathSegment::TaggedVariant(variant.info.name),
-                        ]),
-                    },
-                    variant.ty,
-                )));
+                .add_node(GraphType::Inline(GraphInlineType::Struct(id, variant.ty)));
 
             // Create shadow edges to the original variant struct's fields.
             // These serve two purposes:
@@ -329,9 +320,7 @@ impl<'a> RawGraph<'a> {
         self.graph
             .node_indices()
             .filter_map(|index| match self.graph[index] {
-                GraphType::Schema(GraphSchemaType::Tagged(info, ty)) => {
-                    Some(Node { index, info, ty })
-                }
+                GraphType::Schema(GraphSchemaType::Tagged(_, ty)) => Some(Node { index, ty }),
                 _ => None,
             })
             .flat_map(move |tagged| {
@@ -339,9 +328,9 @@ impl<'a> RawGraph<'a> {
                     .edges_directed(tagged.index, Direction::Outgoing)
                     .filter(|e| matches!(e.weight(), GraphEdge::Variant(_)))
                     .filter_map(move |e| match self.graph[e.target()] {
-                        GraphType::Schema(GraphSchemaType::Struct(info, ty)) => {
+                        GraphType::Schema(GraphSchemaType::Struct(_, ty)) => {
                             let index = e.target();
-                            Some((tagged, Node { index, info, ty }))
+                            Some((tagged, Node { index, ty }))
                         }
                         _ => None,
                     })
@@ -363,8 +352,8 @@ impl<'a> RawGraph<'a> {
                     .graph
                     .neighbors_directed(variant.index, Direction::Incoming)
                     .find_map(|index| match self.graph[index] {
-                        GraphType::Schema(GraphSchemaType::Tagged(info, ty)) => {
-                            Some(Node { index, info, ty })
+                        GraphType::Schema(GraphSchemaType::Tagged(_, ty)) => {
+                            Some(Node { index, ty })
                         }
                         _ => None,
                     })?;
@@ -437,6 +426,7 @@ impl<'a> RawGraph<'a> {
 /// code generation.
 #[derive(Debug)]
 pub struct CookedGraph<'a> {
+    arena: &'a Arena,
     pub(super) graph: CookedDiGraph<'a>,
     info: &'a Info,
     schemas: FxHashMap<&'a str, NodeIndex<usize>>,
@@ -513,9 +503,10 @@ impl<'a> CookedGraph<'a> {
             })
         }));
 
-        let metadata = MetadataBuilder::new(&graph, ops).build();
+        let metadata = MetadataBuilder::new(raw.arena, &graph, ops).build();
 
         Self {
+            arena: raw.arena,
             graph,
             info: raw.spec.info,
             schemas: raw
@@ -526,6 +517,12 @@ impl<'a> CookedGraph<'a> {
             ops,
             metadata,
         }
+    }
+
+    /// Returns this graph's arena.
+    #[inline]
+    pub fn arena(&self) -> &'a Arena {
+        self.arena
     }
 
     /// Returns [`Info`] from the [`Document`][crate::parse::Document]
@@ -555,6 +552,12 @@ impl<'a> CookedGraph<'a> {
                 GraphType::Schema(ty) => Some(SchemaTypeView::new(self, index, ty)),
                 _ => None,
             })
+    }
+
+    /// Looks up and returns a type view by its identifier.
+    #[inline]
+    pub fn view(&self, id: TypeId) -> TypeView<'_, 'a> {
+        TypeView::new(self, id.0)
     }
 
     /// Returns an iterator over all primitive type nodes in this graph.
@@ -627,9 +630,9 @@ impl<'a> CookedGraph<'a> {
 /// A variant that should be inlined into its tagged union.
 struct InlinableVariant<'a> {
     /// The tagged union that owns this variant.
-    tagged: Node<'a, GraphTagged<'a>>,
+    tagged: Node<GraphTagged<'a>>,
     /// The original variant struct node.
-    variant: Node<'a, GraphStruct<'a>>,
+    variant: Node<GraphStruct<'a>>,
 }
 
 /// An edge between two types in the type graph.
@@ -674,9 +677,8 @@ pub struct OutgoingEdge<T> {
 }
 
 #[derive(Clone, Copy)]
-struct Node<'a, Ty> {
+struct Node<Ty> {
     index: NodeIndex<usize>,
-    info: SchemaTypeInfo<'a>,
     ty: Ty,
 }
 
@@ -695,6 +697,8 @@ pub(super) struct CookedGraphMetadata<'a> {
     pub used_by: Vec<Vec<GraphOperation<'a>>>,
     /// Maps each operation to the types that it uses.
     pub uses: FxHashMap<GraphOperation<'a>, FixedBitSet>,
+    /// Maps each inline type to its canonical path through the graph.
+    pub paths: FxHashMap<InlineTypeId, InlineTypePath<'a>>,
     /// Opaque extended data for each type.
     pub extensions: Vec<AtomicRefCell<ExtensionMap>>,
 }
@@ -728,7 +732,15 @@ struct Operations<'a> {
     pub used_by: Vec<Vec<GraphOperation<'a>>>,
 }
 
+/// A canonical path through the graph to an inline type.
+#[derive(Clone, Copy, Debug)]
+pub(super) struct InlineTypePath<'a> {
+    pub root: InlineTypePathRoot<'a, NodeIndex<usize>, &'a str>,
+    pub edges: &'a [EdgeIndex<usize>],
+}
+
 struct MetadataBuilder<'graph, 'a> {
+    arena: &'a Arena,
     graph: &'graph CookedDiGraph<'a>,
     ops: &'graph [&'graph GraphOperation<'a>],
     /// The full transitive closure of each type's dependencies.
@@ -736,8 +748,13 @@ struct MetadataBuilder<'graph, 'a> {
 }
 
 impl<'graph, 'a> MetadataBuilder<'graph, 'a> {
-    fn new(graph: &'graph CookedDiGraph<'a>, ops: &'graph [&'graph GraphOperation<'a>]) -> Self {
+    fn new(
+        arena: &'a Arena,
+        graph: &'graph CookedDiGraph<'a>,
+        ops: &'graph [&'graph GraphOperation<'a>],
+    ) -> Self {
         Self {
+            arena,
             graph,
             ops,
             closure: Closure::new(graph),
@@ -751,6 +768,7 @@ impl<'graph, 'a> MetadataBuilder<'graph, 'a> {
             defaultable,
         } = self.hash_default();
         let box_sccs = self.box_sccs();
+        let paths = self.paths();
         CookedGraphMetadata {
             closure: self.closure,
             box_sccs,
@@ -758,6 +776,7 @@ impl<'graph, 'a> MetadataBuilder<'graph, 'a> {
             defaultable,
             used_by: operations.used_by,
             uses: operations.uses,
+            paths,
             // `AtomicRefCell` doesn't implement `Clone`,
             // so we use this idiom instead of `vec!`.
             extensions: std::iter::repeat_with(AtomicRefCell::default)
@@ -790,6 +809,119 @@ impl<'graph, 'a> MetadataBuilder<'graph, 'a> {
         }
 
         operations
+    }
+
+    /// Precomputes canonical paths for all inline type nodes.
+    fn paths(&self) -> FxHashMap<InlineTypeId, InlineTypePath<'a>> {
+        #[derive(Clone)]
+        struct PartialPath<'a> {
+            root: InlineTypePathRoot<'a, NodeIndex<usize>, &'a str>,
+            edges: Vec<EdgeIndex<usize>>,
+        }
+
+        let filtered = EdgeFiltered::from_fn(self.graph, |e| {
+            !e.weight().shadow() && matches!(self.graph[e.target()], GraphType::Inline(_))
+        });
+
+        let mut by_node = FxHashMap::default();
+        let mut bfs = EdgeBfs::new(&filtered);
+
+        // Expand paths for each named schema root.
+        for index in self.graph.node_indices() {
+            if matches!(self.graph[index], GraphType::Schema(_)) && bfs.discover(index) {
+                by_node.insert(
+                    index,
+                    PartialPath {
+                        root: InlineTypePathRoot::Schema(index),
+                        edges: vec![],
+                    },
+                );
+            }
+            while let Some(edge) = bfs.next() {
+                let parent = &by_node[&edge.source()];
+                let mut child = parent.clone();
+                child.edges.push(edge.id());
+                by_node.insert(edge.target(), child);
+            }
+        }
+
+        // Expand paths for each operation: operations aren't part of the graph;
+        // their parameter, request, and response types are the roots.
+        for op in self.ops {
+            for param in op.params {
+                let (usage, info) = match param {
+                    Parameter::Path(info) => (OperationUsage::Path(info.name), info),
+                    Parameter::Query(info) => (OperationUsage::Query(info.name), info),
+                };
+                if matches!(self.graph[info.ty], GraphType::Inline(_)) && bfs.discover(info.ty) {
+                    by_node.insert(
+                        info.ty,
+                        PartialPath {
+                            root: InlineTypePathRoot::Operation {
+                                id: op.id,
+                                resource: op.resource,
+                                usage,
+                            },
+                            edges: vec![],
+                        },
+                    );
+                }
+            }
+            if let Some(Request::Json(index)) = op.request
+                && matches!(self.graph[index], GraphType::Inline(_))
+                && bfs.discover(index)
+            {
+                by_node.insert(
+                    index,
+                    PartialPath {
+                        root: InlineTypePathRoot::Operation {
+                            id: op.id,
+                            resource: op.resource,
+                            usage: OperationUsage::Request,
+                        },
+                        edges: vec![],
+                    },
+                );
+            }
+            if let Some(Response::Json(index)) = op.response
+                && matches!(self.graph[index], GraphType::Inline(_))
+                && bfs.discover(index)
+            {
+                by_node.insert(
+                    index,
+                    PartialPath {
+                        root: InlineTypePathRoot::Operation {
+                            id: op.id,
+                            resource: op.resource,
+                            usage: OperationUsage::Response,
+                        },
+                        edges: vec![],
+                    },
+                );
+            }
+            while let Some(edge) = bfs.next() {
+                let parent = &by_node[&edge.source()];
+                let mut child = parent.clone();
+                child.edges.push(edge.id());
+                by_node.insert(edge.target(), child);
+            }
+        }
+
+        by_node
+            .into_iter()
+            .filter_map(
+                |(index, PartialPath { root, edges })| match self.graph[index] {
+                    GraphType::Inline(ty) => Some((
+                        ty.id(),
+                        InlineTypePath {
+                            root,
+                            edges: self.arena.alloc_slice(edges),
+                        },
+                    )),
+                    _ => None,
+                },
+            )
+            .collect()
     }
 
     fn box_sccs(&self) -> Vec<usize> {
@@ -1064,7 +1196,7 @@ impl<'a> Iterator for SpecTypeVisitor<'a> {
 }
 
 /// A map that can store one value for each type.
-pub(super) type ExtensionMap = FxHashMap<TypeId, Box<dyn Extension>>;
+pub(super) type ExtensionMap = FxHashMap<StdTypeId, Box<dyn Extension>>;
 
 pub trait Extension: Any + Send + Sync {
     fn into_inner(self: Box<Self>) -> Box<dyn Any>;
@@ -1262,6 +1394,72 @@ impl<N, G> Closable<N> for G where
         + IntoNeighborsDirected<NodeId = N>
         + NodeIndexable<NodeId = N>
 {
+}
+
+/// A breadth-first search that yields discovery edges instead of nodes.
+///
+/// A standard [`Bfs`] yields each node as it's dequeued. This variant yields
+/// the edge that first discovered each target, which is the primitive we need
+/// to build inline type paths.
+///
+/// [`Bfs`]: petgraph::visit::Bfs
+struct EdgeBfs<G, N, VM> {
+    graph: G,
+    queue: VecDeque<N>,
+    discovered: VM,
+}
+
+impl<G, N, VM> EdgeBfs<G, N, VM>
+where
+    N: Copy,
+    VM: VisitMap<N>,
+{
+    /// Creates an empty traversal for the given graph.
+    fn new(graph: G) -> Self
+    where
+        G: GraphRef + Visitable<NodeId = N, Map = VM>,
+    {
+        let discovered = graph.visit_map();
+        Self {
+            graph,
+            queue: VecDeque::new(),
+            discovered,
+        }
+    }
+
+    /// Marks `node` as discovered and enqueues it for expansion.
+    /// Returns `true` if the node was newly discovered.
+    fn discover(&mut self, node: N) -> bool {
+        if self.discovered.visit(node) {
+            self.queue.push_back(node);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Returns the next edge whose target has not been discovered.
+    ///
+    /// The traversal keeps the source node at the front of the queue until
+    /// the targets of all its outgoing edges have been discovered. Each
+    /// returned edge marks its target as discovered and enqueues it for
+    /// later expansion.
+    fn next(&mut self) -> Option<G::EdgeRef>
+    where
+        G: IntoEdges<NodeId = N>,
+    {
+        loop {
+            let &source = self.queue.front()?;
+            for edge in self.graph.edges(source) {
+                let target = edge.target();
+                if self.discovered.visit(target) {
+                    self.queue.push_back(target);
+                    return Some(edge);
+                }
+            }
+            self.queue.pop_front();
+        }
+    }
 }
 
 #[cfg(test)]

--- a/ploidy-core/src/ir/mod.rs
+++ b/ploidy-core/src/ir/mod.rs
@@ -35,6 +35,7 @@ pub use spec::Spec;
 pub use types::*;
 
 pub use views::{
-    ExtendableView, View, any::*, container::*, enum_::*, inline::*, ir::*, operation::*,
-    primitive::*, schema::*, struct_::*, tagged::*, untagged::*,
+    ExtendableView, HasResource, HasTypeId, TypeId, View, any::*, container::*, enum_::*,
+    inline::*, ir::*, operation::*, path::*, primitive::*, schema::*, struct_::*, tagged::*,
+    untagged::*,
 };

--- a/ploidy-core/src/ir/spec.rs
+++ b/ploidy-core/src/ir/spec.rs
@@ -4,6 +4,7 @@ use rustc_hash::FxHashSet;
 
 use crate::{
     arena::Arena,
+    ir::OperationId,
     parse::{
         self, Document, Info, Method, Operation, Parameter, ParameterLocation,
         ParameterStyle as ParsedParameterStyle, RefOrParameter, RefOrRequestBody, RefOrResponse,
@@ -14,12 +15,11 @@ use crate::{
 
 use super::{
     error::IrError,
-    transform::transform,
+    transform::{TransformContext, TypeInfo, transform_with_context},
     types::{
-        InlineTypePath, InlineTypePathRoot, InlineTypePathSegment,
-        ParameterStyle as IrParameterStyle, SchemaTypeInfo, SpecInlineType, SpecOperation,
-        SpecParameter, SpecParameterInfo, SpecRequest, SpecResponse, SpecSchemaType, SpecType,
-        TypeInfo,
+        InlineTypeIds, ParameterStyle as IrParameterStyle, SchemaTypeInfo, SpecInlineType,
+        SpecOperation, SpecParameter, SpecParameterInfo, SpecRequest, SpecResponse, SpecSchemaType,
+        SpecType,
     },
 };
 
@@ -38,6 +38,8 @@ pub struct Spec<'a> {
     pub operations: Vec<SpecOperation<'a>>,
     /// Named schemas from `components/schemas`, keyed by name.
     pub schemas: IndexMap<&'a str, SpecType<'a>>,
+    /// Allocates inline type IDs.
+    pub(crate) ids: InlineTypeIds<'a>,
 }
 
 impl<'a> Spec<'a> {
@@ -47,14 +49,16 @@ impl<'a> Spec<'a> {
     /// long-lived data in the `arena`. Returns an error if the document is
     /// malformed.
     pub fn from_doc(arena: &'a Arena, doc: &'a Document) -> Result<Self, IrError> {
+        let ids = InlineTypeIds::new(arena);
+        let context = TransformContext::new(arena, doc, ids);
+
         let schemas = match &doc.components {
             Some(components) => components
                 .schemas
                 .iter()
                 .map(|(name, schema)| {
-                    let ty = transform(
-                        arena,
-                        doc,
+                    let ty = transform_with_context(
+                        &context,
                         TypeInfo::Schema(SchemaTypeInfo {
                             name,
                             resource: schema.extension("x-resourceId"),
@@ -150,28 +154,9 @@ impl<'a> Spec<'a> {
                         Source::Declared(param) => {
                             let ty: &_ = match &param.schema {
                                 Some(RefOrSchema::Ref(r)) => arena.alloc(SpecType::Ref(r)),
-                                Some(RefOrSchema::Inline(schema)) => arena.alloc(transform(
-                                    arena,
-                                    doc,
-                                    InlineTypePath {
-                                        root: InlineTypePathRoot::Resource(resource),
-                                        segments: arena.alloc_slice_copy(&[
-                                            InlineTypePathSegment::Operation(id),
-                                            InlineTypePathSegment::Parameter(param.name.as_str()),
-                                        ]),
-                                    },
-                                    schema,
-                                )),
-                                None => arena.alloc(
-                                    SpecInlineType::Any(InlineTypePath {
-                                        root: InlineTypePathRoot::Resource(resource),
-                                        segments: arena.alloc_slice_copy(&[
-                                            InlineTypePathSegment::Operation(id),
-                                            InlineTypePathSegment::Parameter(param.name.as_str()),
-                                        ]),
-                                    })
-                                    .into(),
-                                ),
+                                Some(RefOrSchema::Inline(schema)) => arena
+                                    .alloc(transform_with_context(&context, ids.next(), schema)),
+                                None => arena.alloc(SpecInlineType::Any(ids.next()).into()),
                             };
                             let style = match (param.style, param.explode) {
                                 (Some(ParsedParameterStyle::DeepObject), Some(true) | None) => {
@@ -207,16 +192,7 @@ impl<'a> Spec<'a> {
                             })
                         }
                         Source::Synthesized(name) => {
-                            let ty: &_ = arena.alloc(
-                                SpecInlineType::Any(InlineTypePath {
-                                    root: InlineTypePathRoot::Resource(resource),
-                                    segments: arena.alloc_slice_copy(&[
-                                        InlineTypePathSegment::Operation(id),
-                                        InlineTypePathSegment::Parameter(name),
-                                    ]),
-                                })
-                                .into(),
-                            );
+                            let ty: &_ = arena.alloc(SpecInlineType::Any(ids.next()).into());
                             Some(SpecParameter::Path(SpecParameterInfo {
                                 name,
                                 ty,
@@ -261,32 +237,12 @@ impl<'a> Spec<'a> {
                         RequestContent::Json(RefOrSchema::Ref(r)) => {
                             SpecRequest::Json(arena.alloc(SpecType::Ref(r)))
                         }
-                        RequestContent::Json(RefOrSchema::Inline(schema)) => {
-                            SpecRequest::Json(arena.alloc(transform(
-                                arena,
-                                doc,
-                                InlineTypePath {
-                                    root: InlineTypePathRoot::Resource(resource),
-                                    segments: arena.alloc_slice_copy(&[
-                                        InlineTypePathSegment::Operation(id),
-                                        InlineTypePathSegment::Request,
-                                    ]),
-                                },
-                                schema,
-                            )))
-                        }
-                        RequestContent::Any => SpecRequest::Json(
-                            arena.alloc(
-                                SpecInlineType::Any(InlineTypePath {
-                                    root: InlineTypePathRoot::Resource(resource),
-                                    segments: arena.alloc_slice_copy(&[
-                                        InlineTypePathSegment::Operation(id),
-                                        InlineTypePathSegment::Request,
-                                    ]),
-                                })
-                                .into(),
-                            ),
+                        RequestContent::Json(RefOrSchema::Inline(schema)) => SpecRequest::Json(
+                            arena.alloc(transform_with_context(&context, ids.next(), schema)),
                         ),
+                        RequestContent::Any => {
+                            SpecRequest::Json(arena.alloc(SpecInlineType::Any(ids.next()).into()))
+                        }
                     });
 
                 let response = {
@@ -333,37 +289,21 @@ impl<'a> Spec<'a> {
                                 SpecResponse::Json(arena.alloc(SpecType::Ref(r)))
                             }
                             ResponseContent::Json(RefOrSchema::Inline(schema)) => {
-                                SpecResponse::Json(arena.alloc(transform(
-                                    arena,
-                                    doc,
-                                    InlineTypePath {
-                                        root: InlineTypePathRoot::Resource(resource),
-                                        segments: arena.alloc_slice_copy(&[
-                                            InlineTypePathSegment::Operation(id),
-                                            InlineTypePathSegment::Response,
-                                        ]),
-                                    },
+                                SpecResponse::Json(arena.alloc(transform_with_context(
+                                    &context,
+                                    ids.next(),
                                     schema,
                                 )))
                             }
                             ResponseContent::Any => SpecResponse::Json(
-                                arena.alloc(
-                                    SpecInlineType::Any(InlineTypePath {
-                                        root: InlineTypePathRoot::Resource(resource),
-                                        segments: arena.alloc_slice_copy(&[
-                                            InlineTypePathSegment::Operation(id),
-                                            InlineTypePathSegment::Response,
-                                        ]),
-                                    })
-                                    .into(),
-                                ),
+                                arena.alloc(SpecInlineType::Any(ids.next()).into()),
                             ),
                         })
                 };
 
                 Ok(SpecOperation {
                     resource,
-                    id,
+                    id: OperationId::new(id),
                     method: item.method,
                     path: item.path,
                     description: item.op.description.as_deref(),
@@ -379,6 +319,7 @@ impl<'a> Spec<'a> {
             info: &doc.info,
             operations,
             schemas,
+            ids,
         })
     }
 

--- a/ploidy-core/src/ir/tests/graph.rs
+++ b/ploidy-core/src/ir/tests/graph.rs
@@ -4,7 +4,10 @@ use itertools::Itertools;
 
 use crate::{
     arena::Arena,
-    ir::{InlineTypeView, RawGraph, SchemaTypeView, Spec, StructFieldName, TypeView, View},
+    ir::{
+        HasResource, InlineTypeView, RawGraph, SchemaTypeView, Spec, StructFieldName, TypeView,
+        View,
+    },
     parse::Document,
     tests::assert_matches,
 };
@@ -1075,7 +1078,7 @@ fn test_dependencies_propagation() {
     // operations; the others are only used by `getData`.
     let mut user_used_by = user.used_by().map(|op| op.id()).collect_vec();
     user_used_by.sort();
-    assert_matches!(&*user_used_by, ["getData", "getUser"]);
+    assert_eq!(user_used_by, ["getData", "getUser"]);
 
     let mut other_used_by = graph
         .schemas()
@@ -1084,7 +1087,7 @@ fn test_dependencies_propagation() {
         .map(|op| op.id())
         .collect_vec();
     other_used_by.dedup();
-    assert_matches!(&*other_used_by, ["getData"]);
+    assert_eq!(other_used_by, ["getData"]);
 }
 
 // MARK: Backward propagation

--- a/ploidy-core/src/ir/tests/transform.rs
+++ b/ploidy-core/src/ir/tests/transform.rs
@@ -3,15 +3,29 @@
 use crate::{
     arena::Arena,
     ir::{
-        Enum, EnumVariant, InlineTypePath, InlineTypePathRoot, InlineTypePathSegment,
-        PrimitiveType, SchemaTypeInfo, SpecContainer, SpecInlineType, SpecInner, SpecSchemaType,
-        SpecStruct, SpecStructField, SpecTagged, SpecTaggedVariant, SpecType, SpecUntagged,
-        SpecUntaggedVariant, StructFieldName, StructFieldNameHint, UntaggedVariantNameHint,
-        transform::transform,
+        Enum, EnumVariant, InlineTypeIds, PrimitiveType, SchemaTypeInfo, SpecContainer,
+        SpecInlineType, SpecInner, SpecSchemaType, SpecStruct, SpecStructField, SpecTagged,
+        SpecTaggedVariant, SpecType, SpecUntagged, SpecUntaggedVariant, StructFieldName,
+        StructFieldNameHint, UntaggedVariantNameHint,
+        transform::{TransformContext, TypeInfo, transform_with_context},
     },
     parse::{Document, Schema},
     tests::assert_matches,
 };
+
+fn transform<'a>(
+    arena: &'a Arena,
+    doc: &'a Document,
+    name: &'a str,
+    schema: &'a Schema,
+) -> SpecType<'a> {
+    let context = TransformContext::new(arena, doc, InlineTypeIds::new(arena));
+    let info = TypeInfo::Schema(SchemaTypeInfo {
+        name,
+        resource: None,
+    });
+    transform_with_context(&context, info, schema)
+}
 
 // MARK: Enums
 
@@ -614,25 +628,9 @@ fn test_struct_with_additional_properties_inline() {
                         flattened: true,
                         required: true,
                         ty: SpecType::Inline(SpecInlineType::Container(
-                            InlineTypePath {
-                                root: InlineTypePathRoot::Type("Config"),
-                                segments: [InlineTypePathSegment::Field(StructFieldName::Hint(
-                                    StructFieldNameHint::AdditionalProperties,
-                                ))],
-                            },
+                            _,
                             SpecContainer::Map(SpecInner {
-                                ty: SpecType::Inline(SpecInlineType::Struct(
-                                    InlineTypePath {
-                                        root: InlineTypePathRoot::Type("Config"),
-                                        segments: [
-                                            InlineTypePathSegment::Field(StructFieldName::Hint(
-                                                StructFieldNameHint::AdditionalProperties,
-                                            )),
-                                            InlineTypePathSegment::MapValue,
-                                        ],
-                                    },
-                                    _,
-                                )),
+                                ty: SpecType::Inline(SpecInlineType::Struct(_, _)),
                                 ..
                             }),
                         )),
@@ -1045,10 +1043,7 @@ fn test_struct_inline_all_of_becomes_parent() {
                 // The inline `allOf` schemas become inline parent types.
                 parents: [
                     SpecType::Inline(SpecInlineType::Struct(
-                        InlineTypePath {
-                            root: InlineTypePathRoot::Type("Person"),
-                            segments: [InlineTypePathSegment::Parent(1)],
-                        },
+                        _,
                         SpecStruct {
                             fields: [SpecStructField {
                                 name: StructFieldName::Name("name"),
@@ -1058,10 +1053,7 @@ fn test_struct_inline_all_of_becomes_parent() {
                         },
                     )),
                     SpecType::Inline(SpecInlineType::Struct(
-                        InlineTypePath {
-                            root: InlineTypePathRoot::Type("Person"),
-                            segments: [InlineTypePathSegment::Parent(2)],
-                        },
+                        _,
                         SpecStruct {
                             fields: [SpecStructField {
                                 name: StructFieldName::Name("age"),
@@ -1117,10 +1109,7 @@ fn test_struct_mixed_all_of_ref_and_inline() {
                 parents: [
                     SpecType::Ref(r),
                     SpecType::Inline(SpecInlineType::Struct(
-                        InlineTypePath {
-                            root: InlineTypePathRoot::Type("Child"),
-                            segments: [InlineTypePathSegment::Parent(2)],
-                        },
+                        _,
                         SpecStruct {
                             fields: [SpecStructField {
                                 name: StructFieldName::Name("name"),
@@ -2540,23 +2529,10 @@ fn test_deeply_nested_inline_types() {
                 fields: [SpecStructField {
                     name: StructFieldName::Name("items"),
                     ty: SpecType::Inline(SpecInlineType::Container(
-                        InlineTypePath {
-                            root: InlineTypePathRoot::Type("Outer"),
-                            segments: [InlineTypePathSegment::Field(StructFieldName::Name(
-                                "items",
-                            ))],
-                        },
+                        _,
                         SpecContainer::Array(SpecInner {
                             ty: SpecType::Inline(SpecInlineType::Struct(
-                                InlineTypePath {
-                                    root: InlineTypePathRoot::Type("Outer"),
-                                    segments: [
-                                        InlineTypePathSegment::Field(StructFieldName::Name(
-                                            "items",
-                                        )),
-                                        InlineTypePathSegment::ArrayItem,
-                                    ],
-                                },
+                                _,
                                 SpecStruct {
                                     fields: [SpecStructField {
                                         name: StructFieldName::Name("field"),
@@ -2685,13 +2661,7 @@ fn test_array_inline_path_construction() {
                 ..
             },
             SpecContainer::Array(SpecInner {
-                ty: SpecType::Inline(SpecInlineType::Struct(
-                    InlineTypePath {
-                        root: InlineTypePathRoot::Type("Container"),
-                        segments: [InlineTypePathSegment::ArrayItem],
-                    },
-                    _,
-                )),
+                ty: SpecType::Inline(SpecInlineType::Struct(_, _)),
                 ..
             }),
         )),
@@ -2728,13 +2698,7 @@ fn test_map_inline_path_construction() {
                 ..
             },
             SpecContainer::Map(SpecInner {
-                ty: SpecType::Inline(SpecInlineType::Struct(
-                    InlineTypePath {
-                        root: InlineTypePathRoot::Type("Dictionary"),
-                        segments: [InlineTypePathSegment::MapValue],
-                    },
-                    _,
-                )),
+                ty: SpecType::Inline(SpecInlineType::Struct(_, _)),
                 ..
             }),
         )),
@@ -2772,15 +2736,7 @@ fn test_struct_inline_path_construction() {
             SpecStruct {
                 fields: [SpecStructField {
                     name: StructFieldName::Name("nested"),
-                    ty: SpecType::Inline(SpecInlineType::Struct(
-                        InlineTypePath {
-                            root: InlineTypePathRoot::Type("Outer"),
-                            segments: [InlineTypePathSegment::Field(StructFieldName::Name(
-                                "nested",
-                            ))],
-                        },
-                        _,
-                    )),
+                    ty: SpecType::Inline(SpecInlineType::Struct(_, _)),
                     ..
                 }],
                 ..
@@ -2842,12 +2798,7 @@ fn test_inline_tagged_union_in_struct_field() {
                 fields: [SpecStructField {
                     name: StructFieldName::Name("animal"),
                     ty: SpecType::Inline(SpecInlineType::Tagged(
-                        InlineTypePath {
-                            root: InlineTypePathRoot::Type("Container"),
-                            segments: [InlineTypePathSegment::Field(StructFieldName::Name(
-                                "animal",
-                            ))],
-                        },
+                        _,
                         SpecTagged {
                             tag: "kind",
                             variants: [

--- a/ploidy-core/src/ir/tests/views.rs
+++ b/ploidy-core/src/ir/tests/views.rs
@@ -1,14 +1,16 @@
 //! Tests for the IR view layer, indirection, and extension system.
 
+use std::num::NonZeroUsize;
+
 use itertools::Itertools;
 
 use crate::{
     arena::Arena,
     ir::{
-        ContainerView, EnumVariant, ExtendableView, InlineTypePath, InlineTypePathRoot,
-        InlineTypePathSegment, InlineTypeView, ParameterStyle, PrimitiveType, RawGraph,
-        RequestView, Required, ResponseView, SchemaTypeInfo, SchemaTypeView, SomeUntaggedVariant,
-        Spec, StructFieldName, TypeView, View,
+        ContainerView, EnumVariant, ExtendableView, HasResource, HasTypeId, InlineTypePathRoot,
+        InlineTypePathSegment, InlineTypeView, OperationUsage, ParameterStyle, PrimitiveType,
+        RawGraph, RequestView, Required, ResponseView, SchemaTypeInfo, SchemaTypeView,
+        SomeUntaggedVariant, Spec, StructFieldName, TypeView, View,
     },
     parse::{Document, Method, path::PathFragment},
     tests::assert_matches,
@@ -900,15 +902,249 @@ fn test_inlines_discovers_nested_inline_all_of_parents() {
     // The grandparent inline struct (with `grandparent_field`) must
     // be discovered, along with its `grandparent_field` inline struct.
     let has_grandparent_field_struct = inlines.iter().any(|i| {
-        matches!(i, InlineTypeView::Struct(path, _)
-            if path.segments.iter().any(|s| matches!(s,
-                InlineTypePathSegment::Field(StructFieldName::Name("grandparent_field")))))
+        matches!(i, InlineTypeView::Struct(_, _)
+            if i.path().segments().collect_vec().iter().any(|s| matches!(s,
+                InlineTypePathSegment::Field(_, StructFieldName::Name("grandparent_field")))))
     });
     assert!(
         has_grandparent_field_struct,
         "expected `Child.inlines()` to discover the grandparent's \
          inline field struct; got {inlines:?}"
     );
+}
+
+#[test]
+fn test_inlines_multiple_inline_all_of_parents_have_distinct_paths() {
+    // When a struct has multiple inline `allOf` parents, each parent's path
+    // must carry a distinct `Inherits(n)` segment, so that codegen can
+    // produce unique names.
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test
+          version: 1.0.0
+        components:
+          schemas:
+            Combined:
+              allOf:
+                - type: object
+                  properties:
+                    alpha:
+                      type: string
+                - type: object
+                  properties:
+                    beta:
+                      type: string
+                - type: object
+                  properties:
+                    gamma:
+                      type: string
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let spec = Spec::from_doc(&arena, &doc).unwrap();
+    let graph = RawGraph::new(&arena, &spec).cook();
+
+    let combined = match graph.schema("Combined").unwrap() {
+        SchemaTypeView::Struct(_, view) => view,
+        other => panic!("expected struct `Combined`; got {other:?}"),
+    };
+    // Each inline parent struct should have a path with a single
+    // `Inherits(n)` segment.
+    let paths = combined
+        .parents()
+        .map(|parent| match parent {
+            TypeView::Inline(i) => i.path().segments().collect_vec(),
+            other => panic!("expected inline type; got {other:?}"),
+        })
+        .collect_vec();
+    let paths = paths.iter().map(|path| path.as_slice()).collect_vec();
+    assert_eq!(
+        &*paths,
+        [
+            [InlineTypePathSegment::Inherits(
+                NonZeroUsize::new(1).unwrap()
+            )],
+            [InlineTypePathSegment::Inherits(
+                NonZeroUsize::new(2).unwrap()
+            )],
+            [InlineTypePathSegment::Inherits(
+                NonZeroUsize::new(3).unwrap()
+            )],
+        ]
+    );
+}
+
+#[test]
+fn test_nested_type_array_inline_paths_are_distinct() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.1.0
+        info:
+          title: Test
+          version: 1.0.0
+        components:
+          schemas:
+            StringOrIntArrayOrNull:
+              type: [array, 'null']
+              items:
+                type: [string, integer]
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let spec = Spec::from_doc(&arena, &doc).unwrap();
+    let graph = RawGraph::new(&arena, &spec).cook();
+
+    let schema = graph.schema("StringOrIntArrayOrNull").unwrap();
+
+    let array = schema
+        .inlines()
+        .find(|inline| {
+            matches!(
+                inline,
+                InlineTypeView::Container(_, ContainerView::Array(_))
+            )
+        })
+        .unwrap();
+    assert_eq!(array.path().root(), InlineTypePathRoot::Schema(schema.id()));
+    assert_matches!(
+        &*array.path().segments().collect_vec(),
+        [InlineTypePathSegment::Optional]
+    );
+
+    let untagged = schema
+        .inlines()
+        .find(|inline| matches!(inline, InlineTypeView::Untagged(_, _)))
+        .unwrap();
+    assert_eq!(
+        untagged.path().root(),
+        InlineTypePathRoot::Schema(schema.id())
+    );
+    assert_matches!(
+        &*untagged.path().segments().collect_vec(),
+        [
+            InlineTypePathSegment::Optional,
+            InlineTypePathSegment::ArrayItem,
+        ]
+    );
+
+    let string = schema
+        .inlines()
+        .find(|inline| {
+            matches!(inline, InlineTypeView::Primitive(_, p) if p.ty() == PrimitiveType::String)
+        })
+        .unwrap();
+    assert_eq!(
+        string.path().root(),
+        InlineTypePathRoot::Schema(schema.id())
+    );
+    assert_eq!(
+        &*string.path().segments().collect_vec(),
+        [
+            InlineTypePathSegment::Optional,
+            InlineTypePathSegment::ArrayItem,
+            InlineTypePathSegment::UntaggedVariant(NonZeroUsize::new(1).unwrap()),
+        ],
+    );
+
+    let integer = schema
+        .inlines()
+        .find(|inline| {
+            matches!(inline, InlineTypeView::Primitive(_, p) if p.ty() == PrimitiveType::I32)
+        })
+        .unwrap();
+    assert_eq!(
+        integer.path().root(),
+        InlineTypePathRoot::Schema(schema.id()),
+    );
+    assert_eq!(
+        &*integer.path().segments().collect_vec(),
+        [
+            InlineTypePathSegment::Optional,
+            InlineTypePathSegment::ArrayItem,
+            InlineTypePathSegment::UntaggedVariant(NonZeroUsize::new(2).unwrap()),
+        ]
+    );
+}
+
+#[test]
+fn test_inherits_position_excludes_shadow_edges() {
+    // `Shared` has two inline `allOf` parents, and is a variant of
+    // two tagged unions with different discriminators. This triggers
+    // `inline_tagged_variants`, which creates an inline copy of
+    // `Shared` with shadow `Inherits` edges (to the tagged union and
+    // the original `Shared`). The inlined copy's path must not be
+    // polluted by the shadow edges.
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test
+          version: 1.0.0
+        components:
+          schemas:
+            UnionA:
+              oneOf:
+                - $ref: '#/components/schemas/Shared'
+              discriminator:
+                propertyName: kindA
+            UnionB:
+              oneOf:
+                - $ref: '#/components/schemas/Shared'
+              discriminator:
+                propertyName: kindB
+            Shared:
+              type: object
+              allOf:
+                - type: object
+                  properties:
+                    first:
+                      type: string
+                - type: object
+                  properties:
+                    second:
+                      type: string
+              properties:
+                kindA:
+                  type: string
+                kindB:
+                  type: string
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let spec = Spec::from_doc(&arena, &doc).unwrap();
+    let mut raw = RawGraph::new(&arena, &spec);
+    raw.inline_tagged_variants();
+    let graph = raw.cook();
+
+    // Find the inlined copy through the tagged union's variant.
+    let union_a = graph.schema("UnionA").unwrap();
+    let SchemaTypeView::Tagged(_, tagged) = union_a else {
+        panic!("expected tagged `UnionA`; got `{union_a:?}`");
+    };
+    let variant = tagged.variants().next().unwrap();
+    let TypeView::Inline(inlined @ InlineTypeView::Struct(..)) = variant.ty() else {
+        panic!("expected inline struct variant; got `{:?}`", variant.ty());
+    };
+
+    // The inlined copy has shadow `Inherits` edges to `UnionA` and `Shared`.
+    // Its own path should be a single `TaggedVariant` segment, not
+    // an `Inherits` segment from the shadow edges.
+    let path = inlined.path();
+    assert_eq!(path.root(), InlineTypePathRoot::Schema(tagged.id()));
+    assert_matches!(
+        path.segments().collect_vec().as_slice(),
+        [InlineTypePathSegment::TaggedVariant(_, "Shared")]
+    );
+
+    // The inlined copy's `inlines()` should not discover `Shared`'s
+    // inline `allOf` parents; those are behind shadow edges.
+    let inline_paths = inlined
+        .inlines()
+        .map(|i| i.path().segments().collect_vec())
+        .collect_vec();
+    assert_matches!(&*inline_paths, []);
 }
 
 // MARK: Tagged union variant views
@@ -1235,9 +1471,19 @@ fn test_inline_struct_view_construction_and_path_access() {
     // Should be able to match on the `Struct` variant.
     assert_matches!(inline_view, InlineTypeView::Struct(_, _));
 
-    // `path()` should return the path to the inline type.
+    // `path()` returns the precomputed path.
     let path = inline_view.path();
-    assert_eq!(path.segments.len(), 1);
+    assert_eq!(
+        path.root(),
+        InlineTypePathRoot::Schema(container_struct.id())
+    );
+    assert_matches!(
+        path.segments().collect_vec().as_slice(),
+        [InlineTypePathSegment::Field(
+            _,
+            StructFieldName::Name("inline_obj")
+        )]
+    );
 }
 
 #[test]
@@ -1386,13 +1632,15 @@ fn test_inline_view_path_method() {
         other => panic!("expected inline type; got {other:?}"),
     };
 
-    // `path()` should return a path with one segment.
+    // `path()` returns the precomputed path.
     let path = nested_inline.path();
+    assert_eq!(path.root(), InlineTypePathRoot::Schema(parent_struct.id()));
     assert_matches!(
-        path.segments,
-        [InlineTypePathSegment::Field(StructFieldName::Name(
-            "nested"
-        ))]
+        path.segments().collect_vec().as_slice(),
+        [InlineTypePathSegment::Field(
+            _,
+            StructFieldName::Name("nested")
+        )]
     );
 }
 
@@ -2427,14 +2675,9 @@ fn test_operation_view_inlines_finds_inline_types() {
     let address = inlines
         .iter()
         .find(|inline| {
-            matches!(inline, InlineTypeView::Struct(path, _) if matches!(
-                path.segments,
-                [
-                    InlineTypePathSegment::Operation("createUser"),
-                    InlineTypePathSegment::Request,
-                    InlineTypePathSegment::Field(StructFieldName::Name("address")),
-                ],
-            ))
+            matches!(inline, InlineTypeView::Struct(_, _)
+                if inline.path().segments().collect_vec().iter().any(|s| matches!(s,
+                    InlineTypePathSegment::Field(_, StructFieldName::Name("address")))))
         })
         .unwrap();
     assert_matches!(address, InlineTypeView::Struct(_, _));
@@ -2442,13 +2685,16 @@ fn test_operation_view_inlines_finds_inline_types() {
     let request = inlines
         .iter()
         .find(|inline| {
-            matches!(inline, InlineTypeView::Struct(path, _) if matches!(
-                path.segments,
-                [
-                    InlineTypePathSegment::Operation("createUser"),
-                    InlineTypePathSegment::Request,
-                ],
-            ))
+            matches!(inline, InlineTypeView::Struct(_, _)
+                if inline.path().segments().collect_vec().is_empty()
+                    && matches!(
+                        inline.path().root(),
+                        InlineTypePathRoot::Operation {
+                            usage: OperationUsage::Request,
+                            ..
+                        },
+                    )
+            )
         })
         .unwrap();
     assert_matches!(request, InlineTypeView::Struct(_, _));
@@ -2456,13 +2702,16 @@ fn test_operation_view_inlines_finds_inline_types() {
     let response = inlines
         .iter()
         .find(|inline| {
-            matches!(inline, InlineTypeView::Struct(path, _) if matches!(
-                path.segments,
-                [
-                    InlineTypePathSegment::Operation("createUser"),
-                    InlineTypePathSegment::Response,
-                ],
-            ))
+            matches!(inline, InlineTypeView::Struct(_, _)
+                if inline.path().segments().collect_vec().is_empty()
+                    && matches!(
+                        inline.path().root(),
+                        InlineTypePathRoot::Operation {
+                            usage: OperationUsage::Response,
+                            ..
+                        },
+                    )
+            )
         })
         .unwrap();
     assert_matches!(response, InlineTypeView::Struct(_, _));
@@ -2512,14 +2761,16 @@ fn test_operation_request_and_response() {
             operation.request(),
         );
     };
-    assert_matches!(request.path().root, InlineTypePathRoot::Resource(None));
+    let req_path = request.path();
     assert_matches!(
-        request.path().segments,
-        [
-            InlineTypePathSegment::Operation("createUser"),
-            InlineTypePathSegment::Request,
-        ],
+        req_path.root(),
+        InlineTypePathRoot::Operation {
+            id,
+            resource: None,
+            usage: OperationUsage::Request,
+        } if id == "createUser",
     );
+    assert!(req_path.segments().next().is_none());
 
     let Some(ResponseView::Json(TypeView::Inline(response))) = operation.response() else {
         panic!(
@@ -2527,14 +2778,16 @@ fn test_operation_request_and_response() {
             operation.response(),
         );
     };
-    assert_matches!(response.path().root, InlineTypePathRoot::Resource(None));
+    let resp_path = response.path();
     assert_matches!(
-        response.path().segments,
-        [
-            InlineTypePathSegment::Operation("createUser"),
-            InlineTypePathSegment::Response,
-        ],
+        resp_path.root(),
+        InlineTypePathRoot::Operation {
+            id,
+            resource: None,
+            usage: OperationUsage::Response,
+        } if id == "createUser",
     );
+    assert!(resp_path.segments().next().is_none());
 }
 
 // MARK: Parameter views
@@ -2598,43 +2851,41 @@ fn test_parameter_inlines_finds_inline_types() {
     // The root inline is the `filter` struct itself.
     let root = filter_inlines
         .iter()
-        .filter_map(|inline| match inline {
-            InlineTypeView::Struct(path, _) => Some(path),
-            _ => None,
-        })
-        .next()
+        .find(|inline| matches!(inline, InlineTypeView::Struct(_, _)))
         .unwrap();
+    let root_path = root.path();
     assert_matches!(
-        root,
-        InlineTypePath {
-            root: InlineTypePathRoot::Resource(Some("user")),
-            segments: [
-                InlineTypePathSegment::Operation("getUser"),
-                InlineTypePathSegment::Parameter("filter"),
-            ],
+        root_path.root(),
+        InlineTypePathRoot::Operation {
+            resource: Some("user"),
+            usage: OperationUsage::Query("filter"),
+            ..
         },
     );
+    assert!(root_path.segments().next().is_none());
 
     // The nested struct carries the full path.
     let nested = filter_inlines
         .iter()
-        .filter_map(|inline| match inline {
-            InlineTypeView::Struct(path, _) => Some(path),
-            _ => None,
-        })
+        .filter(|inline| matches!(inline, InlineTypeView::Struct(_, _)))
         .skip(1)
         .exactly_one()
         .unwrap();
+    let nested_path = nested.path();
     assert_matches!(
-        nested,
-        InlineTypePath {
-            root: InlineTypePathRoot::Resource(Some("user")),
-            segments: [
-                InlineTypePathSegment::Operation("getUser"),
-                InlineTypePathSegment::Parameter("filter"),
-                InlineTypePathSegment::Field(StructFieldName::Name("nested")),
-            ],
+        nested_path.root(),
+        InlineTypePathRoot::Operation {
+            resource: Some("user"),
+            usage: OperationUsage::Query("filter"),
+            ..
         },
+    );
+    assert_matches!(
+        nested_path.segments().collect_vec().as_slice(),
+        [
+            InlineTypePathSegment::Field(_, StructFieldName::Name("nested")),
+            InlineTypePathSegment::Optional
+        ],
     );
 }
 
@@ -3977,21 +4228,19 @@ fn test_shadow_edges_hide_inlines_but_preserve_dependencies() {
 
     // The original `Dog` schema should own the inline `metadata` struct.
     let dog = graph.schema("Dog").unwrap();
-    let dog_inline_paths = dog
+    let dog_inline_structs = dog
         .inlines()
-        .filter_map(|i| match i {
-            InlineTypeView::Struct(path, _) => Some(path),
-            _ => None,
-        })
+        .filter(|i| matches!(i, InlineTypeView::Struct(_, _)))
         .collect_vec();
+    assert_eq!(dog_inline_structs.len(), 1);
+    let path = dog_inline_structs[0].path();
+    assert_eq!(path.root(), InlineTypePathRoot::Schema(dog.id()));
     assert_matches!(
-        &*dog_inline_paths,
-        [InlineTypePath {
-            root: InlineTypePathRoot::Type("Dog"),
-            segments: [InlineTypePathSegment::Field(StructFieldName::Name(
-                "metadata"
-            ))],
-        }],
+        path.segments().collect_vec().as_slice(),
+        [InlineTypePathSegment::Field(
+            _,
+            StructFieldName::Name("metadata")
+        )],
     );
 
     // The inlined variant `Pet/Dog` should _not_ claim `Dog`'s inline types.
@@ -4005,10 +4254,7 @@ fn test_shadow_edges_hide_inlines_but_preserve_dependencies() {
     };
     let claimed_inline_structs = inlined_dog
         .inlines()
-        .filter_map(|i| match i {
-            InlineTypeView::Struct(path, _) => Some(path),
-            _ => None,
-        })
+        .filter(|i| matches!(i, InlineTypeView::Struct(_, _)))
         .collect_vec();
     assert_matches!(&*claimed_inline_structs, []);
 
@@ -4085,19 +4331,19 @@ fn test_shadow_inherits_hides_ancestor_inlines() {
 
     // `Animal` should own the inline `tag` struct.
     let animal = graph.schema("Animal").unwrap();
-    let animal_inline_paths = animal
+    let animal_inline_structs = animal
         .inlines()
-        .filter_map(|i| match i {
-            InlineTypeView::Struct(path, _) => Some(path),
-            _ => None,
-        })
+        .filter(|i| matches!(i, InlineTypeView::Struct(_, _)))
         .collect_vec();
+    assert_eq!(animal_inline_structs.len(), 1);
+    let path = animal_inline_structs[0].path();
+    assert_eq!(path.root(), InlineTypePathRoot::Schema(animal.id()));
     assert_matches!(
-        &*animal_inline_paths,
-        [InlineTypePath {
-            root: InlineTypePathRoot::Type("Animal"),
-            segments: [InlineTypePathSegment::Field(StructFieldName::Name("tag"))],
-        }],
+        path.segments().collect_vec().as_slice(),
+        [InlineTypePathSegment::Field(
+            _,
+            StructFieldName::Name("tag")
+        )],
     );
 
     // The inlined `Pet/Dog` should _not_ claim `Animal`'s inline types.
@@ -4111,10 +4357,7 @@ fn test_shadow_inherits_hides_ancestor_inlines() {
     };
     let claimed_inline_structs = inlined_dog
         .inlines()
-        .filter_map(|i| match i {
-            InlineTypeView::Struct(path, _) => Some(path),
-            _ => None,
-        })
+        .filter(|i| matches!(i, InlineTypeView::Struct(_, _)))
         .collect_vec();
     assert_matches!(&*claimed_inline_structs, []);
 
@@ -4577,11 +4820,15 @@ fn test_inlined_variant_inline_field_types_not_leaked() {
 
     // Inlines should only include the inline struct variant `Dog`,
     // not `Dog`'s inline field type `Details`.
-    let [InlineTypeView::Struct(path, _)] = &*pet_inlines else {
+    let [InlineTypeView::Struct(_, _)] = &*pet_inlines else {
         panic!("expected inline struct variant `Dog`; got `{pet_inlines:?}`");
     };
-    assert_matches!(path.root, InlineTypePathRoot::Type("Pet"));
-    assert_matches!(path.segments, [InlineTypePathSegment::TaggedVariant("Dog")]);
+    let path = pet_inlines[0].path();
+    assert_eq!(path.root(), InlineTypePathRoot::Schema(pet.id()));
+    assert_matches!(
+        path.segments().collect_vec().as_slice(),
+        [InlineTypePathSegment::TaggedVariant(_, "Dog")]
+    );
 
     // `Dog`'s own `inlines()` still contains its inline types:
     // containers for optional fields, the `Details` struct, etc.
@@ -4596,7 +4843,7 @@ fn test_inlined_variant_inline_field_types_not_leaked() {
     assert!(
         dog_inlines
             .iter()
-            .all(|i| i.path().root == InlineTypePathRoot::Type("Dog")),
+            .all(|i| i.path().root() == InlineTypePathRoot::Schema(dog.id())),
         "all of `Dog`'s inlines should be rooted at `Dog`"
     );
 }
@@ -4810,11 +5057,18 @@ fn test_inlined_when_struct_field_references_tagged_variant() {
         panic!("expected tagged `Pet`; got `{pet:?}`");
     };
     let variant = pet_tagged.variants().next().unwrap();
-    let TypeView::Inline(InlineTypeView::Struct(path, inline_struct)) = variant.ty() else {
+    let TypeView::Inline(inline_view) = variant.ty() else {
         panic!("expected inline struct variant; got `{:?}`", variant.ty());
     };
-    assert_matches!(path.root, InlineTypePathRoot::Type("Pet"));
-    assert_matches!(path.segments, [InlineTypePathSegment::TaggedVariant("Dog")]);
+    let path = inline_view.path();
+    assert_eq!(path.root(), InlineTypePathRoot::Schema(pet_tagged.id()));
+    assert_matches!(
+        path.segments().collect_vec().as_slice(),
+        [InlineTypePathSegment::TaggedVariant(_, "Dog")]
+    );
+    let InlineTypeView::Struct(_, inline_struct) = inline_view else {
+        panic!("expected inline struct variant; got `{inline_view:?}`");
+    };
 
     // The inline struct should have the same fields, and `kind`
     // should be a tag there; it's the tag for `Pet`.

--- a/ploidy-core/src/ir/transform.rs
+++ b/ploidy-core/src/ir/transform.rs
@@ -3,44 +3,52 @@ use rustc_hash::FxHashMap;
 
 use crate::{
     arena::Arena,
-    ir::JsonF64,
+    ir::{JsonF64, SchemaTypeInfo},
     parse::{AdditionalProperties, Document, Format, RefOrSchema, Schema, Ty},
 };
 
 use super::types::{
-    Enum, EnumVariant, InlineTypePath, InlineTypePathRoot, InlineTypePathSegment, PrimitiveType,
-    SpecContainer, SpecInlineType, SpecInner, SpecSchemaType, SpecStruct, SpecStructField,
-    SpecTagged, SpecTaggedVariant, SpecType, SpecUntagged, SpecUntaggedVariant, StructFieldName,
-    StructFieldNameHint, TypeInfo, UntaggedVariantNameHint,
+    Enum, EnumVariant, InlineTypeId, InlineTypeIds, PrimitiveType, SpecContainer, SpecInlineType,
+    SpecInner, SpecSchemaType, SpecStruct, SpecStructField, SpecTagged, SpecTaggedVariant,
+    SpecType, SpecUntagged, SpecUntaggedVariant, StructFieldName, StructFieldNameHint,
+    UntaggedVariantNameHint,
 };
 
-#[inline]
-pub fn transform<'a>(
-    arena: &'a Arena,
-    doc: &'a Document,
-    name: impl Into<TypeInfo<'a>>,
-    schema: &'a Schema,
-) -> SpecType<'a> {
-    let context = TransformContext::new(arena, doc);
-    transform_with_context(&context, name.into(), schema)
+/// Metadata about a type in the dependency graph.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum TypeInfo<'a> {
+    Schema(SchemaTypeInfo<'a>),
+    Inline(InlineTypeId),
+}
+
+impl<'a> From<SchemaTypeInfo<'a>> for TypeInfo<'a> {
+    fn from(info: SchemaTypeInfo<'a>) -> Self {
+        Self::Schema(info)
+    }
+}
+
+impl From<InlineTypeId> for TypeInfo<'_> {
+    fn from(id: InlineTypeId) -> Self {
+        Self::Inline(id)
+    }
 }
 
 /// Context for the [`IrTransformer`].
 #[derive(Debug)]
 pub struct TransformContext<'a> {
-    pub arena: &'a Arena,
-    /// The document being transformed.
-    pub doc: &'a Document,
+    arena: &'a Arena,
+    doc: &'a Document,
+    ids: InlineTypeIds<'a>,
 }
 
 impl<'a> TransformContext<'a> {
     /// Creates a new context for the given document.
-    pub fn new(arena: &'a Arena, doc: &'a Document) -> Self {
-        Self { arena, doc }
+    pub fn new(arena: &'a Arena, doc: &'a Document, ids: InlineTypeIds<'a>) -> Self {
+        Self { arena, doc, ids }
     }
 }
 
-fn transform_with_context<'context, 'a>(
+pub(super) fn transform_with_context<'context, 'a>(
     context: &'context TransformContext<'a>,
     name: impl Into<TypeInfo<'a>>,
     schema: &'a Schema,
@@ -128,7 +136,7 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
 
         Ok(match self.name {
             TypeInfo::Schema(info) => SpecSchemaType::Tagged(info, tagged).into(),
-            TypeInfo::Inline(path) => SpecInlineType::Tagged(path, tagged).into(),
+            TypeInfo::Inline(id) => SpecInlineType::Tagged(id, tagged).into(),
         })
     }
 
@@ -141,7 +149,7 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
             [] => {
                 return Ok(match self.name {
                     TypeInfo::Schema(info) => SpecSchemaType::Any(info).into(),
-                    TypeInfo::Inline(path) => SpecInlineType::Any(path).into(),
+                    TypeInfo::Inline(id) => SpecInlineType::Any(id).into(),
                 });
             }
             [schema] => {
@@ -150,7 +158,7 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
                     RefOrSchema::Ref(r) => SpecType::Ref(r),
                     RefOrSchema::Inline(s) if matches!(&*s.ty, [Ty::Null]) => match self.name {
                         TypeInfo::Schema(info) => SpecSchemaType::Any(info).into(),
-                        TypeInfo::Inline(path) => SpecInlineType::Any(path).into(),
+                        TypeInfo::Inline(id) => SpecInlineType::Any(id).into(),
                     },
                     RefOrSchema::Inline(schema) => {
                         transform_with_context(self.context, self.name, schema)
@@ -166,15 +174,8 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
                         RefOrSchema::Ref(r) => Some(SpecType::Ref(r)),
                         RefOrSchema::Inline(s) if matches!(&*s.ty, [Ty::Null]) => None,
                         RefOrSchema::Inline(schema) => {
-                            let segment = InlineTypePathSegment::Variant(index);
-                            let path = match self.name {
-                                TypeInfo::Schema(info) => InlineTypePath {
-                                    root: InlineTypePathRoot::Type(info.name),
-                                    segments: self.arena().alloc_slice_copy(&[segment]),
-                                },
-                                TypeInfo::Inline(path) => path.join(self.arena(), &[segment]),
-                            };
-                            Some(transform_with_context(self.context, path, schema))
+                            let id = self.context.ids.next();
+                            Some(transform_with_context(self.context, id, schema))
                         }
                     };
                     ty.map(|ty| {
@@ -219,7 +220,7 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
                 });
                 match self.name {
                     TypeInfo::Schema(info) => SpecSchemaType::Container(info, container).into(),
-                    TypeInfo::Inline(path) => SpecInlineType::Container(path, container).into(),
+                    TypeInfo::Inline(id) => SpecInlineType::Container(id, container).into(),
                 }
             }
 
@@ -231,7 +232,7 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
                 };
                 match self.name {
                     TypeInfo::Schema(info) => SpecSchemaType::Untagged(info, untagged).into(),
-                    TypeInfo::Inline(path) => SpecInlineType::Untagged(path, untagged).into(),
+                    TypeInfo::Inline(id) => SpecInlineType::Untagged(id, untagged).into(),
                 }
             }
         })
@@ -258,9 +259,6 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
             .map(|(index, schema)| {
                 let (field_name, ty, description) = match schema {
                     RefOrSchema::Ref(r) => {
-                        // For references, use the referenced type's name
-                        // as the field name. For example, a pointer like
-                        // `#/components/schemas/Address` becomes `address`.
                         let name = StructFieldName::Name(self.arena().alloc_str(&r.name()));
                         let ty: &_ = self.arena().alloc(SpecType::Ref(r));
                         let desc = r
@@ -271,36 +269,20 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
                         (name, ty, desc)
                     }
                     RefOrSchema::Inline(schema) => {
-                        // For inline schemas, we don't have a name that we can use,
-                        // so use its index in `anyOf` as a naming hint.
                         let name = StructFieldName::Hint(StructFieldNameHint::Index(index + 1));
-                        let segment = InlineTypePathSegment::Field(name);
-                        let path = match self.name {
-                            TypeInfo::Schema(info) => InlineTypePath {
-                                root: InlineTypePathRoot::Type(info.name),
-                                segments: self.arena().alloc_slice_copy(&[segment]),
-                            },
-                            TypeInfo::Inline(path) => path.join(self.arena(), &[segment]),
-                        };
+                        let id = self.context.ids.next();
                         let ty: &_ =
                             self.arena()
-                                .alloc(transform_with_context(self.context, path, schema));
+                                .alloc(transform_with_context(self.context, id, schema));
                         let desc = schema.description.as_deref();
                         (name, ty, desc)
                     }
                 };
                 // Flattened `anyOf` fields are always optional.
-                let segment = InlineTypePathSegment::Field(field_name);
-                let path = match self.name {
-                    TypeInfo::Schema(info) => InlineTypePath {
-                        root: InlineTypePathRoot::Type(info.name),
-                        segments: self.arena().alloc_slice_copy(&[segment]),
-                    },
-                    TypeInfo::Inline(path) => path.join(self.arena(), &[segment]),
-                };
+                let id = self.context.ids.next();
                 let ty: &_ = self.arena().alloc(
                     SpecInlineType::Container(
-                        path,
+                        id,
                         SpecContainer::Optional(SpecInner { description, ty }),
                     )
                     .into(),
@@ -329,7 +311,7 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
 
         Ok(match self.name {
             TypeInfo::Schema(info) => SpecSchemaType::Struct(info, ty).into(),
-            TypeInfo::Inline(path) => SpecInlineType::Struct(path, ty).into(),
+            TypeInfo::Inline(id) => SpecInlineType::Struct(id, ty).into(),
         })
     }
 
@@ -365,7 +347,7 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
         };
         Ok(match self.name {
             TypeInfo::Schema(info) => SpecSchemaType::Enum(info, ty).into(),
-            TypeInfo::Inline(path) => SpecInlineType::Enum(path, ty).into(),
+            TypeInfo::Inline(id) => SpecInlineType::Enum(id, ty).into(),
         })
     }
 
@@ -384,7 +366,7 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
         };
         Ok(match self.name {
             TypeInfo::Schema(info) => SpecSchemaType::Struct(info, ty).into(),
-            TypeInfo::Inline(path) => SpecInlineType::Struct(path, ty).into(),
+            TypeInfo::Inline(id) => SpecInlineType::Struct(id, ty).into(),
         })
     }
 
@@ -397,100 +379,55 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
         for ty in &self.schema.ty {
             let variant = match (ty, self.schema.format) {
                 (Ty::String, Some(Format::DateTime)) => {
-                    OtherVariant::Primitive(self.name, PrimitiveType::DateTime)
+                    OtherVariant::Primitive(PrimitiveType::DateTime)
                 }
-                (Ty::String, Some(Format::Date)) => {
-                    OtherVariant::Primitive(self.name, PrimitiveType::Date)
-                }
-                (Ty::String, Some(Format::Uri)) => {
-                    OtherVariant::Primitive(self.name, PrimitiveType::Url)
-                }
-                (Ty::String, Some(Format::Uuid)) => {
-                    OtherVariant::Primitive(self.name, PrimitiveType::Uuid)
-                }
-                (Ty::String, Some(Format::Byte)) => {
-                    OtherVariant::Primitive(self.name, PrimitiveType::Bytes)
-                }
+                (Ty::String, Some(Format::Date)) => OtherVariant::Primitive(PrimitiveType::Date),
+                (Ty::String, Some(Format::Uri)) => OtherVariant::Primitive(PrimitiveType::Url),
+                (Ty::String, Some(Format::Uuid)) => OtherVariant::Primitive(PrimitiveType::Uuid),
+                (Ty::String, Some(Format::Byte)) => OtherVariant::Primitive(PrimitiveType::Bytes),
                 (Ty::String, Some(Format::Binary)) => {
-                    OtherVariant::Primitive(self.name, PrimitiveType::Binary)
+                    OtherVariant::Primitive(PrimitiveType::Binary)
                 }
-                (Ty::String, _) => OtherVariant::Primitive(self.name, PrimitiveType::String),
+                (Ty::String, _) => OtherVariant::Primitive(PrimitiveType::String),
 
-                (Ty::Integer, Some(Format::Int8)) => {
-                    OtherVariant::Primitive(self.name, PrimitiveType::I8)
-                }
-                (Ty::Integer, Some(Format::UInt8)) => {
-                    OtherVariant::Primitive(self.name, PrimitiveType::U8)
-                }
-                (Ty::Integer, Some(Format::Int16)) => {
-                    OtherVariant::Primitive(self.name, PrimitiveType::I16)
-                }
-                (Ty::Integer, Some(Format::UInt16)) => {
-                    OtherVariant::Primitive(self.name, PrimitiveType::U16)
-                }
-                (Ty::Integer, Some(Format::Int32)) => {
-                    OtherVariant::Primitive(self.name, PrimitiveType::I32)
-                }
-                (Ty::Integer, Some(Format::UInt32)) => {
-                    OtherVariant::Primitive(self.name, PrimitiveType::U32)
-                }
-                (Ty::Integer, Some(Format::Int64)) => {
-                    OtherVariant::Primitive(self.name, PrimitiveType::I64)
-                }
-                (Ty::Integer, Some(Format::UInt64)) => {
-                    OtherVariant::Primitive(self.name, PrimitiveType::U64)
-                }
+                (Ty::Integer, Some(Format::Int8)) => OtherVariant::Primitive(PrimitiveType::I8),
+                (Ty::Integer, Some(Format::UInt8)) => OtherVariant::Primitive(PrimitiveType::U8),
+                (Ty::Integer, Some(Format::Int16)) => OtherVariant::Primitive(PrimitiveType::I16),
+                (Ty::Integer, Some(Format::UInt16)) => OtherVariant::Primitive(PrimitiveType::U16),
+                (Ty::Integer, Some(Format::Int32)) => OtherVariant::Primitive(PrimitiveType::I32),
+                (Ty::Integer, Some(Format::UInt32)) => OtherVariant::Primitive(PrimitiveType::U32),
+                (Ty::Integer, Some(Format::Int64)) => OtherVariant::Primitive(PrimitiveType::I64),
+                (Ty::Integer, Some(Format::UInt64)) => OtherVariant::Primitive(PrimitiveType::U64),
                 (Ty::Integer, Some(Format::UnixTime)) => {
-                    OtherVariant::Primitive(self.name, PrimitiveType::UnixTime)
+                    OtherVariant::Primitive(PrimitiveType::UnixTime)
                 }
-                (Ty::Integer, _) => OtherVariant::Primitive(self.name, PrimitiveType::I32),
+                (Ty::Integer, _) => OtherVariant::Primitive(PrimitiveType::I32),
 
-                (Ty::Number, Some(Format::Float)) => {
-                    OtherVariant::Primitive(self.name, PrimitiveType::F32)
-                }
-                (Ty::Number, Some(Format::Double)) => {
-                    OtherVariant::Primitive(self.name, PrimitiveType::F64)
-                }
+                (Ty::Number, Some(Format::Float)) => OtherVariant::Primitive(PrimitiveType::F32),
+                (Ty::Number, Some(Format::Double)) => OtherVariant::Primitive(PrimitiveType::F64),
                 (Ty::Number, Some(Format::UnixTime)) => {
-                    OtherVariant::Primitive(self.name, PrimitiveType::UnixTime)
+                    OtherVariant::Primitive(PrimitiveType::UnixTime)
                 }
-                (Ty::Number, _) => OtherVariant::Primitive(self.name, PrimitiveType::F64),
+                (Ty::Number, _) => OtherVariant::Primitive(PrimitiveType::F64),
 
-                (Ty::Boolean, _) => OtherVariant::Primitive(self.name, PrimitiveType::Bool),
+                (Ty::Boolean, _) => OtherVariant::Primitive(PrimitiveType::Bool),
 
                 (Ty::Array, _) => {
                     let items = match &self.schema.items {
                         Some(RefOrSchema::Ref(r)) => SpecType::Ref(r),
                         Some(RefOrSchema::Inline(schema)) => {
-                            let segment = InlineTypePathSegment::ArrayItem;
-                            let path = match self.name {
-                                TypeInfo::Schema(info) => InlineTypePath {
-                                    root: InlineTypePathRoot::Type(info.name),
-                                    segments: self.arena().alloc_slice_copy(&[segment]),
-                                },
-                                TypeInfo::Inline(path) => path.join(self.arena(), &[segment]),
-                            };
-                            transform_with_context(self.context, path, schema)
+                            let id = self.context.ids.next();
+                            transform_with_context(self.context, id, schema)
                         }
                         None => {
-                            let segment = InlineTypePathSegment::ArrayItem;
-                            let path = match self.name {
-                                TypeInfo::Schema(info) => InlineTypePath {
-                                    root: InlineTypePathRoot::Type(info.name),
-                                    segments: self.arena().alloc_slice_copy(&[segment]),
-                                },
-                                TypeInfo::Inline(path) => path.join(self.arena(), &[segment]),
-                            };
-                            SpecInlineType::Any(path).into()
+                            let id = self.context.ids.next();
+                            SpecInlineType::Any(id).into()
                         }
                     };
-                    OtherVariant::Array(
-                        self.name,
-                        SpecInner {
-                            description: self.schema.description.as_deref(),
-                            ty: self.arena().alloc(items),
-                        },
-                    )
+                    OtherVariant::Array(SpecInner {
+                        description: self.schema.description.as_deref(),
+                        ty: self.arena().alloc(items),
+                    })
                 }
 
                 (Ty::Object, _) => {
@@ -502,44 +439,30 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
                             })
                         }
                         Some(AdditionalProperties::RefOrSchema(RefOrSchema::Inline(schema))) => {
-                            let segment = InlineTypePathSegment::MapValue;
-                            let path = match self.name {
-                                TypeInfo::Schema(info) => InlineTypePath {
-                                    root: InlineTypePathRoot::Type(info.name),
-                                    segments: self.arena().alloc_slice_copy(&[segment]),
-                                },
-                                TypeInfo::Inline(path) => path.join(self.arena(), &[segment]),
-                            };
+                            let id = self.context.ids.next();
                             Some(SpecInner {
                                 description: self.schema.description.as_deref(),
                                 ty: self.arena().alloc(transform_with_context(
                                     self.context,
-                                    path,
+                                    id,
                                     schema,
                                 )),
                             })
                         }
                         Some(AdditionalProperties::Bool(true)) => {
-                            let segment = InlineTypePathSegment::MapValue;
-                            let path = match self.name {
-                                TypeInfo::Schema(info) => InlineTypePath {
-                                    root: InlineTypePathRoot::Type(info.name),
-                                    segments: self.arena().alloc_slice_copy(&[segment]),
-                                },
-                                TypeInfo::Inline(path) => path.join(self.arena(), &[segment]),
-                            };
+                            let id = self.context.ids.next();
                             Some(SpecInner {
                                 description: self.schema.description.as_deref(),
                                 ty: self
                                     .arena()
-                                    .alloc(SpecType::Inline(SpecInlineType::Any(path))),
+                                    .alloc(SpecType::Inline(SpecInlineType::Any(id))),
                             })
                         }
                         _ => None,
                     };
                     match inner {
-                        Some(inner) => OtherVariant::Map(self.name, inner),
-                        None => OtherVariant::Any(self.name),
+                        Some(inner) => OtherVariant::Map(inner),
+                        None => OtherVariant::Any,
                     }
                 }
 
@@ -556,29 +479,34 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
             // but we treat it as "any type".
             ([], false) => match self.name {
                 TypeInfo::Schema(info) => SpecSchemaType::Any(info).into(),
-                TypeInfo::Inline(path) => SpecInlineType::Any(path).into(),
+                TypeInfo::Inline(id) => SpecInlineType::Any(id).into(),
             },
 
             // A `null` variant becomes `Any`.
             ([], true) => match self.name {
                 TypeInfo::Schema(info) => SpecSchemaType::Any(info).into(),
-                TypeInfo::Inline(path) => SpecInlineType::Any(path).into(),
+                TypeInfo::Inline(id) => SpecInlineType::Any(id).into(),
             },
 
             // A union with a single, non-`null` variant unwraps to
             // the type of that variant.
-            ([variant], false) => variant.to_type(),
+            ([variant], false) => match self.name {
+                TypeInfo::Schema(info) => variant.to_schema_type(info).into(),
+                TypeInfo::Inline(id) => variant.to_inline_type(id).into(),
+            },
 
             // A two-variant union, with one type T and one `null` variant,
             // simplifies to `Optional(T)`.
             ([variant], true) => {
                 let container = SpecContainer::Optional(SpecInner {
                     description: self.schema.description.as_deref(),
-                    ty: self.arena().alloc(variant.to_inline_type()),
+                    ty: self
+                        .arena()
+                        .alloc(variant.to_inline_type(self.context.ids.next()).into()),
                 });
                 match self.name {
                     TypeInfo::Schema(info) => SpecSchemaType::Container(info, container).into(),
-                    TypeInfo::Inline(path) => SpecInlineType::Container(path, container).into(),
+                    TypeInfo::Inline(id) => SpecInlineType::Container(id, container).into(),
                 }
             }
 
@@ -593,7 +521,8 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
                             variant
                                 .hint()
                                 .unwrap_or(UntaggedVariantNameHint::Index(index)),
-                            self.arena().alloc(variant.to_inline_type()),
+                            self.arena()
+                                .alloc(variant.to_inline_type(self.context.ids.next()).into()),
                         )
                     })
                     .collect_vec();
@@ -607,7 +536,7 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
                 };
                 match self.name {
                     TypeInfo::Schema(info) => SpecSchemaType::Untagged(info, untagged).into(),
-                    TypeInfo::Inline(path) => SpecInlineType::Untagged(path, untagged).into(),
+                    TypeInfo::Inline(id) => SpecInlineType::Untagged(id, untagged).into(),
                 }
             }
         }
@@ -623,19 +552,12 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
             .flatten()
             .enumerate()
             .map(|(index, parent)| (index + 1, parent))
-            .map(move |(index, parent)| &*match parent {
+            .map(move |(_index, parent)| &*match parent {
                 RefOrSchema::Ref(r) => self.arena().alloc(SpecType::Ref(r)),
                 RefOrSchema::Inline(schema) => {
-                    let segment = InlineTypePathSegment::Parent(index);
-                    let path = match self.name {
-                        TypeInfo::Schema(info) => InlineTypePath {
-                            root: InlineTypePathRoot::Type(info.name),
-                            segments: self.arena().alloc_slice_copy(&[segment]),
-                        },
-                        TypeInfo::Inline(path) => path.join(self.arena(), &[segment]),
-                    };
+                    let id = self.context.ids.next();
                     self.arena()
-                        .alloc(transform_with_context(self.context, path, schema))
+                        .alloc(transform_with_context(self.context, id, schema))
                 }
             })
     }
@@ -653,17 +575,9 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
                 let ty: &_ = match field_schema {
                     RefOrSchema::Ref(r) => self.arena().alloc(SpecType::Ref(r)),
                     RefOrSchema::Inline(schema) => {
-                        let segment =
-                            InlineTypePathSegment::Field(StructFieldName::Name(field_name));
-                        let path = match self.name {
-                            TypeInfo::Schema(info) => InlineTypePath {
-                                root: InlineTypePathRoot::Type(info.name),
-                                segments: self.arena().alloc_slice_copy(&[segment]),
-                            },
-                            TypeInfo::Inline(path) => path.join(self.arena(), &[segment]),
-                        };
+                        let id = self.context.ids.next();
                         self.arena()
-                            .alloc(transform_with_context(self.context, path, schema))
+                            .alloc(transform_with_context(self.context, id, schema))
                     }
                 };
                 let description = match field_schema {
@@ -686,16 +600,9 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
                 // explicitly nullable, or implicitly optional. The `required`
                 // flag distinguishes between the two for codegen.
                 let ty: &_ = if nullable || !required {
-                    let segment = InlineTypePathSegment::Field(StructFieldName::Name(field_name));
-                    let path = match self.name {
-                        TypeInfo::Schema(info) => InlineTypePath {
-                            root: InlineTypePathRoot::Type(info.name),
-                            segments: self.arena().alloc_slice_copy(&[segment]),
-                        },
-                        TypeInfo::Inline(path) => path.join(self.arena(), &[segment]),
-                    };
+                    let id = self.context.ids.next();
                     self.arena().alloc(SpecType::from(SpecInlineType::Container(
-                        path,
+                        id,
                         SpecContainer::Optional(SpecInner { description, ty }),
                     )))
                 } else {
@@ -715,17 +622,6 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
     /// if the schema specifies them.
     fn additional_properties(&self) -> Option<SpecStructField<'a>> {
         let name = StructFieldName::Hint(StructFieldNameHint::AdditionalProperties);
-        let path = match self.name {
-            TypeInfo::Schema(info) => InlineTypePath {
-                root: InlineTypePathRoot::Type(info.name),
-                segments: self
-                    .arena()
-                    .alloc_slice_copy(&[InlineTypePathSegment::Field(name)]),
-            },
-            TypeInfo::Inline(path) => {
-                path.join(self.arena(), &[InlineTypePathSegment::Field(name)])
-            }
-        };
 
         let inner = match &self.schema.additional_properties {
             Some(AdditionalProperties::RefOrSchema(RefOrSchema::Ref(r))) => SpecInner {
@@ -733,28 +629,29 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
                 ty: self.arena().alloc(SpecType::Ref(r)),
             },
             Some(AdditionalProperties::RefOrSchema(RefOrSchema::Inline(schema))) => {
-                let path = path.join(self.arena(), &[InlineTypePathSegment::MapValue]);
+                let id = self.context.ids.next();
                 SpecInner {
                     description: self.schema.description.as_deref(),
                     ty: self
                         .arena()
-                        .alloc(transform_with_context(self.context, path, schema)),
+                        .alloc(transform_with_context(self.context, id, schema)),
                 }
             }
             Some(AdditionalProperties::Bool(true)) => {
-                let path = path.join(self.arena(), &[InlineTypePathSegment::MapValue]);
+                let id = self.context.ids.next();
                 SpecInner {
                     description: self.schema.description.as_deref(),
                     ty: self
                         .arena()
-                        .alloc(SpecType::Inline(SpecInlineType::Any(path))),
+                        .alloc(SpecType::Inline(SpecInlineType::Any(id))),
                 }
             }
             _ => return None,
         };
 
+        let map_id = self.context.ids.next();
         let ty: &_ = self.arena().alloc(SpecType::from(SpecInlineType::Container(
-            path,
+            map_id,
             SpecContainer::Map(inner),
         )));
 
@@ -778,101 +675,40 @@ struct Other<'a> {
 /// A variant of an [`Other`] union.
 #[derive(Clone, Copy)]
 enum OtherVariant<'a> {
-    Primitive(TypeInfo<'a>, PrimitiveType),
-    Array(TypeInfo<'a>, SpecInner<'a>),
-    Map(TypeInfo<'a>, SpecInner<'a>),
-    Any(TypeInfo<'a>),
+    Primitive(PrimitiveType),
+    Array(SpecInner<'a>),
+    Map(SpecInner<'a>),
+    Any,
 }
 
 impl<'a> OtherVariant<'a> {
     /// Returns the name hint for this variant when used in an untagged union.
     fn hint(self) -> Option<UntaggedVariantNameHint> {
         Some(match self {
-            Self::Primitive(_, p) => UntaggedVariantNameHint::Primitive(p),
+            Self::Primitive(p) => UntaggedVariantNameHint::Primitive(p),
             Self::Array(..) => UntaggedVariantNameHint::Array,
             Self::Map(..) => UntaggedVariantNameHint::Map,
-            Self::Any(_) => return None,
+            Self::Any => return None,
         })
     }
 
-    /// Converts this variant to a [`SpecType`].
-    ///
-    /// This is used to unwrap variants for the single-variant
-    /// and untagged union cases.
-    fn to_type(self) -> SpecType<'a> {
+    /// Converts this variant to a [`SpecSchemaType`].
+    fn to_schema_type(self, info: SchemaTypeInfo<'a>) -> SpecSchemaType<'a> {
         match self {
-            Self::Primitive(name, p) => match name {
-                TypeInfo::Schema(info) => SpecSchemaType::Primitive(info, p).into(),
-                TypeInfo::Inline(path) => SpecInlineType::Primitive(path, p).into(),
-            },
-            Self::Array(name, inner) => {
-                let container = SpecContainer::Array(inner);
-                match name {
-                    TypeInfo::Schema(info) => SpecSchemaType::Container(info, container).into(),
-                    TypeInfo::Inline(path) => SpecInlineType::Container(path, container).into(),
-                }
-            }
-            Self::Map(name, inner) => {
-                let container = SpecContainer::Map(inner);
-                match name {
-                    TypeInfo::Schema(info) => SpecSchemaType::Container(info, container).into(),
-                    TypeInfo::Inline(path) => SpecInlineType::Container(path, container).into(),
-                }
-            }
-            Self::Any(name) => match name {
-                TypeInfo::Schema(info) => SpecSchemaType::Any(info).into(),
-                TypeInfo::Inline(path) => SpecInlineType::Any(path).into(),
-            },
+            Self::Primitive(p) => SpecSchemaType::Primitive(info, p),
+            Self::Array(inner) => SpecSchemaType::Container(info, SpecContainer::Array(inner)),
+            Self::Map(inner) => SpecSchemaType::Container(info, SpecContainer::Map(inner)),
+            Self::Any => SpecSchemaType::Any(info),
         }
     }
 
-    /// Converts this variant to an inline [`SpecType`].
-    ///
-    /// This is used to rewrite `[T, null]` unions as `Optional(T)`.
-    fn to_inline_type(self) -> SpecType<'a> {
+    /// Converts this variant to a [`SpecInlineType`].
+    fn to_inline_type(self, id: InlineTypeId) -> SpecInlineType<'a> {
         match self {
-            Self::Primitive(name, p) => {
-                let path = match name {
-                    TypeInfo::Schema(info) => InlineTypePath {
-                        root: InlineTypePathRoot::Type(info.name),
-                        segments: &[],
-                    },
-                    TypeInfo::Inline(path) => path,
-                };
-                SpecInlineType::Primitive(path, p).into()
-            }
-            Self::Array(name, inner) => {
-                let container = SpecContainer::Array(inner);
-                let path = match name {
-                    TypeInfo::Schema(info) => InlineTypePath {
-                        root: InlineTypePathRoot::Type(info.name),
-                        segments: &[],
-                    },
-                    TypeInfo::Inline(path) => path,
-                };
-                SpecInlineType::Container(path, container).into()
-            }
-            Self::Map(name, inner) => {
-                let container = SpecContainer::Map(inner);
-                let path = match name {
-                    TypeInfo::Schema(info) => InlineTypePath {
-                        root: InlineTypePathRoot::Type(info.name),
-                        segments: &[],
-                    },
-                    TypeInfo::Inline(path) => path,
-                };
-                SpecInlineType::Container(path, container).into()
-            }
-            Self::Any(name) => {
-                let path = match name {
-                    TypeInfo::Schema(info) => InlineTypePath {
-                        root: InlineTypePathRoot::Type(info.name),
-                        segments: &[],
-                    },
-                    TypeInfo::Inline(path) => path,
-                };
-                SpecInlineType::Any(path).into()
-            }
+            Self::Primitive(p) => SpecInlineType::Primitive(id, p),
+            Self::Array(inner) => SpecInlineType::Container(id, SpecContainer::Array(inner)),
+            Self::Map(inner) => SpecInlineType::Container(id, SpecContainer::Map(inner)),
+            Self::Any => SpecInlineType::Any(id),
         }
     }
 }

--- a/ploidy-core/src/ir/types/graph.rs
+++ b/ploidy-core/src/ir/types/graph.rs
@@ -3,7 +3,7 @@
 use petgraph::graph::NodeIndex;
 
 use super::{
-    Enum, InlineTypePath, PrimitiveType, SchemaTypeInfo, StructFieldName, UntaggedVariantNameHint,
+    Enum, InlineTypeId, PrimitiveType, SchemaTypeInfo, StructFieldName, UntaggedVariantNameHint,
     shape::{Operation, Parameter, ParameterInfo, Request, Response},
     spec::{SpecContainer, SpecInlineType, SpecSchemaType},
 };
@@ -35,28 +35,17 @@ pub enum GraphSchemaType<'a> {
 }
 
 impl<'a> GraphSchemaType<'a> {
+    /// Returns the [`SchemaTypeInfo`] for this schema type.
     #[inline]
-    pub fn name(&self) -> &'a str {
+    pub fn info(&self) -> SchemaTypeInfo<'a> {
         let (Self::Enum(info, ..)
         | Self::Struct(info, ..)
         | Self::Tagged(info, ..)
         | Self::Untagged(info, ..)
         | Self::Container(info, ..)
         | Self::Primitive(info, ..)
-        | Self::Any(info)) = self;
-        info.name
-    }
-
-    #[inline]
-    pub fn resource(&self) -> Option<&'a str> {
-        let (Self::Enum(info, ..)
-        | Self::Struct(info, ..)
-        | Self::Tagged(info, ..)
-        | Self::Untagged(info, ..)
-        | Self::Container(info, ..)
-        | Self::Primitive(info, ..)
-        | Self::Any(info)) = self;
-        info.resource
+        | Self::Any(info)) = *self;
+        info
     }
 }
 
@@ -93,55 +82,56 @@ impl<'a> From<SpecSchemaType<'a>> for GraphSchemaType<'a> {
 /// An inline type in the graph.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum GraphInlineType<'a> {
-    Enum(InlineTypePath<'a>, Enum<'a>),
-    Struct(InlineTypePath<'a>, GraphStruct<'a>),
-    Tagged(InlineTypePath<'a>, GraphTagged<'a>),
-    Untagged(InlineTypePath<'a>, GraphUntagged<'a>),
-    Container(InlineTypePath<'a>, GraphContainer<'a>),
-    Primitive(InlineTypePath<'a>, PrimitiveType),
-    Any(InlineTypePath<'a>),
+    Enum(InlineTypeId, Enum<'a>),
+    Struct(InlineTypeId, GraphStruct<'a>),
+    Tagged(InlineTypeId, GraphTagged<'a>),
+    Untagged(InlineTypeId, GraphUntagged<'a>),
+    Container(InlineTypeId, GraphContainer<'a>),
+    Primitive(InlineTypeId, PrimitiveType),
+    Any(InlineTypeId),
 }
 
 impl<'a> GraphInlineType<'a> {
+    /// Returns the [`InlineTypeId`] of this inline type.
     #[inline]
-    pub fn path(&self) -> &InlineTypePath<'a> {
-        let (Self::Enum(path, _)
-        | Self::Struct(path, _)
-        | Self::Tagged(path, _)
-        | Self::Untagged(path, _)
-        | Self::Container(path, _)
-        | Self::Primitive(path, _)
-        | Self::Any(path)) = self;
-        path
+    pub fn id(&self) -> InlineTypeId {
+        let (Self::Enum(id, _)
+        | Self::Struct(id, _)
+        | Self::Tagged(id, _)
+        | Self::Untagged(id, _)
+        | Self::Container(id, _)
+        | Self::Primitive(id, _)
+        | Self::Any(id)) = *self;
+        id
     }
 }
 
 impl<'a> From<SpecInlineType<'a>> for GraphInlineType<'a> {
     fn from(spec: SpecInlineType<'a>) -> Self {
         match spec {
-            SpecInlineType::Enum(path, e) => Self::Enum(path, e),
-            SpecInlineType::Struct(path, s) => Self::Struct(
-                path,
+            SpecInlineType::Enum(id, e) => Self::Enum(id, e),
+            SpecInlineType::Struct(id, s) => Self::Struct(
+                id,
                 GraphStruct {
                     description: s.description,
                 },
             ),
-            SpecInlineType::Tagged(path, t) => Self::Tagged(
-                path,
+            SpecInlineType::Tagged(id, t) => Self::Tagged(
+                id,
                 GraphTagged {
                     description: t.description,
                     tag: t.tag,
                 },
             ),
-            SpecInlineType::Untagged(path, u) => Self::Untagged(
-                path,
+            SpecInlineType::Untagged(id, u) => Self::Untagged(
+                id,
                 GraphUntagged {
                     description: u.description,
                 },
             ),
-            SpecInlineType::Container(path, c) => Self::Container(path, c.into()),
-            SpecInlineType::Primitive(path, p) => Self::Primitive(path, p),
-            SpecInlineType::Any(path) => Self::Any(path),
+            SpecInlineType::Container(id, c) => Self::Container(id, c.into()),
+            SpecInlineType::Primitive(id, p) => Self::Primitive(id, p),
+            SpecInlineType::Any(id) => Self::Any(id),
         }
     }
 }

--- a/ploidy-core/src/ir/types/mod.rs
+++ b/ploidy-core/src/ir/types/mod.rs
@@ -1,11 +1,17 @@
 //! Language-agnostic intermediate representation types.
 
 use std::{
-    cmp::Ordering,
+    cmp::Ordering as CmpOrdering,
+    fmt::{self, Display},
     hash::{Hash, Hasher},
+    num::NonZeroUsize,
+    ops::Deref,
+    sync::atomic::{AtomicUsize, Ordering as AtomicOrdering},
 };
 
-use crate::arena::Arena;
+use ref_cast::{RefCastCustom, ref_cast_custom};
+
+use crate::{arena::Arena, ir::views::TypeId};
 
 pub use self::{graph::*, spec::*};
 
@@ -13,36 +19,8 @@ mod graph;
 pub mod shape;
 mod spec;
 
-/// Metadata about a type in the dependency graph.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub enum TypeInfo<'a> {
-    Schema(SchemaTypeInfo<'a>),
-    Inline(InlineTypePath<'a>),
-}
-
-impl<'a> From<&'a str> for TypeInfo<'a> {
-    fn from(name: &'a str) -> Self {
-        Self::Schema(SchemaTypeInfo {
-            name,
-            resource: None,
-        })
-    }
-}
-
-impl<'a> From<SchemaTypeInfo<'a>> for TypeInfo<'a> {
-    fn from(info: SchemaTypeInfo<'a>) -> Self {
-        Self::Schema(info)
-    }
-}
-
-impl<'a> From<InlineTypePath<'a>> for TypeInfo<'a> {
-    fn from(path: InlineTypePath<'a>) -> Self {
-        Self::Inline(path)
-    }
-}
-
 /// Metadata for a named schema type.
-#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct SchemaTypeInfo<'a> {
     /// The name of the schema type.
     pub name: &'a str,
@@ -50,49 +28,104 @@ pub struct SchemaTypeInfo<'a> {
     pub resource: Option<&'a str>,
 }
 
-/// A path to an inline type.
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct InlineTypePath<'a> {
-    pub root: InlineTypePathRoot<'a>,
-    pub segments: &'a [InlineTypePathSegment<'a>],
-}
+/// Generates unique opaque identities for inline types.
+#[derive(Clone, Copy, Debug)]
+pub struct InlineTypeIds<'a>(&'a AtomicUsize);
 
-impl<'a> InlineTypePath<'a> {
-    /// Returns a new path with the suffix appended to the segments.
-    pub fn join(
-        self,
-        arena: &'a Arena,
-        suffix: &[InlineTypePathSegment<'a>],
-    ) -> InlineTypePath<'a> {
-        match suffix {
-            [] => self,
-            suffix => InlineTypePath {
-                root: self.root,
-                segments: arena.alloc_slice(self.segments.iter().chain(suffix).copied()),
-            },
-        }
+impl<'a> InlineTypeIds<'a> {
+    #[inline]
+    pub fn new(arena: &'a Arena) -> Self {
+        Self(arena.alloc_atomic(0))
+    }
+
+    #[inline]
+    pub fn next(&self) -> InlineTypeId {
+        InlineTypeId(self.0.fetch_add(1, AtomicOrdering::Relaxed))
     }
 }
 
+/// Opaque identity for an inline type.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub enum InlineTypePathRoot<'a> {
-    Resource(Option<&'a str>),
-    Type(&'a str),
+pub struct InlineTypeId(usize);
+
+/// An `operationId` from the OpenAPI spec.
+#[derive(Debug, Eq, Hash, Ord, PartialEq, PartialOrd, RefCastCustom)]
+#[repr(transparent)]
+pub struct OperationId(str);
+
+impl OperationId {
+    #[ref_cast_custom]
+    #[inline]
+    pub(in crate::ir) fn new(s: &str) -> &Self;
 }
 
-/// A segment of an inline type path.
+impl Deref for OperationId {
+    type Target = str;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl PartialEq<str> for OperationId {
+    #[inline]
+    fn eq(&self, other: &str) -> bool {
+        self.0 == *other
+    }
+}
+
+impl Display for OperationId {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// The root of an inline type path.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum InlineTypePathRoot<'a, S, O> {
+    Schema(S),
+    Operation {
+        resource: Option<&'a str>,
+        id: O,
+        usage: OperationUsage<'a>,
+    },
+}
+
+/// How an operation uses an inline type.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub enum InlineTypePathSegment<'a> {
-    Operation(&'a str),
-    Parameter(&'a str),
+pub enum OperationUsage<'a> {
+    /// A path parameter with the given name.
+    Path(&'a str),
+    /// A query parameter with the given name.
+    Query(&'a str),
+    /// The request body.
     Request,
+    /// The response body.
     Response,
-    Field(StructFieldName<'a>),
-    MapValue,
+}
+
+/// A segment in an inline type path.
+///
+/// Segments that name fields or variants also carry the parent type,
+/// because those names are scoped to that parent.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum InlineTypePathSegment<'a> {
+    /// Enters an inline type declared as a struct field.
+    Field(TypeId, StructFieldName<'a>),
+    /// Enters an inline type declared as a tagged union variant.
+    TaggedVariant(TypeId, &'a str),
+    /// Enters the nth untagged union variant, counted from 1 in declaration order.
+    UntaggedVariant(NonZeroUsize),
+    /// Enters the item type of an array.
     ArrayItem,
-    Variant(usize),
-    Parent(usize),
-    TaggedVariant(&'a str),
+    /// Enters the value type of a map.
+    MapValue,
+    /// Enters the inner type of an optional container.
+    Optional,
+    /// Enters the nth inherited parent, counted from 1 in declaration order.
+    Inherits(NonZeroUsize),
 }
 
 /// A primitive type in the dependency graph.
@@ -216,7 +249,7 @@ impl Hash for JsonF64 {
 
 impl Ord for JsonF64 {
     #[inline]
-    fn cmp(&self, other: &Self) -> Ordering {
+    fn cmp(&self, other: &Self) -> CmpOrdering {
         // JSON numbers can't be `NaN`, so `unwrap()` is OK.
         self.0.partial_cmp(&other.0).unwrap()
     }
@@ -231,7 +264,7 @@ impl PartialEq for JsonF64 {
 
 impl PartialOrd for JsonF64 {
     #[inline]
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+    fn partial_cmp(&self, other: &Self) -> Option<CmpOrdering> {
         Some(self.cmp(other))
     }
 }

--- a/ploidy-core/src/ir/types/spec.rs
+++ b/ploidy-core/src/ir/types/spec.rs
@@ -4,7 +4,7 @@
 use crate::parse::ComponentRef;
 
 use super::{
-    Enum, InlineTypePath, PrimitiveType, SchemaTypeInfo, StructFieldName, UntaggedVariantNameHint,
+    Enum, InlineTypeId, PrimitiveType, SchemaTypeInfo, StructFieldName, UntaggedVariantNameHint,
     shape::{Operation, Parameter, ParameterInfo, Request, Response},
 };
 
@@ -79,26 +79,27 @@ impl<'a> SpecSchemaType<'a> {
 /// An inline schema type with [`SpecType`] references.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum SpecInlineType<'a> {
-    Enum(InlineTypePath<'a>, Enum<'a>),
-    Struct(InlineTypePath<'a>, SpecStruct<'a>),
-    Tagged(InlineTypePath<'a>, SpecTagged<'a>),
-    Untagged(InlineTypePath<'a>, SpecUntagged<'a>),
-    Container(InlineTypePath<'a>, SpecContainer<'a>),
-    Primitive(InlineTypePath<'a>, PrimitiveType),
-    Any(InlineTypePath<'a>),
+    Enum(InlineTypeId, Enum<'a>),
+    Struct(InlineTypeId, SpecStruct<'a>),
+    Tagged(InlineTypeId, SpecTagged<'a>),
+    Untagged(InlineTypeId, SpecUntagged<'a>),
+    Container(InlineTypeId, SpecContainer<'a>),
+    Primitive(InlineTypeId, PrimitiveType),
+    Any(InlineTypeId),
 }
 
 impl<'a> SpecInlineType<'a> {
+    /// Returns the opaque identity for this inline type node.
     #[inline]
-    pub fn path(&self) -> &InlineTypePath<'a> {
-        let (Self::Enum(path, _)
-        | Self::Struct(path, _)
-        | Self::Tagged(path, _)
-        | Self::Untagged(path, _)
-        | Self::Container(path, _)
-        | Self::Primitive(path, _)
-        | Self::Any(path)) = self;
-        path
+    pub fn id(&self) -> InlineTypeId {
+        let (Self::Enum(id, _)
+        | Self::Struct(id, _)
+        | Self::Tagged(id, _)
+        | Self::Untagged(id, _)
+        | Self::Container(id, _)
+        | Self::Primitive(id, _)
+        | Self::Any(id)) = *self;
+        id
     }
 }
 

--- a/ploidy-core/src/ir/views/inline.rs
+++ b/ploidy-core/src/ir/views/inline.rs
@@ -17,32 +17,30 @@
 //! ```
 //!
 //! Here, `address` isn't a named schema in `components/schemas`, so Ploidy
-//! assigns it the inline path `Type("Pet") / Field("address")`. Each
-//! [`InlineTypeView`] variant pairs an OpenAPI type view with an
-//! [`InlineTypePath`] like this one, which codegen uses to derive a
-//! stable generated name.
+//! assigns it an [inline path] based on its position in the spec.
 //!
 //! [schema]: super::schema::SchemaTypeView
+//! [inline path]: super::path::InlineTypePathView
 
 use petgraph::graph::NodeIndex;
 
-use crate::ir::{InlineTypePath, graph::CookedGraph, types::GraphInlineType};
+use crate::ir::{InlineTypeId, graph::CookedGraph, types::GraphInlineType};
 
 use super::{
-    ViewNode, any::AnyView, container::ContainerView, enum_::EnumView, primitive::PrimitiveView,
-    struct_::StructView, tagged::TaggedView, untagged::UntaggedView,
+    ViewNode, any::AnyView, container::ContainerView, enum_::EnumView, path::InlineTypePathView,
+    primitive::PrimitiveView, struct_::StructView, tagged::TaggedView, untagged::UntaggedView,
 };
 
 /// A graph-aware view of an [inline type][GraphInlineType].
 #[derive(Debug)]
 pub enum InlineTypeView<'graph, 'a> {
-    Enum(InlineTypePath<'a>, EnumView<'graph, 'a>),
-    Struct(InlineTypePath<'a>, StructView<'graph, 'a>),
-    Tagged(InlineTypePath<'a>, TaggedView<'graph, 'a>),
-    Untagged(InlineTypePath<'a>, UntaggedView<'graph, 'a>),
-    Container(InlineTypePath<'a>, ContainerView<'graph, 'a>),
-    Primitive(InlineTypePath<'a>, PrimitiveView<'graph, 'a>),
-    Any(InlineTypePath<'a>, AnyView<'graph, 'a>),
+    Enum(InlineTypeId, EnumView<'graph, 'a>),
+    Struct(InlineTypeId, StructView<'graph, 'a>),
+    Tagged(InlineTypeId, TaggedView<'graph, 'a>),
+    Untagged(InlineTypeId, UntaggedView<'graph, 'a>),
+    Container(InlineTypeId, ContainerView<'graph, 'a>),
+    Primitive(InlineTypeId, PrimitiveView<'graph, 'a>),
+    Any(InlineTypeId, AnyView<'graph, 'a>),
 }
 
 impl<'graph, 'a> InlineTypeView<'graph, 'a> {
@@ -53,38 +51,33 @@ impl<'graph, 'a> InlineTypeView<'graph, 'a> {
         ty: GraphInlineType<'a>,
     ) -> Self {
         match ty {
-            GraphInlineType::Enum(path, ty) => Self::Enum(path, EnumView::new(cooked, index, ty)),
-            GraphInlineType::Struct(path, ty) => {
-                Self::Struct(path, StructView::new(cooked, index, ty))
+            GraphInlineType::Enum(id, ty) => Self::Enum(id, EnumView::new(cooked, index, ty)),
+            GraphInlineType::Struct(id, ty) => Self::Struct(id, StructView::new(cooked, index, ty)),
+            GraphInlineType::Tagged(id, ty) => Self::Tagged(id, TaggedView::new(cooked, index, ty)),
+            GraphInlineType::Untagged(id, ty) => {
+                Self::Untagged(id, UntaggedView::new(cooked, index, ty))
             }
-            GraphInlineType::Tagged(path, ty) => {
-                Self::Tagged(path, TaggedView::new(cooked, index, ty))
+            GraphInlineType::Container(id, container) => {
+                Self::Container(id, ContainerView::new(cooked, index, container))
             }
-            GraphInlineType::Untagged(path, ty) => {
-                Self::Untagged(path, UntaggedView::new(cooked, index, ty))
+            GraphInlineType::Primitive(id, p) => {
+                Self::Primitive(id, PrimitiveView::new(cooked, index, p))
             }
-            GraphInlineType::Container(path, container) => {
-                Self::Container(path, ContainerView::new(cooked, index, container))
-            }
-            GraphInlineType::Primitive(path, p) => {
-                Self::Primitive(path, PrimitiveView::new(cooked, index, p))
-            }
-            GraphInlineType::Any(path) => Self::Any(path, AnyView::new(cooked, index)),
+            GraphInlineType::Any(id) => Self::Any(id, AnyView::new(cooked, index)),
         }
     }
 
-    /// Returns the path describing where this inline type was found
-    /// in the spec.
+    /// Returns the path to this inline type.
     #[inline]
-    pub fn path(&self) -> InlineTypePath<'a> {
-        let (Self::Enum(path, _)
-        | Self::Struct(path, _)
-        | Self::Tagged(path, _)
-        | Self::Untagged(path, _)
-        | Self::Container(path, _)
-        | Self::Primitive(path, _)
-        | Self::Any(path, _)) = self;
-        *path
+    pub fn path(&self) -> InlineTypePathView<'graph, 'a> {
+        let (Self::Enum(id, _)
+        | Self::Struct(id, _)
+        | Self::Tagged(id, _)
+        | Self::Untagged(id, _)
+        | Self::Container(id, _)
+        | Self::Primitive(id, _)
+        | Self::Any(id, _)) = self;
+        InlineTypePathView::new(self.cooked(), *id)
     }
 }
 

--- a/ploidy-core/src/ir/views/inline.rs
+++ b/ploidy-core/src/ir/views/inline.rs
@@ -24,11 +24,14 @@
 
 use petgraph::graph::NodeIndex;
 
-use crate::ir::{InlineTypeId, graph::CookedGraph, types::GraphInlineType};
+use crate::ir::{
+    GraphType, InlineTypeId, InlineTypePathRoot, graph::CookedGraph, types::GraphInlineType,
+};
 
 use super::{
-    ViewNode, any::AnyView, container::ContainerView, enum_::EnumView, path::InlineTypePathView,
-    primitive::PrimitiveView, struct_::StructView, tagged::TaggedView, untagged::UntaggedView,
+    HasResource, ViewNode, any::AnyView, container::ContainerView, enum_::EnumView,
+    path::InlineTypePathView, primitive::PrimitiveView, struct_::StructView, tagged::TaggedView,
+    untagged::UntaggedView,
 };
 
 /// A graph-aware view of an [inline type][GraphInlineType].
@@ -70,14 +73,35 @@ impl<'graph, 'a> InlineTypeView<'graph, 'a> {
     /// Returns the path to this inline type.
     #[inline]
     pub fn path(&self) -> InlineTypePathView<'graph, 'a> {
-        let (Self::Enum(id, _)
+        InlineTypePathView::new(self.cooked(), self.id())
+    }
+
+    #[inline]
+    fn id(&self) -> InlineTypeId {
+        let &(Self::Enum(id, _)
         | Self::Struct(id, _)
         | Self::Tagged(id, _)
         | Self::Untagged(id, _)
         | Self::Container(id, _)
         | Self::Primitive(id, _)
         | Self::Any(id, _)) = self;
-        InlineTypePathView::new(self.cooked(), *id)
+        id
+    }
+}
+
+impl<'a> HasResource<'a> for InlineTypeView<'_, 'a> {
+    /// Returns the name of the resource that this inline type belongs to.
+    #[inline]
+    fn resource(&self) -> Option<&'a str> {
+        let cooked = self.cooked();
+        let id = self.id();
+        match cooked.metadata.paths[&id].root {
+            InlineTypePathRoot::Schema(index) => match cooked.graph[index] {
+                GraphType::Schema(schema) => schema.info().resource,
+                GraphType::Inline(_) => unreachable!(),
+            },
+            InlineTypePathRoot::Operation { resource, .. } => resource,
+        }
     }
 }
 

--- a/ploidy-core/src/ir/views/mod.rs
+++ b/ploidy-core/src/ir/views/mod.rs
@@ -28,7 +28,7 @@
 //! [`ExtendableView`] attaches a type-erased extension map to each view node.
 //! Codegen backends use this to store and retrieve arbitrary metadata.
 
-use std::{any::TypeId, fmt::Debug};
+use std::{any::TypeId as StdTypeId, fmt::Debug};
 
 use atomic_refcell::{AtomicRef, AtomicRefMut};
 use petgraph::{
@@ -48,6 +48,7 @@ pub mod enum_;
 pub mod inline;
 pub mod ir;
 pub mod operation;
+pub mod path;
 pub mod primitive;
 pub mod schema;
 pub mod struct_;
@@ -86,6 +87,22 @@ pub trait View<'graph, 'a: 'graph> {
     fn defaultable(&self) -> bool;
 }
 
+/// A uniquely identifiable graph type view.
+pub trait HasTypeId {
+    /// Returns an opaque identity for this type.
+    fn id(&self) -> TypeId;
+}
+
+/// Opaque identity for a type in a [`CookedGraph`].
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct TypeId(pub(in crate::ir) NodeIndex<usize>);
+
+/// A graph view that can belong to a resource.
+pub trait HasResource<'a> {
+    /// Returns the resource name, if this view belongs to one.
+    fn resource(&self) -> Option<&'a str>;
+}
+
 /// A view of a graph type with extended data.
 ///
 /// Codegen backends use extended data to decorate types with extra information.
@@ -101,6 +118,15 @@ pub trait ExtendableView<'graph, 'a: 'graph>: View<'graph, 'a> {
     fn extensions_mut(&mut self) -> &mut ViewExtensions<Self>
     where
         Self: Sized;
+}
+
+impl<'graph, 'a: 'graph, T> HasTypeId for T
+where
+    T: ViewNode<'graph, 'a>,
+{
+    fn id(&self) -> TypeId {
+        TypeId(self.index())
+    }
 }
 
 impl<'graph, 'a: 'graph, T> View<'graph, 'a> for T
@@ -231,7 +257,7 @@ impl<'a, X: internal::Extendable<'a>> ViewExtensions<X> {
     {
         AtomicRef::filter_map(self.0.ext(), |ext| {
             Some(
-                ext.get(&TypeId::of::<T>())?
+                ext.get(&StdTypeId::of::<T>())?
                     .as_ref()
                     .downcast_ref::<T>()
                     .unwrap(),
@@ -245,7 +271,7 @@ impl<'a, X: internal::Extendable<'a>> ViewExtensions<X> {
     pub fn insert<T: Send + Sync + 'static>(&mut self, value: T) -> Option<T> {
         self.0
             .ext_mut()
-            .insert(TypeId::of::<T>(), Box::new(value))
+            .insert(StdTypeId::of::<T>(), Box::new(value))
             .and_then(|old| *Extension::into_inner(old).downcast().unwrap())
     }
 }

--- a/ploidy-core/src/ir/views/operation.rs
+++ b/ploidy-core/src/ir/views/operation.rs
@@ -66,7 +66,7 @@ use crate::{
         graph::CookedGraph,
         types::{
             GraphOperation, GraphParameter, GraphParameterInfo, GraphRequest, GraphResponse,
-            GraphType, ParameterStyle,
+            GraphType, OperationId, ParameterStyle,
         },
     },
     parse::{
@@ -75,7 +75,7 @@ use crate::{
     },
 };
 
-use super::{View, inline::InlineTypeView, ir::TypeView};
+use super::{HasResource, View, inline::InlineTypeView, ir::TypeView};
 
 /// A graph-aware view of an [operation][GraphOperation].
 #[derive(Debug)]
@@ -95,8 +95,8 @@ impl<'graph, 'a> OperationView<'graph, 'a> {
 
     /// Returns the `operationId`.
     #[inline]
-    pub fn id(&self) -> &'a str {
-        self.op.id
+    pub fn id(&self) -> &'a OperationId {
+        OperationId::new(self.op.id)
     }
 
     /// Returns the HTTP method.
@@ -142,11 +142,13 @@ impl<'graph, 'a> OperationView<'graph, 'a> {
             GraphResponse::Json(index) => ResponseView::Json(TypeView::new(self.cooked, *index)),
         })
     }
+}
 
+impl<'a> HasResource<'a> for OperationView<'_, 'a> {
     /// Returns the resource name that this operation declares
     /// in its `x-resource-name` extension field.
     #[inline]
-    pub fn resource(&self) -> Option<&'a str> {
+    fn resource(&self) -> Option<&'a str> {
         self.op.resource
     }
 }

--- a/ploidy-core/src/ir/views/path.rs
+++ b/ploidy-core/src/ir/views/path.rs
@@ -1,0 +1,111 @@
+//! Inline type paths.
+
+use std::num::NonZeroUsize;
+
+use itertools::Itertools;
+use petgraph::visit::EdgeRef;
+
+use crate::ir::{
+    InlineTypeId, InlineTypePathRoot, InlineTypePathSegment, OperationId,
+    graph::{CookedGraph, GraphEdge},
+    types::{GraphContainer, GraphInlineType, GraphSchemaType, GraphType, VariantMeta},
+};
+
+use super::TypeId;
+
+/// A view of a canonical inline type path.
+#[derive(Clone, Copy, Debug)]
+pub struct InlineTypePathView<'graph, 'a> {
+    cooked: &'graph CookedGraph<'a>,
+    id: InlineTypeId,
+}
+
+impl<'graph, 'a> InlineTypePathView<'graph, 'a> {
+    #[inline]
+    pub(in crate::ir) fn new(cooked: &'graph CookedGraph<'a>, id: InlineTypeId) -> Self {
+        Self { cooked, id }
+    }
+
+    /// Returns the root of this path.
+    #[inline]
+    pub fn root(&self) -> InlineTypePathRoot<'a, TypeId, &'a OperationId> {
+        match self.cooked.metadata.paths[&self.id].root {
+            InlineTypePathRoot::Schema(index) => InlineTypePathRoot::Schema(TypeId(index)),
+            InlineTypePathRoot::Operation {
+                id,
+                resource,
+                usage,
+            } => InlineTypePathRoot::Operation {
+                id: OperationId::new(id),
+                resource,
+                usage,
+            },
+        }
+    }
+
+    /// Returns an iterator over this path's segments.
+    #[inline]
+    pub fn segments(&self) -> impl Iterator<Item = InlineTypePathSegment<'a>> + use<'graph, 'a> {
+        let cooked = self.cooked;
+        cooked.metadata.paths[&self.id]
+            .edges
+            .iter()
+            .filter_map(|&index| {
+                let (from, to) = cooked.graph.edge_endpoints(index)?;
+                Some(match cooked.graph[index] {
+                    GraphEdge::Field { meta, .. } => {
+                        InlineTypePathSegment::Field(TypeId(from), meta.name)
+                    }
+                    GraphEdge::Contains => {
+                        let source = match cooked.graph[from] {
+                            GraphType::Schema(GraphSchemaType::Container(_, container)) => {
+                                container
+                            }
+                            GraphType::Inline(GraphInlineType::Container(_, container)) => {
+                                container
+                            }
+                            _ => return None,
+                        };
+                        match source {
+                            GraphContainer::Array { .. } => InlineTypePathSegment::ArrayItem,
+                            GraphContainer::Map { .. } => InlineTypePathSegment::MapValue,
+                            GraphContainer::Optional { .. } => InlineTypePathSegment::Optional,
+                        }
+                    }
+                    GraphEdge::Variant(VariantMeta::Tagged(m)) => {
+                        InlineTypePathSegment::TaggedVariant(TypeId(from), m.name)
+                    }
+                    GraphEdge::Variant(VariantMeta::Untagged(_)) => {
+                        let (index, _) = cooked
+                            .graph
+                            .edges(from)
+                            .filter(|e| matches!(e.weight(), GraphEdge::Variant(_)))
+                            .find_position(|e| e.target() == to)?;
+                        InlineTypePathSegment::UntaggedVariant(
+                            NonZeroUsize::new(index + 1).unwrap(),
+                        )
+                    }
+                    GraphEdge::Inherits { .. } => {
+                        let (index, _) = cooked
+                            .graph
+                            .edges(from)
+                            .filter(|e| matches!(e.weight(), GraphEdge::Inherits { .. }))
+                            .find_position(|e| e.target() == to)?;
+                        InlineTypePathSegment::Inherits(NonZeroUsize::new(index + 1).unwrap())
+                    }
+                })
+            })
+    }
+
+    /// Returns the number of edge indices in the path.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.cooked.metadata.paths[&self.id].edges.len()
+    }
+
+    /// Returns `true` if the path has no edges.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.cooked.metadata.paths[&self.id].edges.is_empty()
+    }
+}

--- a/ploidy-core/src/ir/views/schema.rs
+++ b/ploidy-core/src/ir/views/schema.rs
@@ -10,8 +10,8 @@ use petgraph::graph::NodeIndex;
 use crate::ir::{SchemaTypeInfo, graph::CookedGraph, types::GraphSchemaType};
 
 use super::{
-    ViewNode, any::AnyView, container::ContainerView, enum_::EnumView, primitive::PrimitiveView,
-    struct_::StructView, tagged::TaggedView, untagged::UntaggedView,
+    HasResource, ViewNode, any::AnyView, container::ContainerView, enum_::EnumView,
+    primitive::PrimitiveView, struct_::StructView, tagged::TaggedView, untagged::UntaggedView,
 };
 
 /// A graph-aware view of a [schema type][GraphSchemaType].
@@ -54,17 +54,22 @@ impl<'graph, 'a> SchemaTypeView<'graph, 'a> {
         }
     }
 
+    #[inline]
+    pub fn info(&self) -> SchemaTypeInfo<'a> {
+        let &(Self::Enum(info, ..)
+        | Self::Struct(info, ..)
+        | Self::Tagged(info, ..)
+        | Self::Untagged(info, ..)
+        | Self::Container(info, ..)
+        | Self::Primitive(info, ..)
+        | Self::Any(info, ..)) = self;
+        info
+    }
+
     /// Returns the schema name from `components/schemas`.
     #[inline]
     pub fn name(&self) -> &'a str {
-        let (Self::Enum(SchemaTypeInfo { name, .. }, ..)
-        | Self::Struct(SchemaTypeInfo { name, .. }, ..)
-        | Self::Tagged(SchemaTypeInfo { name, .. }, ..)
-        | Self::Untagged(SchemaTypeInfo { name, .. }, ..)
-        | Self::Container(SchemaTypeInfo { name, .. }, ..)
-        | Self::Primitive(SchemaTypeInfo { name, .. }, ..)
-        | Self::Any(SchemaTypeInfo { name, .. }, ..)) = self;
-        name
+        self.info().name
     }
 
     /// Returns whether this type transitively depends on `other`.
@@ -75,11 +80,13 @@ impl<'graph, 'a> SchemaTypeView<'graph, 'a> {
             .closure
             .depends_on(self.index(), other.index())
     }
+}
 
+impl<'a> HasResource<'a> for SchemaTypeView<'_, 'a> {
     /// Returns the resource name that this schema type declares
     /// in its `x-resourceId` extension field.
     #[inline]
-    pub fn resource(&self) -> Option<&'a str> {
+    fn resource(&self) -> Option<&'a str> {
         let (&Self::Enum(SchemaTypeInfo { resource, .. }, ..)
         | &Self::Struct(SchemaTypeInfo { resource, .. }, ..)
         | &Self::Tagged(SchemaTypeInfo { resource, .. }, ..)

--- a/ploidy-core/src/lib.rs
+++ b/ploidy-core/src/lib.rs
@@ -46,8 +46,8 @@
 //!   in the OpenAPI document. Each carries a [`SchemaTypeInfo`] with
 //!   the schema name and additional metadata.
 //! - **Inline types** are anonymous schemas nested inside other types.
-//!   Each carries an [`InlineTypePath`](ir::InlineTypePath) that
-//!   encodes the type's position in the document.
+//!   Each carries an [`InlineTypeId`](ir::InlineTypeId) for identity,
+//!   and a [canonical path](ir::InlineTypePathView).
 //!
 //! The two kinds carry different metadata, but share the same structural
 //! shapes: [any], [containers], [enums], [primitives], [structs],

--- a/ploidy/src/main.rs
+++ b/ploidy/src/main.rs
@@ -78,7 +78,7 @@ fn main() -> Result<()> {
 
             let counts = graph
                 .operations()
-                .into_grouping_map_by(|op| op.resource())
+                .into_grouping_map_by(|op| graph.resource_for(op))
                 .fold(0, |count, _, _| count + 1);
             println!(
                 "Generating {} client methods across {} resources...",


### PR DESCRIPTION
This is a mega-refactor that:

* Replaces inline path construction during IR lowering with opaque inline type IDs.
* Changes codegen to uniquify generated names up front, then look up those names during rendering.
* Fixes uniquification for pathological cases—empty names, numbers, and numeric suffixes—so they don't collide.

The big change is that we build inline type paths during cooking, not lowering. Since we already encode type relationships as graph edges, we can follow those edges from root to leaf to find the canonical path for each inline type. That makes the paths handle graph rewrites properly, and means we can use uniquified names in path segments.

`CodegenGraph` now uniquifies all names up front, so (1) inline types get names that match their uniquified owning types and operations, and (2) we avoid nasty collisions in inline type names.

### Breaking changes in generated code

Anonymous inline types might get different names after this PR. Operation inline types specifically now include their usage in the generated name, so query, path, request, and response type names no longer collide. For example, a query parameter named `filter` for an operation named `getItems` becomes `GetItemsQueryFilter`, and the same parameter in the path becomes `GetItemsPathFilter`. Before, both would be named `GetItemsFilter`, and collide.

Nullable and optional inlines get new names, because codegen now correctly ignores optional container segments when building inline type names. We didn't handle this consistently in the IR lowering before, especially when rewriting `null` variants.

Resource feature and module names are now correctly uniquified. In particular, a resource literally named `default` no longer unifies with Cargo's `default` feature, and is instead emitted as a uniquified name like `default2`.