### PR TITLE
Collapse trivial inline `allOf` wrappers.

### DIFF
--- a/ploidy-core/src/ir/graph.rs
+++ b/ploidy-core/src/ir/graph.rs
@@ -15,8 +15,9 @@ use petgraph::{
     graph::{DiGraph, EdgeIndex, NodeIndex},
     stable_graph::StableDiGraph,
     visit::{
-        DfsPostOrder, EdgeFiltered, EdgeRef, GraphRef, IntoEdges, IntoNeighbors,
-        IntoNeighborsDirected, IntoNodeIdentifiers, NodeCount, NodeIndexable, VisitMap, Visitable,
+        DfsPostOrder, EdgeFiltered, EdgeRef, GraphRef, IntoEdgeReferences, IntoEdges,
+        IntoNeighbors, IntoNeighborsDirected, IntoNodeIdentifiers, NodeCount, NodeIndexable,
+        VisitMap, Visitable,
     },
 };
 use rustc_hash::{FxBuildHasher, FxHashMap};
@@ -274,6 +275,199 @@ impl<'a> RawGraph<'a> {
                 let new_target = retargets.get(&(index, target)).copied().unwrap_or(target);
                 self.graph.add_edge(index, new_target, weight);
             }
+        }
+
+        self
+    }
+
+    /// Simplifies trivial `allOf` compositions.
+    ///
+    /// Drops inheritance edges from `Any`, and collapses inline structs and
+    /// unions with a single parent and without own fields or variants,
+    /// to that parent. Trivial named schemas are preserved, so that user code
+    /// can refer to them by name.
+    ///
+    /// This transformation simplifies OpenAPI 3.1 `$ref` schemas with adjacent
+    /// keywords. A schema like `{ "$ref": "...", "description": "..." }` is
+    /// sugar for an inline `allOf` schema with two subschemas: a reference and
+    /// an inline with just a `description`. The latter doesn't contribute any
+    /// type constraints, so the inline `allOf` is redundant.
+    pub fn collapse_trivial_inlines(&mut self) -> &mut Self {
+        // `Any` doesn't contribute any members, and dropping `Inherits` edges
+        // to it here simplifies the logic to find collapsible inlines and
+        // their new targets.
+        let inherits_to_any = self
+            .graph
+            .edge_references()
+            .filter(|edge| {
+                matches!(edge.weight(), GraphEdge::Inherits { .. })
+                    && matches!(
+                        self.graph[edge.target()],
+                        GraphType::Schema(GraphSchemaType::Any(_))
+                            | GraphType::Inline(GraphInlineType::Any(_))
+                    )
+            })
+            .map(|edge| edge.id())
+            .collect_vec();
+        for id in inherits_to_any {
+            self.graph.remove_edge(id);
+        }
+
+        // Find all inlines with no own members (i.e., no fields or variants)
+        // and exactly one parent.
+        let collapsibles: FixedBitSet = self
+            .graph
+            .node_indices()
+            .filter(|&node| {
+                matches!(
+                    self.graph[node],
+                    GraphType::Inline(
+                        GraphInlineType::Struct(..)
+                            | GraphInlineType::Tagged(..)
+                            | GraphInlineType::Untagged(..)
+                    )
+                )
+            })
+            .filter(|&node| {
+                self.graph
+                    .edges_directed(node, Direction::Outgoing)
+                    .all(|edge| {
+                        !matches!(
+                            edge.weight(),
+                            GraphEdge::Field { .. } | GraphEdge::Variant(_)
+                        )
+                    })
+                    && self
+                        .graph
+                        .edges_directed(node, Direction::Outgoing)
+                        .filter(|edge| {
+                            matches!(edge.weight(), GraphEdge::Inherits { .. })
+                                && edge.target() != node
+                        })
+                        .exactly_one()
+                        .is_ok()
+            })
+            .map(|node| node.index())
+            .collect();
+
+        // Compute the transitive closure over the inheritance subgraph
+        // rooted at the collapsible set, then map each collapsible node to its
+        // non-collapsible target. Each collapsible has exactly one
+        // outgoing edge in this subgraph, so its dependency set is a linear
+        // chain ending in either the target or a cycle entirely within the
+        // collapsible set. Only chains with a target are recorded.
+        let closure = Closure::new(&EdgeFiltered::from_fn(&self.graph, |edge| {
+            matches!(edge.weight(), GraphEdge::Inherits { .. })
+                && collapsibles.contains(edge.source().index())
+        }));
+        let collapsed_to: FxHashMap<_, _> = collapsibles
+            .ones()
+            .map(NodeIndex::new)
+            .flat_map(|node| {
+                closure
+                    .dependencies_of(node)
+                    .find(|target| !collapsibles.contains(target.index()))
+                    .map(|target| (node, target))
+            })
+            .collect();
+        if collapsed_to.is_empty() {
+            return self;
+        }
+
+        // Redirect every incoming edge of a collapsible to its target.
+        // Skip edges whose source is also collapsible; we'll remove those last.
+        let sources_to_redirect: FixedBitSet = self
+            .graph
+            .edge_references()
+            .filter(|edge| {
+                collapsed_to.contains_key(&edge.target())
+                    && !collapsed_to.contains_key(&edge.source())
+            })
+            .map(|edge| edge.source().index())
+            .collect();
+        for source in sources_to_redirect.ones().map(NodeIndex::new) {
+            let old_edges = self
+                .graph
+                .edges_directed(source, Direction::Outgoing)
+                .map(|edge| {
+                    let old_target = edge.target();
+                    let new_target = collapsed_to.get(&old_target).copied().unwrap_or(old_target);
+                    (edge.id(), *edge.weight(), new_target)
+                })
+                .collect_vec();
+            for &(id, _, _) in &old_edges {
+                self.graph.remove_edge(id);
+            }
+            // Re-add edges. `edges_directed` yields edges in reverse order
+            // of addition; reversing them adds edges in their original order.
+            // Since edge order matters, we need to remove and re-add them all.
+            for (_, weight, target) in old_edges.into_iter().rev() {
+                self.graph.add_edge(source, target, weight);
+            }
+        }
+
+        // Redirect operation roots, which don't have graph edges.
+        let ops = self
+            .ops
+            .iter()
+            .map(|&op| {
+                let params = op
+                    .params
+                    .iter()
+                    .map(|&param| {
+                        let rewrite = match param {
+                            Parameter::Path(info) => collapsed_to
+                                .get(&info.ty)
+                                .map(|&ty| Parameter::Path(ParameterInfo { ty, ..info })),
+                            Parameter::Query(info) => collapsed_to
+                                .get(&info.ty)
+                                .map(|&ty| Parameter::Query(ParameterInfo { ty, ..info })),
+                        };
+                        rewrite.unwrap_or(param)
+                    })
+                    .collect_vec();
+
+                let request = op
+                    .request
+                    .and_then(|request| match request {
+                        Request::Json(ty) => {
+                            let &ty = collapsed_to.get(&ty)?;
+                            Some(Request::Json(ty))
+                        }
+                        Request::Multipart => None,
+                    })
+                    .or(op.request);
+
+                let response = op
+                    .response
+                    .and_then(|response| match response {
+                        Response::Json(ty) => {
+                            let &ty = collapsed_to.get(&ty)?;
+                            Some(Response::Json(ty))
+                        }
+                    })
+                    .or(op.response);
+
+                if params == op.params && request == op.request && response == op.response {
+                    op
+                } else {
+                    self.arena.alloc(Operation {
+                        params: self.arena.alloc_slice_copy(&params),
+                        request,
+                        response,
+                        ..*op
+                    })
+                }
+            })
+            .collect_vec();
+        if ops != self.ops {
+            self.ops = self.arena.alloc_slice_copy(&ops);
+        }
+
+        // Remove every collapsed node. `remove_node` removes incident edges,
+        // including those between two collapsibles in a chain.
+        for (node, _) in collapsed_to {
+            self.graph.remove_node(node);
         }
 
         self
@@ -1142,6 +1336,9 @@ impl<'a> Iterator for SpecTypeVisitor<'a> {
                                 (GraphEdge::Variant(UntaggedVariantMeta::Null.into()), top)
                             }
                         }),
