### PR TITLE
fix(array): Widen element types for prefixItems, unevaluatedItems, contains

### DIFF
--- a/ploidy-core/src/ir/tests/transform.rs
+++ b/ploidy-core/src/ir/tests/transform.rs
@@ -3336,3 +3336,235 @@ fn test_optional_field_container_description_is_not_parent_schema() {
         )),
     );
 }
+
+#[test]
+fn test_array_with_prefix_items_widens_element_type() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+         title: Test API
+         version: 1.0.0
+    "})
+    .unwrap();
+    let schema: Schema = serde_saphyr::from_str(indoc::indoc! {"
+        type: array
+        items:
+         type: string
+        prefixItems:
+         - type: boolean
+         - type: number
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let result = transform(&arena, &doc, "MixedArray", &schema);
+
+    assert_matches!(
+        result,
+        SpecType::Schema(SpecSchemaType::Container(
+            SchemaTypeInfo {
+                name: "MixedArray",
+                ..
+            },
+            SpecContainer::Array(SpecInner {
+                ty: SpecType::Schema(SpecSchemaType::Untagged(
+                    _,
+                    SpecUntagged { variants: _, .. }
+                )),
+                ..
+            }),
+        )),
+    );
+}
+
+#[test]
+fn test_array_with_contains_widens_element_type() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+         title: Test API
+         version: 1.0.0
+    "})
+    .unwrap();
+    let schema: Schema = serde_saphyr::from_str(indoc::indoc! {"
+        type: array
+        items:
+         type: string
+        contains:
+         type: object
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let result = transform(&arena, &doc, "ArrayWithContains", &schema);
+
+    assert_matches!(
+        result,
+        SpecType::Schema(SpecSchemaType::Container(
+            SchemaTypeInfo {
+                name: "ArrayWithContains",
+                ..
+            },
+            SpecContainer::Array(SpecInner {
+                ty: SpecType::Schema(SpecSchemaType::Untagged(
+                    _,
+                    SpecUntagged { variants: _, .. }
+                )),
+                ..
+            }),
+        )),
+    );
+}
+
+#[test]
+fn test_array_with_unevaluated_items_true_widens_element_type() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+         title: Test API
+         version: 1.0.0
+    "})
+    .unwrap();
+    let schema: Schema = serde_saphyr::from_str(indoc::indoc! {"
+        type: array
+        items:
+         type: string
+        unevaluatedItems: true
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let result = transform(&arena, &doc, "ArrayWithUnevaluated", &schema);
+
+    assert_matches!(
+        result,
+        SpecType::Schema(SpecSchemaType::Container(
+            SchemaTypeInfo {
+                name: "ArrayWithUnevaluated",
+                ..
+            },
+            SpecContainer::Array(SpecInner {
+                ty: SpecType::Schema(SpecSchemaType::Untagged(
+                    _,
+                    SpecUntagged { variants: _, .. }
+                )),
+                ..
+            }),
+        )),
+    );
+}
+
+#[test]
+fn test_array_with_unevaluated_items_false_no_widening() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+         title: Test API
+         version: 1.0.0
+    "})
+    .unwrap();
+    let schema: Schema = serde_saphyr::from_str(indoc::indoc! {"
+        type: array
+        items:
+         type: string
+        unevaluatedItems: false
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let result = transform(&arena, &doc, "ArrayNoExtra", &schema);
+
+    assert_matches!(
+        result,
+        SpecType::Schema(SpecSchemaType::Container(
+            SchemaTypeInfo {
+                name: "ArrayNoExtra",
+                ..
+            },
+            SpecContainer::Array(SpecInner {
+                ty: SpecType::Inline(SpecInlineType::Primitive(_, PrimitiveType::String)),
+                ..
+            }),
+        )),
+    );
+}
+
+#[test]
+fn test_array_with_all_keywords_creates_union() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+         title: Test API
+         version: 1.0.0
+    "})
+    .unwrap();
+    let schema: Schema = serde_saphyr::from_str(indoc::indoc! {"
+        type: array
+        items:
+         type: string
+        prefixItems:
+         - type: boolean
+        contains:
+         type: number
+        unevaluatedItems: true
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let result = transform(&arena, &doc, "FullArray", &schema);
+
+    assert_matches!(
+        result,
+        SpecType::Schema(SpecSchemaType::Container(
+            SchemaTypeInfo {
+                name: "FullArray",
+                ..
+            },
+            SpecContainer::Array(SpecInner {
+                ty: SpecType::Schema(SpecSchemaType::Untagged(
+                    _,
+                    SpecUntagged { variants: _, .. }
+                )),
+                ..
+            }),
+        )),
+    );
+}
+
+#[test]
+fn test_array_with_prefix_items_only_creates_union() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+         title: Test API
+         version: 1.0.0
+    "})
+    .unwrap();
+    let schema: Schema = serde_saphyr::from_str(indoc::indoc! {"
+        type: array
+        prefixItems:
+         - type: string
+         - type: number
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let result = transform(&arena, &doc, "TupleArray", &schema);
+
+    assert_matches!(
+        result,
+        SpecType::Schema(SpecSchemaType::Container(
+            SchemaTypeInfo {
+                name: "TupleArray",
+                ..
+            },
+            SpecContainer::Array(SpecInner {
+                ty: SpecType::Schema(SpecSchemaType::Untagged(
+                    _,
+                    SpecUntagged { variants: _, .. }
+                )),
+                ..
+            }),
+        )),
+    );
+}

--- a/ploidy-core/src/ir/transform.rs
+++ b/ploidy-core/src/ir/transform.rs
@@ -413,21 +413,174 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
                 (Ty::Boolean, _) => OtherVariant::Primitive(PrimitiveType::Bool),
 
                 (Ty::Array, _) => {
-                    let items = match &self.schema.items {
-                        Some(RefOrSchema::Ref(r)) => SpecType::Ref(r),
-                        Some(RefOrSchema::Inline(schema)) => {
-                            let id = self.context.ids.next();
-                            transform_with_context(self.context, id, schema)
+                    // Check if we need to widen the array element type due to
+                    // prefixItems, unevaluatedItems, or contains.
+                    let has_prefix_items = self.schema.prefix_items.is_some()
+                        && !self.schema.prefix_items.as_ref().unwrap().is_empty();
+                    let has_unevaluated_items = self.schema.unevaluated_items.is_some();
+                    let has_contains = self.schema.contains.is_some();
+
+                    if has_prefix_items || has_unevaluated_items || has_contains {
+                        // Collect all possible element types.
+                        let mut element_types: Vec<SpecType<'a>> = Vec::new();
+
+                        // Add items schema.
+                        if let Some(items) = &self.schema.items {
+                            let ty = match items {
+                                RefOrSchema::Ref(r) => SpecType::Ref(r),
+                                RefOrSchema::Inline(schema) => {
+                                    let id = self.context.ids.next();
+                                    transform_with_context(self.context, id, schema)
+                                }
+                            };
+                            element_types.push(ty);
                         }
-                        None => {
-                            let id = self.context.ids.next();
-                            SpecInlineType::Any(id).into()
+
+                        // Add prefix items schemas.
+                        if let Some(prefix_items) = &self.schema.prefix_items {
+                            for item_schema in prefix_items {
+                                let ty = match item_schema {
+                                    RefOrSchema::Ref(r) => SpecType::Ref(r),
+                                    RefOrSchema::Inline(schema) => {
+                                        let id = self.context.ids.next();
+                                        transform_with_context(self.context, id, schema)
+                                    }
+                                };
+                                element_types.push(ty);
+                            }
                         }
-                    };
-                    OtherVariant::Array(SpecInner {
-                        description: self.schema.description.as_deref(),
-                        ty: self.arena().alloc(items),
-                    })
+
+                        // Add contains schema.
+                        if let Some(contains) = &self.schema.contains {
+                            let ty = match contains {
+                                RefOrSchema::Ref(r) => SpecType::Ref(r),
+                                RefOrSchema::Inline(schema) => {
+                                    let id = self.context.ids.next();
+                                    transform_with_context(self.context, id, schema)
+                                }
+                            };
+                            element_types.push(ty);
+                        }
+
+                        // Add unevaluated items.
+                        if let Some(unevaluated_items) = &self.schema.unevaluated_items {
+                            match unevaluated_items {
+                                crate::parse::UnevaluatedItems::Bool(true) => {
+                                    let id = self.context.ids.next();
+                                    element_types.push(SpecInlineType::Any(id).into());
+                                }
+                                crate::parse::UnevaluatedItems::RefOrSchema(RefOrSchema::Ref(
+                                    r,
+                                )) => {
+                                    element_types.push(SpecType::Ref(r));
+                                }
+                                crate::parse::UnevaluatedItems::RefOrSchema(
+                                    RefOrSchema::Inline(schema),
+                                ) => {
+                                    let id = self.context.ids.next();
+                                    element_types.push(transform_with_context(
+                                        self.context,
+                                        id,
+                                        schema,
+                                    ));
+                                }
+                                crate::parse::UnevaluatedItems::Bool(false) => {
+                                    // false means no additional items allowed, skip.
+                                }
+                            }
+                        }
+
+                        // Deduplicate element types by converting to string representation.
+                        // This is a simple approach; we keep types in order of appearance.
+                        let mut seen = std::collections::HashSet::new();
+                        let mut unique_types = Vec::new();
+                        for ty in element_types {
+                            let key = format!("{:?}", ty);
+                            if seen.insert(key) {
+                                unique_types.push(ty);
+                            }
+                        }
+
+                        // If no unique types were collected, default to Any.
+                        if unique_types.is_empty() {
+                            let id = self.context.ids.next();
+                            unique_types.push(SpecInlineType::Any(id).into());
+                        }
+
+                        // Create an untagged union of element types if we have multiple types.
+                        let items = if unique_types.len() == 1 {
+                            unique_types.into_iter().next().unwrap()
+                        } else {
+                            let variants = unique_types
+                                .into_iter()
+                                .enumerate()
+                                .map(|(index, ty)| {
+                                    let hint = match ty {
+                                        SpecType::Schema(SpecSchemaType::Primitive(_, p))
+                                        | SpecType::Inline(SpecInlineType::Primitive(_, p)) => {
+                                            UntaggedVariantNameHint::Primitive(p)
+                                        }
+                                        SpecType::Schema(SpecSchemaType::Container(
+                                            _,
+                                            SpecContainer::Array(_),
+                                        ))
+                                        | SpecType::Inline(SpecInlineType::Container(
+                                            _,
+                                            SpecContainer::Array(_),
+                                        )) => UntaggedVariantNameHint::Array,
+                                        SpecType::Schema(SpecSchemaType::Container(
+                                            _,
+                                            SpecContainer::Map(_),
+                                        ))
+                                        | SpecType::Inline(SpecInlineType::Container(
+                                            _,
+                                            SpecContainer::Map(_),
+                                        )) => UntaggedVariantNameHint::Map,
+                                        _ => UntaggedVariantNameHint::Index(index + 1),
+                                    };
+                                    SpecUntaggedVariant::Some(hint, self.arena().alloc(ty))
+                                })
+                                .collect_vec();
+
+                            let untagged = SpecUntagged {
+                                description: self.schema.description.as_deref(),
+                                variants: self.arena().alloc_slice_copy(&variants),
+                                fields: self
+                                    .arena()
+                                    .alloc_slice(std::iter::empty::<SpecStructField<'a>>()),
+                            };
+                            match self.name {
+                                TypeInfo::Schema(info) => {
+                                    SpecSchemaType::Untagged(info, untagged).into()
+                                }
+                                TypeInfo::Inline(id) => {
+                                    SpecInlineType::Untagged(id, untagged).into()
+                                }
+                            }
+                        };
+
+                        OtherVariant::Array(SpecInner {
+                            description: self.schema.description.as_deref(),
+                            ty: self.arena().alloc(items),
+                        })
+                    } else {
+                        // Original logic when no widening keywords are present.
+                        let items = match &self.schema.items {
+                            Some(RefOrSchema::Ref(r)) => SpecType::Ref(r),
+                            Some(RefOrSchema::Inline(schema)) => {
+                                let id = self.context.ids.next();
+                                transform_with_context(self.context, id, schema)
+                            }
+                            None => {
+                                let id = self.context.ids.next();
+                                SpecInlineType::Any(id).into()
+                            }
+                        };
+                        OtherVariant::Array(SpecInner {
+                            description: self.schema.description.as_deref(),
+                            ty: self.arena().alloc(items),
+                        })
+                    }
                 }
 
                 (Ty::Object, _) => {

--- a/ploidy-core/src/parse/types.rs
+++ b/ploidy-core/src/parse/types.rs
@@ -370,6 +370,14 @@ pub enum AdditionalProperties {
     RefOrSchema(RefOrSchema),
 }
 
+#[derive(Clone, Debug, Deserialize, JsonPointee, JsonPointerTarget)]
+#[serde(untagged)]
+#[ploidy(pointer(untagged))]
+pub enum UnevaluatedItems {
+    Bool(bool),
+    RefOrSchema(RefOrSchema),
+}
+
 /// An OpenAPI schema definition.
 #[derive(Debug, Clone, Default, Deserialize, JsonPointee, JsonPointerTarget)]
 #[serde(rename_all = "camelCase")]
@@ -396,6 +404,12 @@ pub struct Schema {
     // Array items.
     #[serde(default)]
     pub items: Option<RefOrSchema>,
+    #[serde(default)]
+    pub prefix_items: Option<Vec<RefOrSchema>>,
+    #[serde(default)]
+    pub unevaluated_items: Option<UnevaluatedItems>,
+    #[serde(default)]
+    pub contains: Option<RefOrSchema>,
 
     // Enum variants.
     #[serde(rename = "enum", default)]


### PR DESCRIPTION
## Description

Fixes #82

Arrays with `prefixItems`, `unevaluatedItems` or `contains` keywords now correctly widen their element type to a union that includes all possible element types, rather than only using the `items` schema.

## Changes

- **Parse Layer**: Added `prefixItems`, `unevaluatedItems` and `contains` fields to the `Schema` struct
- **IR Transform**: Modified array handling in the `other()` method to detect and process widening keywords
- **Type Widening**: Creates an `#[serde(untagged)]` union of all possible element types when multiple types are detected
- **Backward Compatibility**: Preserves original behavior when no widening keywords are present

## How It Works

When an array uses any of these keywords, ploidy now:
1. Collects element types from: `items`, all `prefixItems`, `contains`, and `unevaluatedItems`
2. Deduplicates the collected types
3. Creates an untagged union if multiple types exist
4. Single-type arrays remain simple (no unnecessary union wrapper)

### Example

**Before (incorrect type):**
```rust
// Schema: items: string + prefixItems: [boolean, number]
Vec<String>  // Only considers items schema
```
After (correct type):
```rust
// Schema: items: string + prefixItems: [boolean, number]
Vec<OneOfStringBooleanNumber>  // Includes all possible types
```
Testing

Added 6 comprehensive tests covering:

- Arrays with prefixItems
- Arrays with contains
- Arrays with unevaluatedItems: true (allows any type)
- Arrays with unevaluatedItems: false (no widening)
- Arrays with all keywords combined
- Tuple-like arrays (prefixItems only)

All tests pass: 318+ tests in the workspace...