### PR TITLE
fix(object): Widen additionalProperties for patternProperties and unevaluatedProperties

### DIFF
--- a/ploidy-core/src/ir/tests/transform.rs
+++ b/ploidy-core/src/ir/tests/transform.rs
@@ -3336,3 +3336,249 @@ fn test_optional_field_container_description_is_not_parent_schema() {
         )),
     );
 }
+
+#[test]
+fn test_object_with_pattern_properties_widens_value_type() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test API
+          version: 1.0.0
+    "})
+    .unwrap();
+    let schema: Schema = serde_saphyr::from_str(indoc::indoc! {"
+        type: object
+        additionalProperties:
+          type: string
+        patternProperties:
+          '^S_': 
+            type: number
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let result = transform(&arena, &doc, "PatternObj", &schema);
+
+    assert_matches!(
+        result,
+        SpecType::Schema(SpecSchemaType::Struct(
+            SchemaTypeInfo {
+                name: "PatternObj",
+                ..
+            },
+            SpecStruct {
+                fields: [SpecStructField {
+                    name: StructFieldName::Hint(StructFieldNameHint::AdditionalProperties),
+                    ty: SpecType::Inline(SpecInlineType::Container(
+                        _,
+                        SpecContainer::Map(SpecInner {
+                            ty: SpecType::Schema(SpecSchemaType::Untagged(
+                                _,
+                                SpecUntagged { variants: _, .. }
+                            )),
+                            ..
+                        }),
+                    )),
+                    ..
+                }],
+                ..
+            },
+        )),
+    );
+}
+
+#[test]
+fn test_object_with_unevaluated_properties_widens_value_type() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test API
+          version: 1.0.0
+    "})
+    .unwrap();
+    let schema: Schema = serde_saphyr::from_str(indoc::indoc! {"
+        type: object
+        additionalProperties:
+          type: string
+        unevaluatedProperties:
+          type: object
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let result = transform(&arena, &doc, "UnevalObj", &schema);
+
+    assert_matches!(
+        result,
+        SpecType::Schema(SpecSchemaType::Struct(
+            SchemaTypeInfo {
+                name: "UnevalObj",
+                ..
+            },
+            SpecStruct {
+                fields: [SpecStructField {
+                    name: StructFieldName::Hint(StructFieldNameHint::AdditionalProperties),
+                    ty: SpecType::Inline(SpecInlineType::Container(
+                        _,
+                        SpecContainer::Map(SpecInner {
+                            ty: SpecType::Schema(SpecSchemaType::Untagged(
+                                _,
+                                SpecUntagged { variants: _, .. }
+                            )),
+                            ..
+                        }),
+                    )),
+                    ..
+                }],
+                ..
+            },
+        )),
+    );
+}
+
+#[test]
+fn test_object_with_unevaluated_properties_true_no_widening() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test API
+          version: 1.0.0
+    "})
+    .unwrap();
+    let schema: Schema = serde_saphyr::from_str(indoc::indoc! {"
+        type: object
+        additionalProperties:
+          type: string
+        unevaluatedProperties: true
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let result = transform(&arena, &doc, "UnevalTrue", &schema);
+
+    assert_matches!(
+        result,
+        SpecType::Schema(SpecSchemaType::Struct(
+            SchemaTypeInfo {
+                name: "UnevalTrue",
+                ..
+            },
+            SpecStruct {
+                fields: [SpecStructField {
+                    name: StructFieldName::Hint(StructFieldNameHint::AdditionalProperties),
+                    ty: SpecType::Inline(SpecInlineType::Container(
+                        _,
+                        SpecContainer::Map(SpecInner {
+                            ty: SpecType::Inline(SpecInlineType::Any(_)),
+                            ..
+                        }),
+                    )),
+                    ..
+                }],
+                ..
+            },
+        )),
+    );
+}
+
+#[test]
+fn test_object_with_pattern_properties_only() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test API
+          version: 1.0.0
+    "})
+    .unwrap();
+    let schema: Schema = serde_saphyr::from_str(indoc::indoc! {"
+        type: object
+        patternProperties:
+          '^num_':
+            type: number
+          '^str_':
+            type: string
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let result = transform(&arena, &doc, "PatternOnly", &schema);
+
+    assert_matches!(
+        result,
+        SpecType::Schema(SpecSchemaType::Struct(
+            SchemaTypeInfo {
+                name: "PatternOnly",
+                ..
+            },
+            SpecStruct {
+                fields: [SpecStructField {
+                    name: StructFieldName::Hint(StructFieldNameHint::AdditionalProperties),
+                    ty: SpecType::Inline(SpecInlineType::Container(
+                        _,
+                        SpecContainer::Map(SpecInner {
+                            ty: SpecType::Schema(SpecSchemaType::Untagged(
+                                _,
+                                SpecUntagged { variants: _, .. }
+                            )),
+                            ..
+                        }),
+                    )),
+                    ..
+                }],
+                ..
+            },
+        )),
+    );
+}
+
+#[test]
+fn test_object_with_all_property_keywords() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test API
+          version: 1.0.0
+    "})
+    .unwrap();
+    let schema: Schema = serde_saphyr::from_str(indoc::indoc! {"
+        type: object
+        additionalProperties:
+          type: string
+        patternProperties:
+          '^num_':
+            type: number
+        unevaluatedProperties:
+          type: boolean
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let result = transform(&arena, &doc, "AllKeywords", &schema);
+
+    assert_matches!(
+        result,
+        SpecType::Schema(SpecSchemaType::Struct(
+            SchemaTypeInfo {
+                name: "AllKeywords",
+                ..
+            },
+            SpecStruct {
+                fields: [SpecStructField {
+                    name: StructFieldName::Hint(StructFieldNameHint::AdditionalProperties),
+                    ty: SpecType::Inline(SpecInlineType::Container(
+                        _,
+                        SpecContainer::Map(SpecInner {
+                            ty: SpecType::Schema(SpecSchemaType::Untagged(
+                                _,
+                                SpecUntagged { variants: _, .. }
+                            )),
+                            ..
+                        }),
+                    )),
+                    ..
+                }],
+                ..
+            },
+        )),
+    );
+}

--- a/ploidy-core/src/ir/transform.rs
+++ b/ploidy-core/src/ir/transform.rs
@@ -352,7 +352,15 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
     }
 
     fn try_struct(self) -> Result<SpecType<'a>, Self> {
-        if self.schema.properties.is_none() && self.schema.all_of.is_none() {
+        let has_pattern_properties = self.schema.pattern_properties.is_some()
+            && !self.schema.pattern_properties.as_ref().unwrap().is_empty();
+        let has_unevaluated_properties = self.schema.unevaluated_properties.is_some();
+
+        if self.schema.properties.is_none()
+            && self.schema.all_of.is_none()
+            && !has_pattern_properties
+            && !has_unevaluated_properties
+        {
             return Err(self);
         }
 
@@ -623,30 +631,192 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
     fn additional_properties(&self) -> Option<SpecStructField<'a>> {
         let name = StructFieldName::Hint(StructFieldNameHint::AdditionalProperties);
 
-        let inner = match &self.schema.additional_properties {
-            Some(AdditionalProperties::RefOrSchema(RefOrSchema::Ref(r))) => SpecInner {
-                description: self.schema.description.as_deref(),
-                ty: self.arena().alloc(SpecType::Ref(r)),
-            },
+        // Check if we need to widen the value type due to patternProperties or unevaluatedProperties.
+        let has_pattern_properties = self.schema.pattern_properties.is_some()
+            && !self.schema.pattern_properties.as_ref().unwrap().is_empty();
+        let has_unevaluated_properties = self.schema.unevaluated_properties.is_some();
+
+        // If none of the widening keywords are present, use original logic.
+        if !has_pattern_properties && !has_unevaluated_properties {
+            let inner = match &self.schema.additional_properties {
+                Some(AdditionalProperties::RefOrSchema(RefOrSchema::Ref(r))) => SpecInner {
+                    description: self.schema.description.as_deref(),
+                    ty: self.arena().alloc(SpecType::Ref(r)),
+                },
+                Some(AdditionalProperties::RefOrSchema(RefOrSchema::Inline(schema))) => {
+                    let id = self.context.ids.next();
+                    SpecInner {
+                        description: self.schema.description.as_deref(),
+                        ty: self
+                            .arena()
+                            .alloc(transform_with_context(self.context, id, schema)),
+                    }
+                }
+                Some(AdditionalProperties::Bool(true)) => {
+                    let id = self.context.ids.next();
+                    SpecInner {
+                        description: self.schema.description.as_deref(),
+                        ty: self
+                            .arena()
+                            .alloc(SpecType::Inline(SpecInlineType::Any(id))),
+                    }
+                }
+                _ => return None,
+            };
+
+            let map_id = self.context.ids.next();
+            let ty: &_ = self.arena().alloc(SpecType::from(SpecInlineType::Container(
+                map_id,
+                SpecContainer::Map(inner),
+            )));
+
+            return Some(SpecStructField {
+                name,
+                ty,
+                required: true,
+                description: None,
+                flattened: true,
+            });
+        }
+
+        // Widening keywords are present. Collect all possible value types.
+        let mut value_types: Vec<SpecType<'a>> = Vec::new();
+        let mut has_any = false;
+
+        // Add additionalProperties schema.
+        match &self.schema.additional_properties {
+            Some(AdditionalProperties::RefOrSchema(RefOrSchema::Ref(r))) => {
+                value_types.push(SpecType::Ref(r));
+            }
             Some(AdditionalProperties::RefOrSchema(RefOrSchema::Inline(schema))) => {
                 let id = self.context.ids.next();
-                SpecInner {
-                    description: self.schema.description.as_deref(),
-                    ty: self
-                        .arena()
-                        .alloc(transform_with_context(self.context, id, schema)),
-                }
+                value_types.push(transform_with_context(self.context, id, schema));
             }
             Some(AdditionalProperties::Bool(true)) => {
-                let id = self.context.ids.next();
-                SpecInner {
-                    description: self.schema.description.as_deref(),
-                    ty: self
-                        .arena()
-                        .alloc(SpecType::Inline(SpecInlineType::Any(id))),
-                }
+                has_any = true;
             }
-            _ => return None,
+            _ => {}
+        }
+
+        // Add patternProperties schemas.
+        if let Some(pattern_props) = &self.schema.pattern_properties {
+            for (_pattern, schema) in pattern_props {
+                let ty = match schema {
+                    RefOrSchema::Ref(r) => SpecType::Ref(r),
+                    RefOrSchema::Inline(s) => {
+                        let id = self.context.ids.next();
+                        transform_with_context(self.context, id, s)
+                    }
+                };
+                value_types.push(ty);
+            }
+        }
+
+        // Add unevaluatedProperties.
+        match &self.schema.unevaluated_properties {
+            Some(crate::parse::UnevaluatedProperties::Bool(true)) => {
+                has_any = true;
+            }
+            Some(crate::parse::UnevaluatedProperties::RefOrSchema(RefOrSchema::Ref(r))) => {
+                value_types.push(SpecType::Ref(r));
+            }
+            Some(crate::parse::UnevaluatedProperties::RefOrSchema(RefOrSchema::Inline(schema))) => {
+                let id = self.context.ids.next();
+                value_types.push(transform_with_context(self.context, id, schema));
+            }
+            _ => {}
+        }
+
+        // If any keyword is `true`, use Any type.
+        if has_any {
+            let id = self.context.ids.next();
+            let inner = SpecInner {
+                description: self.schema.description.as_deref(),
+                ty: self
+                    .arena()
+                    .alloc(SpecType::Inline(SpecInlineType::Any(id))),
+            };
+            let map_id = self.context.ids.next();
+            let ty: &_ = self.arena().alloc(SpecType::from(SpecInlineType::Container(
+                map_id,
+                SpecContainer::Map(inner),
+            )));
+            return Some(SpecStructField {
+                name,
+                ty,
+                required: true,
+                description: None,
+                flattened: true,
+            });
+        }
+
+        // No value types collected means no additional properties are allowed.
+        if value_types.is_empty() {
+            return None;
+        }
+
+        // Deduplicate types.
+        let mut seen = std::collections::HashSet::new();
+        let mut unique_types = Vec::new();
+        for ty in value_types {
+            let key = format!("{:?}", ty);
+            if seen.insert(key) {
+                unique_types.push(ty);
+            }
+        }
+
+        // Create the value type: single type or union of types.
+        let value_type = if unique_types.len() == 1 {
+            unique_types.into_iter().next().unwrap()
+        } else {
+            let variants =
+                unique_types
+                    .into_iter()
+                    .enumerate()
+                    .map(|(index, ty)| {
+                        let hint = match ty {
+                            SpecType::Schema(SpecSchemaType::Primitive(_, p))
+                            | SpecType::Inline(SpecInlineType::Primitive(_, p)) => {
+                                UntaggedVariantNameHint::Primitive(p)
+                            }
+                            SpecType::Schema(SpecSchemaType::Container(
+                                _,
+                                SpecContainer::Array(_),
+                            ))
+                            | SpecType::Inline(SpecInlineType::Container(
+                                _,
+                                SpecContainer::Array(_),
+                            )) => UntaggedVariantNameHint::Array,
+                            SpecType::Schema(SpecSchemaType::Container(
+                                _,
+                                SpecContainer::Map(_),
+                            ))
+                            | SpecType::Inline(SpecInlineType::Container(
+                                _,
+                                SpecContainer::Map(_),
+                            )) => UntaggedVariantNameHint::Map,
+                            _ => UntaggedVariantNameHint::Index(index + 1),
+                        };
+                        SpecUntaggedVariant::Some(hint, self.arena().alloc(ty))
+                    })
+                    .collect_vec();
+
+            let untagged = SpecUntagged {
+                description: self.schema.description.as_deref(),
+                variants: self.arena().alloc_slice_copy(&variants),
+                fields: self
+                    .arena()
+                    .alloc_slice(std::iter::empty::<SpecStructField<'a>>()),
+            };
+            match self.name {
+                TypeInfo::Schema(info) => SpecSchemaType::Untagged(info, untagged).into(),
+                TypeInfo::Inline(id) => SpecInlineType::Untagged(id, untagged).into(),
+            }
+        };
+
+        let inner = SpecInner {
+            description: self.schema.description.as_deref(),
+            ty: self.arena().alloc(value_type),
         };
 
         let map_id = self.context.ids.next();

--- a/ploidy-core/src/parse/types.rs
+++ b/ploidy-core/src/parse/types.rs
@@ -370,6 +370,14 @@ pub enum AdditionalProperties {
     RefOrSchema(RefOrSchema),
 }
 
+#[derive(Clone, Debug, Deserialize, JsonPointee, JsonPointerTarget)]
+#[serde(untagged)]
+#[ploidy(pointer(untagged))]
+pub enum UnevaluatedProperties {
+    Bool(bool),
+    RefOrSchema(RefOrSchema),
+}
+
 /// An OpenAPI schema definition.
 #[derive(Debug, Clone, Default, Deserialize, JsonPointee, JsonPointerTarget)]
 #[serde(rename_all = "camelCase")]
@@ -392,6 +400,10 @@ pub struct Schema {
     pub required: Vec<String>,
     #[serde(default)]
     pub additional_properties: Option<AdditionalProperties>,
+    #[serde(default)]
+    pub pattern_properties: Option<IndexMap<String, RefOrSchema>>,
+    #[serde(default)]
+    pub unevaluated_properties: Option<UnevaluatedProperties>,
 
     // Array items.
     #[serde(default)]


### PR DESCRIPTION
## Description

Fixes #83

Objects with `patternProperties`, `unevaluatedProperties` or `additionalProperties` now correctly widen their property value type to a union that includes all possible  value types, rather than only using the `additionalProperties` schema.

## Changes

- **Parse Layer**: Added `patternProperties` and `unevaluatedProperties` fields to the `Schema` struct
- **Parse Layer**: Added `UnevaluatedProperties` enum to handle boolean or schema values
- **IR Transform**: Modified `additional_properties()` method to collect and union value types
- **IR Transform**: Modified `try_struct()` method to recognize widening keywords and create Struct accordingly
- **Type Widening**: Creates an `#[serde(untagged)]` union of all possible value types when multiple types are detected
- **Backward Compatibility**: Preserves original behavior when no widening keywords are present

## How It Works

When an object uses any of these keywords, ploidy now:
1. Collects value types from: `additionalProperties`, all `patternProperties` and `unevaluatedProperties`
2. Deduplicates the collected types
3. Creates an untagged union if multiple types exist
4. Single-type objects remain simple (no unnecessary union wrapper)
5. If any keyword is `true` (allowing any type), uses `Any` instead of union

### Example

**Before (incorrect type):**
```rust
// Schema: additionalProperties: string + patternProperties: {'^num_': number}
BTreeMap<String, String>  // Only considers additionalProperties
```
After (correct type):
```rust
// Schema: additionalProperties: string + patternProperties: {'^num_': number}
BTreeMap<String, OneOfStringNumber>  // Includes all possible types
```
Testing

Added 5 comprehensive tests covering:

- Objects with patternProperties
- Objects with unevaluatedProperties
- Objects with unevaluatedProperties: true (allows any type)
- Objects with only patternProperties
- Objects with all keywords combined

All tests pass: 317+ tests in the workspace