+                        ty.parents
+                            .iter()
+                            .map(|parent| (GraphEdge::Inherits { shadow: false }, *parent)),
                     )
                     .map(|(edge, ty)| (Some((top, edge)), ty))
                     .rev(),
@@ -1173,6 +1370,9 @@ impl<'a> Iterator for SpecTypeVisitor<'a> {
                             ),
                             variant.ty
                         )),
+                        ty.parents
+                            .iter()
+                            .map(|parent| (GraphEdge::Inherits { shadow: false }, *parent)),
                     )
                     .map(|(edge, ty)| (Some((top, edge)), ty))
                     .rev(),

--- a/ploidy-core/src/ir/tests/graph.rs
+++ b/ploidy-core/src/ir/tests/graph.rs
@@ -5,8 +5,8 @@ use itertools::Itertools;
 use crate::{
     arena::Arena,
     ir::{
-        HasResource, InlineTypeView, RawGraph, SchemaTypeView, Spec, StructFieldName, TypeView,
-        View,
+        ContainerView, HasResource, InlineTypeView, RawGraph, RequestView, ResponseView,
+        SchemaTypeView, Spec, StructFieldName, TypeView, View,
     },
     parse::Document,
     tests::assert_matches,
@@ -2239,4 +2239,675 @@ fn test_needs_box_through_inlined_tagged_variant() {
         .find(|f| matches!(f.name(), StructFieldName::Name("parent")))
         .unwrap();
     assert!(parent_field.needs_box());
+}
+
+// MARK: Collapsing trivial inlines
+
+#[test]
+fn test_inline_ref_with_description_collapses_to_ref() {
+    // OpenAPI 3.1 supports adjacent keywords on `$ref` schemas,
+    // which desugar to `allOf`: `{ "$ref": "...", "description": "..." }`
+    // becomes `{ "allOf": [{ "$ref": "..." }], "description": "..." }`.
+    // For a subschema without any type constraints, the inline `allOf`
+    // carries no structural information, and collapses to a plain reference.
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.1.0
+        info:
+          title: Test
+          version: 1.0.0
+        components:
+          schemas:
+            Pet:
+              type: object
+              properties:
+                name:
+                  type: string
+            Owner:
+              type: object
+              properties:
+                pet:
+                  $ref: '#/components/schemas/Pet'
+                  description: The owner's pet.
+              required:
+                - pet
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let spec = Spec::from_doc(&arena, &doc).unwrap();
+    let mut raw = RawGraph::new(&arena, &spec);
+    raw.collapse_trivial_inlines();
+    let graph = raw.cook();
+
+    let owner = graph.schema("Owner").unwrap();
+    let owner_struct = match owner {
+        SchemaTypeView::Struct(_, view) => view,
+        other => panic!("expected struct `Owner`; got `{other:?}`"),
+    };
+    let pet_field = owner_struct
+        .fields()
+        .find(|f| matches!(f.name(), StructFieldName::Name("pet")))
+        .unwrap();
+
+    // The field should resolve directly to the `Pet` schema, not
+    // an inline struct that inherits from it.
+    let target = match pet_field.ty() {
+        TypeView::Schema(SchemaTypeView::Struct(info, _)) => info.name,
+        other => panic!("expected struct view of `Pet`; got `{other:?}`"),
+    };
+    assert_eq!(target, "Pet");
+}
+
+#[test]
+fn test_container_inner_refs_with_description_collapse_to_refs() {
+    // Container edges should be retargeted when their inner type is a
+    // collapsed inline `allOf` wrapper.
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.1.0
+        info:
+          title: Test
+          version: 1.0.0
+        components:
+          schemas:
+            Pet:
+              type: object
+              properties:
+                name:
+                  type: string
+            Owner:
+              type: object
+              properties:
+                pets:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/Pet'
+                    description: The pet.
+                pets_by_name:
+                  type: object
+                  additionalProperties:
+                    $ref: '#/components/schemas/Pet'
+                    description: The pet.
+              required:
+                - pets
+                - pets_by_name
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let spec = Spec::from_doc(&arena, &doc).unwrap();
+    let mut raw = RawGraph::new(&arena, &spec);
+    raw.collapse_trivial_inlines();
+    let graph = raw.cook();
+
+    let owner = graph.schema("Owner").unwrap();
+    let owner_struct = match owner {
+        SchemaTypeView::Struct(_, view) => view,
+        other => panic!("expected struct `Owner`; got `{other:?}`"),
+    };
+
+    let pets_field = owner_struct
+        .fields()
+        .find(|f| matches!(f.name(), StructFieldName::Name("pets")))
+        .unwrap();
+    let pets_target = match pets_field.ty() {
+        TypeView::Inline(InlineTypeView::Container(_, ContainerView::Array(inner))) => {
+            match inner.ty() {
+                TypeView::Schema(SchemaTypeView::Struct(info, _)) => info.name,
+                other => panic!("expected array item schema view of `Pet`; got `{other:?}`"),
+            }
+        }
+        other => panic!("expected array container; got `{other:?}`"),
+    };
+    assert_eq!(pets_target, "Pet");
+
+    let pets_by_name_field = owner_struct
+        .fields()
+        .find(|f| matches!(f.name(), StructFieldName::Name("pets_by_name")))
+        .unwrap();
+    let pets_by_name_target = match pets_by_name_field.ty() {
+        TypeView::Inline(InlineTypeView::Container(_, ContainerView::Map(inner))) => {
+            match inner.ty() {
+                TypeView::Schema(SchemaTypeView::Struct(info, _)) => info.name,
+                other => panic!("expected map value schema view of `Pet`; got `{other:?}`"),
+            }
+        }
+        other => panic!("expected map container; got `{other:?}`"),
+    };
+    assert_eq!(pets_by_name_target, "Pet");
+}
+
+#[test]
+fn test_operation_response_ref_with_description_collapses_to_ref() {
+    // Operations aren't part of the graph, so their roots don't have any
+    // incoming graph edges, but they still need to be retargeted before
+    // removing collapsed inline `allOf`s.
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.1.0
+        info:
+          title: Test
+          version: 1.0.0
+        paths:
+          /pet:
+            get:
+              operationId: getPet
+              responses:
+                '200':
+                  description: OK
+                  content:
+                    application/json:
+                      schema:
+                        $ref: '#/components/schemas/Pet'
+                        description: The pet.
+        components:
+          schemas:
+            Pet:
+              type: object
+              properties:
+                name:
+                  type: string
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let spec = Spec::from_doc(&arena, &doc).unwrap();
+    let mut raw = RawGraph::new(&arena, &spec);
+    raw.collapse_trivial_inlines();
+    let graph = raw.cook();
+
+    let operation = graph.operations().next().unwrap();
+    let target = match operation.response() {
+        Some(ResponseView::Json(TypeView::Schema(SchemaTypeView::Struct(info, _)))) => info.name,
+        other => panic!("expected response struct view of `Pet`; got `{other:?}`"),
+    };
+    assert_eq!(target, "Pet");
+}
+
+#[test]
+fn test_operation_request_ref_with_description_collapses_to_ref() {
+    // Operations aren't part of the graph, so request roots need the same
+    // retargeting as response roots before removing collapsed inline `allOf`s.
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.1.0
+        info:
+          title: Test
+          version: 1.0.0
+        paths:
+          /pet:
+            post:
+              operationId: createPet
+              requestBody:
+                content:
+                  application/json:
+                    schema:
+                      $ref: '#/components/schemas/Pet'
+                      description: The pet.
+              responses:
+                '201':
+                  description: Created
+        components:
+          schemas:
+            Pet:
+              type: object
+              properties:
+                name:
+                  type: string
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let spec = Spec::from_doc(&arena, &doc).unwrap();
+    let mut raw = RawGraph::new(&arena, &spec);
+    raw.collapse_trivial_inlines();
+    let graph = raw.cook();
+
+    let operation = graph.operations().next().unwrap();
+    let target = match operation.request() {
+        Some(RequestView::Json(TypeView::Schema(SchemaTypeView::Struct(info, _)))) => info.name,
+        other => panic!("expected request struct view of `Pet`; got `{other:?}`"),
+    };
+    assert_eq!(target, "Pet");
+}
+
+#[test]
+fn test_operation_parameter_refs_with_description_collapse_to_refs() {
+    // Operation parameters aren't part of the graph, so path and query roots
+    // need to be retargeted before removing collapsed inline `allOf`s.
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.1.0
+        info:
+          title: Test
+          version: 1.0.0
+        paths:
+          /pets/{pet_id}:
+            get:
+              operationId: getPet
+              parameters:
+                - name: pet_id
+                  in: path
+                  required: true
+                  schema:
+                    $ref: '#/components/schemas/PetId'
+                    description: The pet ID.
+                - name: filter
+                  in: query
+                  schema:
+                    $ref: '#/components/schemas/PetFilter'
+                    description: The pet filter.
+              responses:
+                '200':
+                  description: OK
+        components:
+          schemas:
+            PetId:
+              type: string
+            PetFilter:
+              type: object
+              properties:
+                status:
+                  type: string
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let spec = Spec::from_doc(&arena, &doc).unwrap();
+    let mut raw = RawGraph::new(&arena, &spec);
+    raw.collapse_trivial_inlines();
+    let graph = raw.cook();
+
+    let operation = graph.operations().next().unwrap();
+
+    let path_param = operation.path().params().next().unwrap();
+    let path_target = match path_param.ty() {
+        TypeView::Schema(SchemaTypeView::Primitive(info, _)) => info.name,
+        other => panic!("expected primitive schema view of `PetId`; got `{other:?}`"),
+    };
+    assert_eq!(path_target, "PetId");
+
+    let query_param = operation.query().next().unwrap();
+    let query_target = match query_param.ty() {
+        TypeView::Schema(SchemaTypeView::Struct(info, _)) => info.name,
+        other => panic!("expected struct schema view of `PetFilter`; got `{other:?}`"),
+    };
+    assert_eq!(query_target, "PetFilter");
+}
+
+#[test]
+fn test_parent_ref_with_description_collapses_to_ref() {
+    // Inheritance edges should be retargeted when their parent is a
+    // collapsed inline `allOf` wrapper.
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.1.0
+        info:
+          title: Test
+          version: 1.0.0
+        components:
+          schemas:
+            Pet:
+              type: object
+              properties:
+                name:
+                  type: string
+            OwnedPet:
+              allOf:
+                - $ref: '#/components/schemas/Pet'
+                  description: The pet.
+              properties:
+                owner:
+                  type: string
+              required:
+                - owner
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let spec = Spec::from_doc(&arena, &doc).unwrap();
+    let mut raw = RawGraph::new(&arena, &spec);
+    raw.collapse_trivial_inlines();
+    let graph = raw.cook();
+
+    let owned_pet = graph.schema("OwnedPet").unwrap();
+    let owned_pet_struct = match owned_pet {
+        SchemaTypeView::Struct(_, view) => view,
+        other => panic!("expected struct `OwnedPet`; got `{other:?}`"),
+    };
+
+    let parents = owned_pet_struct.parents().collect_vec();
+    assert_matches!(
+        &*parents,
+        [TypeView::Schema(SchemaTypeView::Struct(info, _))] if info.name == "Pet"
+    );
+}
+
+#[test]
+fn test_collapse_trivial_inlines_drops_inherits_edge_from_any() {
+    // A schema that inherits from another that's effectively `Any`
+    // (e.g., an empty schema) should drop that inheritance edge.
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test
+          version: 1.0.0
+        components:
+          schemas:
+            Anything: {}
+            Thing:
+              allOf:
+                - $ref: '#/components/schemas/Anything'
+              properties:
+                name:
+                  type: string
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let spec = Spec::from_doc(&arena, &doc).unwrap();
+    let mut raw = RawGraph::new(&arena, &spec);
+    raw.collapse_trivial_inlines();
+    let graph = raw.cook();
+
+    let thing = graph.schema("Thing").unwrap();
+    let thing_struct = match thing {
+        SchemaTypeView::Struct(_, view) => view,
+        other => panic!("expected struct `Thing`; got `{other:?}`"),
+    };
+
+    // Without the `Any` inheritance edge, `Thing` has no parents.
+    let parents = thing_struct.parents().collect_vec();
+    assert_matches!(&*parents, []);
+}
+
+#[test]
+fn test_collapse_trivial_inlines_drops_any_parent_before_collapsing_inline() {
+    // Dropping `Any` parents first should allow an otherwise trivial inline
+    // `allOf` wrapper to collapse to its remaining parent.
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test
+          version: 1.0.0
+        components:
+          schemas:
+            Pet:
+              type: object
+              properties:
+                name:
+                  type: string
+            Owner:
+              type: object
+              properties:
+                pet:
+                  allOf:
+                    - {}
+                    - $ref: '#/components/schemas/Pet'
+              required:
+                - pet
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let spec = Spec::from_doc(&arena, &doc).unwrap();
+    let mut raw = RawGraph::new(&arena, &spec);
+    raw.collapse_trivial_inlines();
+    let graph = raw.cook();
+
+    let owner = graph.schema("Owner").unwrap();
+    let owner_struct = match owner {
+        SchemaTypeView::Struct(_, view) => view,
+        other => panic!("expected struct `Owner`; got `{other:?}`"),
+    };
+    let pet_field = owner_struct
+        .fields()
+        .find(|f| matches!(f.name(), StructFieldName::Name("pet")))
+        .unwrap();
+
+    let target = match pet_field.ty() {
+        TypeView::Schema(SchemaTypeView::Struct(info, _)) => info.name,
+        other => panic!("expected struct view of `Pet`; got `{other:?}`"),
+    };
+    assert_eq!(target, "Pet");
+}
+
+#[test]
+fn test_named_schema_ref_sibling_does_not_collapse() {
+    // A named schema with just `$ref` and `description` becomes a
+    // single-parent struct with no own fields; it's not collapsed so that
+    // user code can refer to it by name.
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.1.0
+        info:
+          title: Test
+          version: 1.0.0
+        components:
+          schemas:
+            Pet:
+              type: object
+              properties:
+                name:
+                  type: string
+            Owner:
+              $ref: '#/components/schemas/Pet'
+              description: A pet's owner.
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let spec = Spec::from_doc(&arena, &doc).unwrap();
+    let mut raw = RawGraph::new(&arena, &spec);
+    raw.collapse_trivial_inlines();
+    let graph = raw.cook();
+
+    let schema_names = graph.schemas().map(|s| s.name()).collect_vec();
+    assert_matches!(&*schema_names, ["Pet", "Owner"]);
+}
+
+#[test]
+fn test_collapsing_wrapper_preserves_variant_order() {
+    // The order of untagged union variants is significant (`#[serde(untagged)]`
+    // relies on it, for example), so collapsing must preserve it.
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.1.0
+        info:
+          title: Test
+          version: 1.0.0
+        components:
+          schemas:
+            A:
+              type: object
+              properties:
+                value:
+                  type: string
+            B:
+              type: object
+              properties:
+                value:
+                  type: integer
+            Choice:
+              oneOf:
+                - $ref: '#/components/schemas/A'
+                  description: Metadata only.
+                - $ref: '#/components/schemas/B'
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let spec = Spec::from_doc(&arena, &doc).unwrap();
+    let mut raw = RawGraph::new(&arena, &spec);
+    raw.collapse_trivial_inlines();
+    let graph = raw.cook();
+
+    let choice = graph.schema("Choice").unwrap();
+    let choice = match choice {
+        SchemaTypeView::Untagged(_, view) => view,
+        other => panic!("expected untagged `Choice`; got `{other:?}`"),
+    };
+    let variant_names = choice
+        .variants()
+        .map(|variant| match variant.ty().unwrap().view {
+            TypeView::Schema(schema) => schema.name(),
+            other => panic!("expected schema variant; got `{other:?}`"),
+        })
+        .collect_vec();
+
+    assert_matches!(&*variant_names, ["A", "B"]);
+}
+
+#[test]
+fn test_collapse_trivial_inlines_preserves_ref_with_one_of_sibling() {
+    // A `$ref` with an adjacent structural keyword like `oneOf` shouldn't be
+    // collapsed, because those keywords carry real type constraints.
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.1.0
+        info:
+          title: Test
+          version: 1.0.0
+        components:
+          schemas:
+            Cat:
+              type: object
+              properties:
+                meow:
+                  type: string
+            Dog:
+              type: object
+              properties:
+                bark:
+                  type: string
+            Pet:
+              type: object
+              properties:
+                name:
+                  type: string
+            Owner:
+              type: object
+              properties:
+                pet:
+                  $ref: '#/components/schemas/Pet'
+                  oneOf:
+                    - $ref: '#/components/schemas/Cat'
+                    - $ref: '#/components/schemas/Dog'
+              required:
+                - pet
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let spec = Spec::from_doc(&arena, &doc).unwrap();
+    let mut raw = RawGraph::new(&arena, &spec);
+    raw.collapse_trivial_inlines();
+    let graph = raw.cook();
+
+    let owner = graph.schema("Owner").unwrap();
+    let owner_struct = match owner {
+        SchemaTypeView::Struct(_, view) => view,
+        other => panic!("expected struct `Owner`; got `{other:?}`"),
+    };
+    let pet_field = owner_struct
+        .fields()
+        .find(|f| matches!(f.name(), StructFieldName::Name("pet")))
+        .unwrap();
+
+    // The field should resolve to an inline untagged union,
+    // not collapse to `Pet`.
+    assert_matches!(
+        pet_field.ty(),
+        TypeView::Inline(InlineTypeView::Untagged(..))
+    );
+}
+
+#[test]
+fn test_collapse_trivial_inlines_is_idempotent() {
+    // Collapsing inlines twice shouldn't change the graph.
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.1.0
+        info:
+          title: Test
+          version: 1.0.0
+        components:
+          schemas:
+            Pet:
+              type: object
+              properties:
+                name:
+                  type: string
+            Owner:
+              type: object
+              properties:
+                pet:
+                  $ref: '#/components/schemas/Pet'
+                  description: The pet.
+              required:
+                - pet
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let spec = Spec::from_doc(&arena, &doc).unwrap();
+
+    let cooked_once = {
+        let mut raw = RawGraph::new(&arena, &spec);
+        raw.collapse_trivial_inlines();
+        raw.cook()
+    };
+    let cooked_twice = {
+        let mut raw = RawGraph::new(&arena, &spec);
+        raw.collapse_trivial_inlines();
+        raw.collapse_trivial_inlines();
+        raw.cook()
+    };
+
+    let names_once = cooked_once.schemas().map(|s| s.name()).collect_vec();
+    let names_twice = cooked_twice.schemas().map(|s| s.name()).collect_vec();
+    assert_eq!(names_once, names_twice);
+}
+
+#[test]
+fn test_collapse_trivial_inline_chain_to_ref() {
+    // Nested inline `allOf`s produce a chain of trivial inline wrappers,
+    // each inheriting from its parent. The whole chain should collapse to
+    // the innermost named schema reference.
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test
+          version: 1.0.0
+        components:
+          schemas:
+            Pet:
+              type: object
+              properties:
+                name:
+                  type: string
+            Owner:
+              type: object
+              properties:
+                pet:
+                  allOf:
+                    - allOf:
+                        - $ref: '#/components/schemas/Pet'
+              required:
+                - pet
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let spec = Spec::from_doc(&arena, &doc).unwrap();
+    let mut raw = RawGraph::new(&arena, &spec);
+    raw.collapse_trivial_inlines();
+    let graph = raw.cook();
+
+    let owner = graph.schema("Owner").unwrap();
+    let owner_struct = match owner {
+        SchemaTypeView::Struct(_, view) => view,
+        other => panic!("expected struct `Owner`; got `{other:?}`"),
+    };
+    let pet_field = owner_struct
+        .fields()
+        .find(|f| matches!(f.name(), StructFieldName::Name("pet")))
+        .unwrap();
+
+    let target = match pet_field.ty() {
+        TypeView::Schema(SchemaTypeView::Struct(info, _)) => info.name,
+        other => panic!("expected struct view of `Pet`; got `{other:?}`"),
+    };
+    assert_eq!(target, "Pet");
 }

--- a/ploidy-core/src/ir/tests/graph.rs
+++ b/ploidy-core/src/ir/tests/graph.rs
@@ -40,11 +40,8 @@ fn test_graph_basic_construction() {
     let spec = Spec::from_doc(&arena, &doc).unwrap();
     let graph = RawGraph::new(&arena, &spec).cook();
 
-    // Should be able to iterate over schemas.
-    // The order of iteration isn't guaranteed.
-    let mut schema_names = graph.schemas().map(|s| s.name()).collect_vec();
-    schema_names.sort();
-    assert_matches!(&*schema_names, ["Company", "Person"]);
+    let schema_names = graph.schemas().map(|s| s.name()).collect_vec();
+    assert_matches!(&*schema_names, ["Person", "Company"]);
 }
 
 #[test]
@@ -79,9 +76,8 @@ fn test_graph_deduplication() {
     let graph = RawGraph::new(&arena, &spec).cook();
 
     // Should have all 3 schemas, with `Shared` appearing only once.
-    let mut schema_names = graph.schemas().map(|s| s.name()).collect_vec();
-    schema_names.sort();
-    assert_matches!(&*schema_names, ["Container1", "Container2", "Shared"]);
+    let schema_names = graph.schemas().map(|s| s.name()).collect_vec();
+    assert_matches!(&*schema_names, ["Shared", "Container1", "Container2"]);
 }
 
 #[test]
@@ -111,9 +107,8 @@ fn test_graph_struct_field_edges() {
     let graph = RawGraph::new(&arena, &spec).cook();
 
     // Both schemas should be present.
-    let mut schema_names = graph.schemas().map(|s| s.name()).collect_vec();
-    schema_names.sort();
-    assert_matches!(&*schema_names, ["Container", "FieldType"]);
+    let schema_names = graph.schemas().map(|s| s.name()).collect_vec();
+    assert_matches!(&*schema_names, ["FieldType", "Container"]);
 }
 
 #[test]
@@ -152,9 +147,8 @@ fn test_graph_tagged_variant_edges() {
     let graph = RawGraph::new(&arena, &spec).cook();
 
     // Should have all schemas.
-    let mut schema_names = graph.schemas().map(|s| s.name()).collect_vec();
-    schema_names.sort();
-    assert_matches!(&*schema_names, ["Animal", "Cat", "Dog"]);
+    let schema_names = graph.schemas().map(|s| s.name()).collect_vec();
+    assert_matches!(&*schema_names, ["Dog", "Cat", "Animal"]);
 }
 
 #[test]
@@ -188,9 +182,8 @@ fn test_graph_untagged_variant_edges() {
     let graph = RawGraph::new(&arena, &spec).cook();
 
     // Should have all schemas.
-    let mut schema_names = graph.schemas().map(|s| s.name()).collect_vec();
-    schema_names.sort();
-    assert_matches!(&*schema_names, ["AOrB", "TypeA", "TypeB"]);
+    let schema_names = graph.schemas().map(|s| s.name()).collect_vec();
+    assert_matches!(&*schema_names, ["TypeA", "TypeB", "AOrB"]);
 }
 
 #[test]
@@ -222,8 +215,7 @@ fn test_graph_array_edge() {
     let graph = RawGraph::new(&arena, &spec).cook();
 
     // Should have both schemas.
-    let mut schema_names = graph.schemas().map(|s| s.name()).collect_vec();
-    schema_names.sort();
+    let schema_names = graph.schemas().map(|s| s.name()).collect_vec();
     assert_matches!(&*schema_names, ["Item", "Items"]);
 }
 
@@ -256,9 +248,8 @@ fn test_graph_map_edge() {
     let graph = RawGraph::new(&arena, &spec).cook();
 
     // Should have both schemas.
-    let mut schema_names = graph.schemas().map(|s| s.name()).collect_vec();
-    schema_names.sort();
-    assert_matches!(&*schema_names, ["Dictionary", "Value"]);
+    let schema_names = graph.schemas().map(|s| s.name()).collect_vec();
+    assert_matches!(&*schema_names, ["Value", "Dictionary"]);
 }
 
 #[test]
@@ -289,9 +280,8 @@ fn test_graph_nullable_edge() {
     let graph = RawGraph::new(&arena, &spec).cook();
 
     // Should have both schemas.
-    let mut schema_names = graph.schemas().map(|s| s.name()).collect_vec();
-    schema_names.sort();
-    assert_matches!(&*schema_names, ["Container", "NullableType"]);
+    let schema_names = graph.schemas().map(|s| s.name()).collect_vec();
+    assert_matches!(&*schema_names, ["NullableType", "Container"]);
 }
 
 #[test]
@@ -323,8 +313,7 @@ fn test_graph_ref_resolution() {
     let graph = RawGraph::new(&arena, &spec).cook();
 
     // Should have both `Parent` and `Child` schemas.
-    let mut schema_names = graph.schemas().map(|s| s.name()).collect_vec();
-    schema_names.sort();
+    let schema_names = graph.schemas().map(|s| s.name()).collect_vec();
     assert_matches!(&*schema_names, ["Child", "Parent"]);
 }
 

--- a/ploidy-core/src/ir/tests/views.rs
+++ b/ploidy-core/src/ir/tests/views.rs
@@ -50,15 +50,14 @@ fn test_struct_view_fields_iterator() {
     };
 
     // `fields()` should iterate over all struct fields.
-    let mut field_names = person_struct
+    let field_names = person_struct
         .fields()
         .map(|f| match f.name() {
             StructFieldName::Name(n) => n,
             other => panic!("expected explicit struct field name; got {other:?}"),
         })
         .collect_vec();
-    field_names.sort();
-    assert_matches!(&*field_names, ["age", "email", "name"]);
+    assert_matches!(&*field_names, ["name", "age", "email"]);
 }
 
 #[test]

--- a/ploidy-core/src/ir/transform.rs
+++ b/ploidy-core/src/ir/transform.rs
@@ -132,6 +132,7 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
             tag: discriminator.property_name.as_str(),
             variants: self.arena().alloc_slice_copy(&variants),
             fields: self.arena().alloc_slice(self.properties()),
+            parents: self.arena().alloc_slice(self.parents()),
         };
 
         Ok(match self.name {
@@ -229,6 +230,7 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
                     description: self.schema.description.as_deref(),
                     variants: self.arena().alloc_slice_copy(variants),
                     fields: self.arena().alloc_slice(self.properties()),
+                    parents: self.arena().alloc_slice(self.parents()),
                 };
                 match self.name {
                     TypeInfo::Schema(info) => SpecSchemaType::Untagged(info, untagged).into(),
@@ -533,6 +535,7 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
                     description: self.schema.description.as_deref(),
                     variants: self.arena().alloc_slice_copy(&variants),
                     fields: &[],
+                    parents: self.arena().alloc_slice(self.parents()),
                 };
                 match self.name {
                     TypeInfo::Schema(info) => SpecSchemaType::Untagged(info, untagged).into(),

--- a/ploidy-core/src/ir/types/spec.rs
+++ b/ploidy-core/src/ir/types/spec.rs
@@ -131,6 +131,8 @@ pub struct SpecTagged<'a> {
     pub variants: &'a [SpecTaggedVariant<'a>],
     /// Own fields that the union declares as `properties`.
     pub fields: &'a [SpecStructField<'a>],
+    /// Immediate parent types from `allOf`, in declaration order.
+    pub parents: &'a [&'a SpecType<'a>],
 }
 
 /// A variant of a tagged union.
@@ -150,6 +152,8 @@ pub struct SpecUntagged<'a> {
     pub variants: &'a [SpecUntaggedVariant<'a>],
     /// Own fields that the union declares as `properties`.
     pub fields: &'a [SpecStructField<'a>],
+    /// Immediate parent types from `allOf`, in declaration order.
+    pub parents: &'a [&'a SpecType<'a>],
 }
 
 /// A variant of an untagged union.

--- a/ploidy-core/src/lib.rs
+++ b/ploidy-core/src/lib.rs
@@ -22,6 +22,7 @@
 //! let arena = Arena::new();
 //! let spec = Spec::from_doc(&arena, &doc)?;
 //! let mut raw = RawGraph::new(&arena, &spec);
+//! raw.collapse_trivial_inlines();
 //! raw.inline_tagged_variants();
 //! let graph = raw.cook();
 //!

--- a/ploidy/src/main.rs
+++ b/ploidy/src/main.rs
@@ -43,6 +43,7 @@ fn main() -> Result<()> {
             let arena = Arena::new();
             let spec = Spec::from_doc(&arena, &doc).into_diagnostic()?;
             let mut raw = RawGraph::new(&arena, &spec);
+            raw.collapse_trivial_inlines();
             raw.inline_tagged_variants();
 
             let config = language


### PR DESCRIPTION
OpenAPI 3.1 inherits JSON Schema Draft 2020-12's support for `$ref` schemas with adjacent keywords, like this:

```yaml
Owner:
  type: object
  properties:
    pet:
      $ref: '#/components/schemas/Pet'
      description: The owner's pet.
  required:
    - pet
```

Ploidy desugars these into the semantically equivalent:

```yaml
Owner:
  type: object
  properties:
    pet:
      allOf:
        - $ref: '#/components/schemas/Pet'
      description: The owner's pet.
  required:
    - pet
```

...But that comes at the cost of noisy inlines: the `description` doesn't actually add any type constraints, so Ploidy emits an inline struct with the same shape as `Owner`. This PR rewrites those trivial inlines back to their referenced parent type before cooking the graph, so the generated Rust can reference `Pet` directly, not the inline copy.