### PR TITLE
Derive inline names from their enclosing types. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Ploidy has first-class support for inheritance and polymorphism:
 
 * **`allOf`**: Structs with fields linearized from all parent schemas.
 * **`oneOf` with discriminator**: Enums with named newtype variants for each mapping, represented as an [internally tagged](https://serde.rs/enum-representations.html#internally-tagged) Serde enum.
-* **`oneOf` without discriminator**: Enums with automatically named (`V1`, `V2`, `V3`...) variants for each subschema, represented as an [untagged](https://serde.rs/enum-representations.html#untagged) Serde enum.
+* **`oneOf` without discriminator**: Enums with automatically named variants for each subschema, represented as an [untagged](https://serde.rs/enum-representations.html#untagged) Serde enum.
 * **`anyOf`**, with or without discriminator: Structs with optional [flattened fields](https://serde.rs/attr-flatten.html) for each subschema.
 
 ### Fast and correct

--- a/ploidy-codegen-rust/src/cargo.rs
+++ b/ploidy-codegen-rust/src/cargo.rs
@@ -944,8 +944,8 @@ mod tests {
         let manifest = CodegenCargoManifest::new(&graph, &default_manifest()).to_manifest();
 
         let features = manifest.features();
-        assert_matches!(&*features["default2"], []);
-        assert_matches!(&*features["default"], ["default2"]);
+        assert_matches!(&*features["default-2"], []);
+        assert_matches!(&*features["default"], ["default-2"]);
     }
 
     // MARK: Operation feature dependencies
@@ -1083,8 +1083,8 @@ mod tests {
         let manifest = CodegenCargoManifest::new(&graph, &default_manifest()).to_manifest();
 
         let features = manifest.features();
-        assert_matches!(&*features["default2"], []);
-        assert_matches!(&*features["default"], ["default2"]);
+        assert_matches!(&*features["default-2"], []);
+        assert_matches!(&*features["default"], ["default-2"]);
     }
 
     // MARK: Diamond dependencies

--- a/ploidy-codegen-rust/src/cfg.rs
+++ b/ploidy-codegen-rust/src/cfg.rs
@@ -538,7 +538,7 @@ mod tests {
         let cfg = CfgFeature::for_schema_type(&graph, &default_type);
 
         let actual: syn::Attribute = parse_quote!(#cfg);
-        let expected: syn::Attribute = parse_quote!(#[cfg(feature = "default2")]);
+        let expected: syn::Attribute = parse_quote!(#[cfg(feature = "default-2")]);
         assert_eq!(actual, expected);
     }
 
@@ -727,7 +727,7 @@ mod tests {
         let cfg = CfgFeature::for_schema_type(&graph, &default_type);
 
         let actual: syn::Attribute = parse_quote!(#cfg);
-        let expected: syn::Attribute = parse_quote!(#[cfg(feature = "default2")]);
+        let expected: syn::Attribute = parse_quote!(#[cfg(feature = "default-2")]);
         assert_eq!(actual, expected);
     }
 

--- a/ploidy-codegen-rust/src/cfg.rs
+++ b/ploidy-codegen-rust/src/cfg.rs
@@ -286,7 +286,7 @@ mod tests {
     fn test_single_feature() {
         let arena = Arena::new();
         let mut scope = UniqueIdents::new(&arena);
-        let cfg = CfgFeature::Single(scope.ident("pets"));
+        let cfg = CfgFeature::Single(scope.reserve("pets"));
 
         let actual: syn::Attribute = parse_quote!(#cfg);
         let expected: syn::Attribute = parse_quote!(#[cfg(feature = "pets")]);
@@ -298,9 +298,9 @@ mod tests {
         let arena = Arena::new();
         let mut scope = UniqueIdents::new(&arena);
         let cfg = CfgFeature::AnyOf(BTreeSet::from_iter([
-            scope.ident("cats"),
-            scope.ident("dogs"),
-            scope.ident("aardvarks"),
+            scope.reserve("cats"),
+            scope.reserve("dogs"),
+            scope.reserve("aardvarks"),
         ]));
 
         let actual: syn::Attribute = parse_quote!(#cfg);
@@ -314,9 +314,9 @@ mod tests {
         let arena = Arena::new();
         let mut scope = UniqueIdents::new(&arena);
         let cfg = CfgFeature::AllOf(BTreeSet::from_iter([
-            scope.ident("cats"),
-            scope.ident("dogs"),
-            scope.ident("aardvarks"),
+            scope.reserve("cats"),
+            scope.reserve("dogs"),
+            scope.reserve("aardvarks"),
         ]));
 
         let actual: syn::Attribute = parse_quote!(#cfg);
@@ -330,8 +330,8 @@ mod tests {
         let arena = Arena::new();
         let mut scope = UniqueIdents::new(&arena);
         let cfg = CfgFeature::OwnAndUsedBy {
-            own: scope.ident("own"),
-            used_by: BTreeSet::from_iter([scope.ident("a"), scope.ident("b")]),
+            own: scope.reserve("own"),
+            used_by: BTreeSet::from_iter([scope.reserve("a"), scope.reserve("b")]),
         };
 
         let actual: syn::Attribute = parse_quote!(#cfg);
@@ -344,7 +344,7 @@ mod tests {
     fn test_any_of_simplifies_single_feature() {
         let arena = Arena::new();
         let mut scope = UniqueIdents::new(&arena);
-        let cfg = CfgFeature::any_of(BTreeSet::from_iter([scope.ident("pets")]));
+        let cfg = CfgFeature::any_of(BTreeSet::from_iter([scope.reserve("pets")]));
 
         let actual: syn::Attribute = parse_quote!(#cfg);
         let expected: syn::Attribute = parse_quote!(#[cfg(feature = "pets")]);
@@ -355,7 +355,7 @@ mod tests {
     fn test_all_of_simplifies_single_feature() {
         let arena = Arena::new();
         let mut scope = UniqueIdents::new(&arena);
-        let cfg = CfgFeature::all_of(BTreeSet::from_iter([scope.ident("pets")]));
+        let cfg = CfgFeature::all_of(BTreeSet::from_iter([scope.reserve("pets")]));
 
         let actual: syn::Attribute = parse_quote!(#cfg);
         let expected: syn::Attribute = parse_quote!(#[cfg(feature = "pets")]);
@@ -378,8 +378,8 @@ mod tests {
     fn test_own_and_used_by_simplifies_single_used_by_to_all_of() {
         let arena = Arena::new();
         let mut scope = UniqueIdents::new(&arena);
-        let own = scope.ident("own");
-        let other = scope.ident("other");
+        let own = scope.reserve("own");
+        let other = scope.reserve("other");
         // `OwnedAndUsedBy` with one `used_by` feature should simplify to `AllOf`.
         let cfg = CfgFeature::own_and_used_by(own, BTreeSet::from_iter([other]));
         assert_eq!(cfg, CfgFeature::AllOf(BTreeSet::from_iter([other, own])),);
@@ -389,7 +389,7 @@ mod tests {
     fn test_own_and_used_by_simplifies_empty_to_single() {
         let arena = Arena::new();
         let mut scope = UniqueIdents::new(&arena);
-        let own = scope.ident("own");
+        let own = scope.reserve("own");
         // `OwnedAndUsedBy` with no `used_by` features should simplify to `Single`.
         let cfg = CfgFeature::own_and_used_by(own, BTreeSet::new());
         assert_eq!(cfg, CfgFeature::Single(own));
@@ -399,8 +399,8 @@ mod tests {
     fn test_own_and_used_by_simplifies_own_used_by_to_single() {
         let arena = Arena::new();
         let mut scope = UniqueIdents::new(&arena);
-        let own = scope.ident("own");
-        let other = scope.ident("other");
+        let own = scope.reserve("own");
+        let other = scope.reserve("other");
         let cfg = CfgFeature::own_and_used_by(own, BTreeSet::from_iter([own, other]));
         assert_eq!(cfg, CfgFeature::Single(own));
     }

--- a/ploidy-codegen-rust/src/client.rs
+++ b/ploidy-codegen-rust/src/client.rs
@@ -213,7 +213,7 @@ mod tests {
         let mut scope = UniqueIdents::new(&arena);
         let resources = [
             ResourceGroup::Default,
-            ResourceGroup::Named(scope.ident("customer_profiles")),
+            ResourceGroup::Named(scope.reserve("customer_profiles")),
         ];
         let modules = ResourceModules(&resources);
 

--- a/ploidy-codegen-rust/src/graph.rs
+++ b/ploidy-codegen-rust/src/graph.rs
@@ -1,11 +1,12 @@
-use std::{collections::BTreeSet, fmt::Write, ops::Deref};
+use std::{collections::BTreeSet, fmt::Write, num::NonZeroUsize, ops::Deref};
 
 use ploidy_core::{
+    arena::Arena,
     ir::{
         ContainerView, CookedGraph, EnumVariant, EnumView, HasResource, HasTypeId,
         InlineTypePathRoot, InlineTypePathSegment, InlineTypePathView, InlineTypeView, OperationId,
-        OperationUsage, SchemaTypeView, StructFieldName, StructView, TaggedView, TypeId, TypeView,
-        UntaggedView, View,
+        OperationUsage, PrimitiveType, SchemaTypeView, StructFieldName, StructView, TaggedView,
+        TypeId, TypeView, UntaggedView, View,
     },
     parse::ParameterLocation,
 };
@@ -13,7 +14,7 @@ use rustc_hash::FxHashMap;
 
 use super::{
     config::{CodegenConfig, DateTimeFormat},
-    naming::{CodegenIdentUsage, ResourceGroup, UniqueIdent, UniqueIdents},
+    naming::{CodegenIdentUsage, ResourceGroup, UniqueIdent, UniqueIdents, idents},
 };
 
 /// A [`CookedGraph`] decorated with Rust-specific information.
@@ -51,10 +52,7 @@ impl<'a> CodegenGraph<'a> {
             Operation(op) => self.idents[&Key::Operation(op)],
             Path(op, name) => self.idents[&Key::Parameter(op, ParameterLocation::Path, name)],
             Query(op, name) => self.idents[&Key::Parameter(op, ParameterLocation::Query, name)],
-            Type(id) => match self.cooked.view(id) {
-                TypeView::Schema(s) => self.idents[&Key::Schema(s.name())],
-                TypeView::Inline(i) => self.idents[&Key::Inline(i.id())],
-            },
+            Type(id) => self.idents[&Key::Type(id)],
             StructField(id, name) => self.idents[&Key::StructField(id, name)],
             EnumVariant(id, name) => self.idents[&Key::EnumVariant(id, name)],
             TaggedVariant(id, name) => self.idents[&Key::TaggedVariant(id, name)],
@@ -91,29 +89,21 @@ impl<'a> Deref for CodegenGraph<'a> {
 pub enum IdentMapping<'a> {
     /// A schema or inline type.
     Type(TypeId),
-
     /// An operation method.
     Operation(&'a OperationId),
-
     /// A path parameter for an operation.
     Path(&'a OperationId, &'a str),
-
     /// A query parameter for an operation.
     Query(&'a OperationId, &'a str),
-
     /// A struct field.
     StructField(TypeId, StructFieldName<'a>),
-
     /// A string enum variant.
     EnumVariant(TypeId, &'a str),
-
     /// A tagged union variant.
     TaggedVariant(TypeId, &'a str),
-
     /// An untagged union variant.
-    UntaggedVariant(TypeId, usize),
-
-    /// ...
+    UntaggedVariant(TypeId, NonZeroUsize),
+    /// A resource name for a type or an operation.
     Resource(&'a str),
 }
 
@@ -133,22 +123,22 @@ impl<'a> From<TypeId> for IdentMapping<'a> {
 
 /// Builds the identifier table for every name that Rust code generation emits.
 ///
-/// Names are assigned in dependency order. Schema, operation, parameter, field,
-/// and variant identifiers are uniquified first; inline type names are composed
-/// from those earlier identifiers.
+/// Names are assigned in dependency order. Schema types and operations are
+/// uniquified first, then inline types are named from their paths, and finally
+/// inline type members.
 fn ident_map<'a>(cooked: &CookedGraph<'a>) -> IdentMap<'a> {
     let mut idents = FxHashMap::default();
     idents.extend({
         let mut scope = UniqueIdents::new(cooked.arena());
         cooked
             .schemas()
-            .map(move |ty| (IdentMapKey::Schema(ty.name()), scope.ident(ty.name())))
+            .map(move |ty| (IdentMapKey::Type(ty.id()), scope.reserve(ty.name())))
     });
     idents.extend({
         let mut scope = UniqueIdents::new(cooked.arena());
         cooked
             .operations()
-            .map(move |op| (IdentMapKey::Operation(op.id()), scope.ident(op.id())))
+            .map(move |op| (IdentMapKey::Operation(op.id()), scope.reserve(op.id())))
     });
     idents.extend({
         let resources: BTreeSet<_> = cooked
@@ -160,7 +150,7 @@ fn ident_map<'a>(cooked: &CookedGraph<'a>) -> IdentMap<'a> {
         let mut scope = UniqueIdents::with_reserved(cooked.arena(), &["default"]);
         resources
             .into_iter()
-            .map(move |name| (IdentMapKey::Resource(name), scope.ident(name)))
+            .map(move |name| (IdentMapKey::Resource(name), scope.reserve(name)))
     });
     for op in cooked.operations() {
         {
@@ -172,7 +162,7 @@ fn ident_map<'a>(cooked: &CookedGraph<'a>) -> IdentMap<'a> {
                 &["query", "request", "form", "url", "response"],
             );
             for param in op.path().params() {
-                let ident = scope.ident(param.name());
+                let ident = scope.reserve(param.name());
                 idents.insert(
                     IdentMapKey::Parameter(op.id(), ParameterLocation::Path, param.name()),
                     ident,
@@ -183,7 +173,7 @@ fn ident_map<'a>(cooked: &CookedGraph<'a>) -> IdentMap<'a> {
             // Query parameters become regular struct fields.
             let mut scope = UniqueIdents::new(cooked.arena());
             for param in op.query() {
-                let ident = scope.ident(param.name());
+                let ident = scope.reserve(param.name());
                 idents.insert(
                     IdentMapKey::Parameter(op.id(), ParameterLocation::Query, param.name()),
                     ident,
@@ -192,85 +182,15 @@ fn ident_map<'a>(cooked: &CookedGraph<'a>) -> IdentMap<'a> {
         }
     }
 
-    {
-        let domains = cooked
-            .schemas()
-            .filter_map(MemberIdentDomain::from_schema_type)
-            .chain(
-                cooked
-                    .schemas()
-                    .flat_map(|s| s.inlines())
-                    .chain(cooked.operations().flat_map(|op| op.inlines()))
-                    .filter_map(MemberIdentDomain::from_inline_type),
-            );
-        for domain in domains {
-            match domain {
-                // Own, inherited, and synthesized struct fields.
-                MemberIdentDomain::Struct(id, view) => {
-                    let mut scope = UniqueIdents::new(cooked.arena());
-                    for field in view.fields() {
-                        let ident = match field.name() {
-                            StructFieldName::Name(n) => scope.ident(n),
-                            StructFieldName::Hint(hint) => scope.field_name_hint(hint),
-                        };
-                        idents.insert(IdentMapKey::StructField(id, field.name()), ident);
-                    }
-                }
-                // Common fields inherited by all untagged variants. The struct arm
-                // uniquifies them for fields; this arm uniquifies them for
-                // naming inline types.
-                MemberIdentDomain::Untagged(id, view) => {
-                    let mut scope = UniqueIdents::new(cooked.arena());
-                    for (index, variant) in view.variants().enumerate() {
-                        let ident = match variant.ty() {
-                            Some(variant) => scope.variant_name_hint(variant.hint),
-                            None => scope.ident("None"),
-                        };
-                        idents.insert(IdentMapKey::UntaggedVariant(id, index), ident);
-                    }
-                    let mut scope = UniqueIdents::new(cooked.arena());
-                    for field in view.fields() {
-                        let ident = match field.name() {
-                            StructFieldName::Name(n) => scope.ident(n),
-                            StructFieldName::Hint(hint) => scope.field_name_hint(hint),
-                        };
-                        idents.insert(IdentMapKey::StructField(id, field.name()), ident);
-                    }
-                }
-                // String enum variants.
-                MemberIdentDomain::Enum(id, view) => {
-                    let mut scope = UniqueIdents::new(cooked.arena());
-                    for variant in view.variants() {
-                        if let EnumVariant::String(name) = variant {
-                            let ident = scope.ident(name);
-                            idents.insert(IdentMapKey::EnumVariant(id, name), ident);
-                        }
-                    }
-                }
-                // Tagged variant names and common fields form different scopes:
-                // variant names must be unique within the generated enum;
-                // common fields are for naming inline types.
-                MemberIdentDomain::Tagged(id, view) => {
-                    let mut scope = UniqueIdents::new(cooked.arena());
-                    for variant in view.variants() {
-                        let ident = scope.ident(variant.name());
-                        idents.insert(IdentMapKey::TaggedVariant(id, variant.name()), ident);
-                    }
-                    let mut scope = UniqueIdents::new(cooked.arena());
-                    for field in view.fields() {
-                        let ident = match field.name() {
-                            StructFieldName::Name(n) => scope.ident(n),
-                            StructFieldName::Hint(hint) => scope.field_name_hint(hint),
-                        };
-                        idents.insert(IdentMapKey::StructField(id, field.name()), ident);
-                    }
-                }
-            }
+    for schema in cooked.schemas() {
+        if let Some(domain) = MemberIdentDomain::from_schema_type(schema) {
+            let map = domain.into_idents(cooked.arena(), &idents);
+            idents.extend(map);
         }
     }
 
-    // Inline type names depend on uniquified path segments, so build them after
-    // all schemas, operations, parameters, fields, and variants have names.
+    // Inline type names depend on uniquified path segments. Build each inline
+    // type after its parent, then name its members for child path segments.
     {
         let inlines = cooked
             .schemas()
@@ -296,7 +216,11 @@ fn ident_map<'a>(cooked: &CookedGraph<'a>) -> IdentMap<'a> {
             let scope = scopes
                 .entry(domain)
                 .or_insert_with(|| UniqueIdents::new(cooked.arena()));
-            idents.insert(IdentMapKey::Inline(inline.id()), scope.ident(&name));
+            idents.insert(IdentMapKey::Type(inline.id()), scope.reserve(&name));
+            if let Some(domain) = MemberIdentDomain::from_inline_type(inline) {
+                let map = domain.into_idents(cooked.arena(), &idents);
+                idents.extend(map);
+            }
         }
     }
     idents
@@ -306,15 +230,14 @@ type IdentMap<'a> = FxHashMap<IdentMapKey<'a>, &'a UniqueIdent>;
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 enum IdentMapKey<'a> {
-    Schema(&'a str),
-    Inline(TypeId),
+    Type(TypeId),
     Operation(&'a OperationId),
     Parameter(&'a OperationId, ParameterLocation, &'a str),
     Resource(&'a str),
     StructField(TypeId, StructFieldName<'a>),
     EnumVariant(TypeId, &'a str),
     TaggedVariant(TypeId, &'a str),
-    UntaggedVariant(TypeId, usize),
+    UntaggedVariant(TypeId, NonZeroUsize),
 }
 
 /// A uniqueness domain for inline type identifiers.
@@ -324,7 +247,6 @@ enum InlineTypeIdentDomain<'a> {
     Resource(ResourceGroup<'a>),
 }
 
-/// A uniqueness domain for field and variant identifiers.
 enum MemberIdentDomain<'graph, 'a> {
     Struct(TypeId, StructView<'graph, 'a>),
     Enum(TypeId, EnumView<'graph, 'a>),
@@ -336,10 +258,10 @@ impl<'graph, 'a> MemberIdentDomain<'graph, 'a> {
     fn from_schema_type(schema: SchemaTypeView<'graph, 'a>) -> Option<Self> {
         let id = schema.id();
         Some(match schema {
-            SchemaTypeView::Struct(_, v) => Self::Struct(id, v),
-            SchemaTypeView::Enum(_, v) => Self::Enum(id, v),
-            SchemaTypeView::Tagged(_, v) => Self::Tagged(id, v),
-            SchemaTypeView::Untagged(_, v) => Self::Untagged(id, v),
+            SchemaTypeView::Struct(_, view) => Self::Struct(id, view),
+            SchemaTypeView::Enum(_, view) => Self::Enum(id, view),
+            SchemaTypeView::Tagged(_, view) => Self::Tagged(id, view),
+            SchemaTypeView::Untagged(_, view) => Self::Untagged(id, view),
             _ => return None,
         })
     }
@@ -347,12 +269,145 @@ impl<'graph, 'a> MemberIdentDomain<'graph, 'a> {
     fn from_inline_type(inline: InlineTypeView<'graph, 'a>) -> Option<Self> {
         let id = inline.id();
         Some(match inline {
-            InlineTypeView::Struct(_, v) => Self::Struct(id, v),
-            InlineTypeView::Enum(_, v) => Self::Enum(id, v),
-            InlineTypeView::Tagged(_, v) => Self::Tagged(id, v),
-            InlineTypeView::Untagged(_, v) => Self::Untagged(id, v),
+            InlineTypeView::Struct(_, view) => Self::Struct(id, view),
+            InlineTypeView::Enum(_, view) => Self::Enum(id, view),
+            InlineTypeView::Tagged(_, view) => Self::Tagged(id, view),
+            InlineTypeView::Untagged(_, view) => Self::Untagged(id, view),
             _ => return None,
         })
+    }
+
+    fn into_idents(self, arena: &'a Arena, idents: &IdentMap<'a>) -> IdentMap<'a> {
+        let mut map = IdentMap::default();
+        match self {
+            Self::Struct(id, view) => {
+                // Own, inherited, and synthesized struct fields.
+                let mut scope = UniqueIdents::new(arena);
+                for field in view.fields() {
+                    let name = field.name();
+                    let ident = match name {
+                        StructFieldName::Name(name) => scope.reserve(name),
+                        StructFieldName::Ordinal(ordinal) => {
+                            let ident = idents[&IdentMapKey::Type(id)];
+                            scope.reserve(&format!(
+                                "{}_{ordinal}",
+                                CodegenIdentUsage::Type(ident).display()
+                            ))
+                        }
+                        StructFieldName::AdditionalProperties => {
+                            scope.reserve_ident(idents::ADDITIONAL_PROPERTIES)
+                        }
+                    };
+                    map.insert(IdentMapKey::StructField(id, name), ident);
+                }
+            }
+            Self::Enum(id, view) => {
+                let mut scope = UniqueIdents::new(arena);
+                for &variant in view.variants() {
+                    if let EnumVariant::String(name) = variant {
+                        let ident = scope.reserve(name);
+                        map.insert(IdentMapKey::EnumVariant(id, name), ident);
+                    }
+                }
+            }
+            Self::Tagged(id, view) => {
+                // Tagged variant names and common fields form different scopes:
+                // variant names must be unique within the generated enum;
+                // common fields are for naming inline types.
+                let mut scope = UniqueIdents::new(arena);
+                for variant in view.variants() {
+                    let name = variant.name();
+                    let ident = scope.reserve(name);
+                    map.insert(IdentMapKey::TaggedVariant(id, name), ident);
+                }
+                let mut scope = UniqueIdents::new(arena);
+                for field in view.fields() {
+                    let name = field.name();
+                    let ident = match name {
+                        StructFieldName::Name(name) => scope.reserve(name),
+                        StructFieldName::Ordinal(ordinal) => {
+                            let ident = idents[&IdentMapKey::Type(id)];
+                            scope.reserve(&format!(
+                                "{}_{ordinal}",
+                                CodegenIdentUsage::Type(ident).display()
+                            ))
+                        }
+                        StructFieldName::AdditionalProperties => {
+                            scope.reserve_ident(idents::ADDITIONAL_PROPERTIES)
+                        }
+                    };
+                    map.insert(IdentMapKey::StructField(id, name), ident);
+                }
+            }
+            Self::Untagged(id, view) => {
+                let mut scope = UniqueIdents::new(arena);
+                for variant in view.variants() {
+                    use {ContainerView::*, InlineTypeView::*, TypeView::*};
+                    let ordinal = variant.ordinal();
+                    let ident = match variant.ty() {
+                        Some(Schema(schema)) => {
+                            let ident = idents[&IdentMapKey::Type(schema.id())];
+                            scope.reserve_ident(ident)
+                        }
+                        Some(Inline(Primitive(_, primitive))) => {
+                            let ident = match primitive.ty() {
+                                PrimitiveType::String => idents::STRING,
+                                PrimitiveType::I8 => idents::I8,
+                                PrimitiveType::U8 => idents::U8,
+                                PrimitiveType::I16 => idents::I16,
+                                PrimitiveType::U16 => idents::U16,
+                                PrimitiveType::I32 => idents::I32,
+                                PrimitiveType::U32 => idents::U32,
+                                PrimitiveType::I64 => idents::I64,
+                                PrimitiveType::U64 => idents::U64,
+                                PrimitiveType::F32 => idents::F32,
+                                PrimitiveType::F64 => idents::F64,
+                                PrimitiveType::Bool => idents::BOOL,
+                                PrimitiveType::DateTime => idents::DATE_TIME,
+                                PrimitiveType::UnixTime => idents::UNIX_TIME,
+                                PrimitiveType::Date => idents::DATE,
+                                PrimitiveType::Url => idents::URL,
+                                PrimitiveType::Uuid => idents::UUID,
+                                PrimitiveType::Bytes => idents::BYTES,
+                                PrimitiveType::Binary => idents::BINARY,
+                            };
+                            scope.reserve_ident(ident)
+                        }
+                        Some(Inline(Container(_, Array(_)))) => scope.reserve_ident(idents::ARRAY),
+                        Some(Inline(Container(_, Map(_)))) => scope.reserve_ident(idents::MAP),
+                        Some(Inline(..)) => {
+                            let ident = idents[&IdentMapKey::Type(id)];
+                            scope.reserve(&format!(
+                                "{}_{ordinal}",
+                                CodegenIdentUsage::Type(ident).display()
+                            ))
+                        }
+                        None => scope.reserve_ident(idents::NONE),
+                    };
+                    map.insert(IdentMapKey::UntaggedVariant(id, ordinal), ident);
+                }
+                // Common fields inherited by all untagged variants.
+                let mut scope = UniqueIdents::new(arena);
+                for field in view.fields() {
+                    let name = field.name();
+                    let ident = match name {
+                        StructFieldName::Name(name) => scope.reserve(name),
+                        StructFieldName::Ordinal(ordinal) => {
+                            let ident = idents[&IdentMapKey::Type(id)];
+                            scope.reserve(&format!(
+                                "{}_{ordinal}",
+                                CodegenIdentUsage::Type(ident).display()
+                            ))
+                        }
+                        StructFieldName::AdditionalProperties => {
+                            scope.reserve_ident(idents::ADDITIONAL_PROPERTIES)
+                        }
+                    };
+                    map.insert(IdentMapKey::StructField(id, name), ident);
+                }
+            }
+        }
+        map
     }
 }
 
@@ -362,55 +417,64 @@ fn inline_type_candidate_name<'a>(
 ) -> String {
     let mut name = String::new();
 
-    match path.root() {
-        InlineTypePathRoot::Schema(_) => {}
-        InlineTypePathRoot::Operation { id, usage, .. } => {
-            let ident = idents[&IdentMapKey::Operation(id)];
-            write!(name, "{}", CodegenIdentUsage::Type(ident).display()).unwrap();
-
-            match usage {
-                OperationUsage::Path(param) => {
-                    let ident = idents[&IdentMapKey::Parameter(id, ParameterLocation::Path, param)];
-                    write!(name, "Path{}", CodegenIdentUsage::Type(ident).display()).unwrap();
-                }
-                OperationUsage::Query(param) => {
-                    let ident =
-                        idents[&IdentMapKey::Parameter(id, ParameterLocation::Query, param)];
-                    write!(name, "Query{}", CodegenIdentUsage::Type(ident).display()).unwrap();
-                }
-                OperationUsage::Request => name.push_str("Request"),
-                OperationUsage::Response => name.push_str("Response"),
-            }
-        }
-    }
-
     for segment in path.segments() {
         match segment {
-            InlineTypePathSegment::Field(parent, field_name) => {
-                let ident = idents[&IdentMapKey::StructField(parent, field_name)];
+            InlineTypePathSegment::Field(parent, field) => {
+                let ident = idents[&IdentMapKey::StructField(parent, field)];
                 write!(name, "{}", CodegenIdentUsage::Type(ident).display()).unwrap();
             }
-            InlineTypePathSegment::TaggedVariant(parent, variant_name) => {
-                let ident = idents[&IdentMapKey::TaggedVariant(parent, variant_name)];
+            InlineTypePathSegment::TaggedVariant(parent, variant) => {
+                let ident = idents[&IdentMapKey::TaggedVariant(parent, variant)];
                 write!(name, "{}", CodegenIdentUsage::Variant(ident).display()).unwrap();
             }
-            InlineTypePathSegment::UntaggedVariant(index) => {
-                write!(name, "V{index}").unwrap();
+            InlineTypePathSegment::UntaggedVariant(parent, ordinal) => {
+                let ident = idents[&IdentMapKey::UntaggedVariant(parent, ordinal)];
+                write!(name, "{}", CodegenIdentUsage::Variant(ident).display()).unwrap();
             }
             InlineTypePathSegment::ArrayItem => name.push_str("Item"),
             InlineTypePathSegment::MapValue => name.push_str("Value"),
             InlineTypePathSegment::Optional => {
                 // Optional types are invisible for naming.
             }
-            InlineTypePathSegment::Inherits(index) => {
-                write!(name, "P{index}").unwrap();
+            InlineTypePathSegment::Inherits(parent, ordinal) => {
+                let ident = idents[&IdentMapKey::Type(parent)];
+                write!(
+                    name,
+                    "{}_{ordinal}",
+                    CodegenIdentUsage::Type(ident).display()
+                )
+                .unwrap();
             }
         }
     }
 
-    if name.is_empty() {
-        name.push_str("Value");
-    }
+    match path.root() {
+        InlineTypePathRoot::Schema(id) if name.is_empty() => {
+            let ident = idents[&IdentMapKey::Type(id)];
+            CodegenIdentUsage::Type(ident).display().to_string()
+        }
+        InlineTypePathRoot::Schema(..) => name,
+        InlineTypePathRoot::Operation { id, usage, .. } => {
+            let mut full = String::new();
 
-    name
+            let ident = idents[&IdentMapKey::Operation(id)];
+            write!(full, "{}", CodegenIdentUsage::Type(ident).display()).unwrap();
+            match usage {
+                OperationUsage::Path(param) => {
+                    let ident = idents[&IdentMapKey::Parameter(id, ParameterLocation::Path, param)];
+                    write!(full, "Path{}", CodegenIdentUsage::Type(ident).display()).unwrap();
+                }
+                OperationUsage::Query(param) => {
+                    let ident =
+                        idents[&IdentMapKey::Parameter(id, ParameterLocation::Query, param)];
+                    write!(full, "Query{}", CodegenIdentUsage::Type(ident).display()).unwrap();
+                }
+                OperationUsage::Request => full.push_str("Request"),
+                OperationUsage::Response => full.push_str("Response"),
+            }
+            full.push_str(&name);
+
+            full
+        }
+    }
 }

--- a/ploidy-codegen-rust/src/naming.rs
+++ b/ploidy-codegen-rust/src/naming.rs
@@ -8,12 +8,40 @@ use itertools::Itertools;
 use ploidy_core::{
     arena::Arena,
     codegen::{UniqueNames, unique::WordSegments},
-    ir::{PrimitiveType, StructFieldNameHint, UntaggedVariantNameHint},
 };
 
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{IdentFragment, ToTokens, TokenStreamExt};
 use ref_cast::{RefCastCustom, ref_cast_custom};
+
+/// Static identifiers for type and field names.
+pub mod idents {
+    use super::CodegenIdent;
+
+    pub const ADDITIONAL_PROPERTIES: &CodegenIdent = CodegenIdent::new("additional_properties");
+    pub const ARRAY: &CodegenIdent = CodegenIdent::new("Array");
+    pub const BINARY: &CodegenIdent = CodegenIdent::new("Binary");
+    pub const BOOL: &CodegenIdent = CodegenIdent::new("Bool");
+    pub const BYTES: &CodegenIdent = CodegenIdent::new("Bytes");
+    pub const DATE: &CodegenIdent = CodegenIdent::new("Date");
+    pub const DATE_TIME: &CodegenIdent = CodegenIdent::new("DateTime");
+    pub const F32: &CodegenIdent = CodegenIdent::new("F32");
+    pub const F64: &CodegenIdent = CodegenIdent::new("F64");
+    pub const I8: &CodegenIdent = CodegenIdent::new("I8");
+    pub const I16: &CodegenIdent = CodegenIdent::new("I16");
+    pub const I32: &CodegenIdent = CodegenIdent::new("I32");
+    pub const I64: &CodegenIdent = CodegenIdent::new("I64");
+    pub const MAP: &CodegenIdent = CodegenIdent::new("Map");
+    pub const NONE: &CodegenIdent = CodegenIdent::new("None");
+    pub const STRING: &CodegenIdent = CodegenIdent::new("String");
+    pub const U8: &CodegenIdent = CodegenIdent::new("U8");
+    pub const U16: &CodegenIdent = CodegenIdent::new("U16");
+    pub const U32: &CodegenIdent = CodegenIdent::new("U32");
+    pub const U64: &CodegenIdent = CodegenIdent::new("U64");
+    pub const UNIX_TIME: &CodegenIdent = CodegenIdent::new("UnixTime");
+    pub const URL: &CodegenIdent = CodegenIdent::new("Url");
+    pub const UUID: &CodegenIdent = CodegenIdent::new("Uuid");
+}
 
 // Keywords that can't be used as identifiers, even with `r#`.
 const KEYWORDS: &[&str] = &["crate", "self", "super", "Self"];
@@ -25,7 +53,7 @@ pub struct CodegenIdent(str);
 
 impl CodegenIdent {
     #[ref_cast_custom]
-    fn new(s: &str) -> &Self;
+    const fn new(s: &str) -> &Self;
 }
 
 /// An identifier that's unique within its [`UniqueIdents`] scope.
@@ -198,49 +226,14 @@ impl<'a> UniqueIdents<'a> {
 
     /// Cleans and uniquifies an identifier.
     #[inline]
-    pub fn ident(&mut self, name: &str) -> &'a UniqueIdent {
+    pub fn reserve(&mut self, name: &str) -> &'a UniqueIdent {
         UniqueIdent::new(self.0.uniquify(&clean(name)))
     }
 
-    /// Uniquifies a struct field name from a [`StructFieldNameHint`].
+    /// Uniquifies an already-cleaned identifier.
     #[inline]
-    pub fn field_name_hint(&mut self, hint: StructFieldNameHint) -> &'a UniqueIdent {
-        use StructFieldNameHint::*;
-        UniqueIdent::new(match hint {
-            Index(index) => self.0.uniquify(&format!("variant_{index}")),
-            AdditionalProperties => self.0.uniquify("additional_properties"),
-        })
-    }
-
-    /// Uniquifies an untagged union variant name from an
-    /// [`UntaggedVariantNameHint`].
-    #[inline]
-    pub fn variant_name_hint(&mut self, hint: UntaggedVariantNameHint) -> &'a UniqueIdent {
-        use {PrimitiveType::*, UntaggedVariantNameHint::*};
-        UniqueIdent::new(match hint {
-            Primitive(String) => self.0.uniquify("String"),
-            Primitive(I8) => self.0.uniquify("I8"),
-            Primitive(U8) => self.0.uniquify("U8"),
-            Primitive(I16) => self.0.uniquify("I16"),
-            Primitive(U16) => self.0.uniquify("U16"),
-            Primitive(I32) => self.0.uniquify("I32"),
-            Primitive(U32) => self.0.uniquify("U32"),
-            Primitive(I64) => self.0.uniquify("I64"),
-            Primitive(U64) => self.0.uniquify("U64"),
-            Primitive(F32) => self.0.uniquify("F32"),
-            Primitive(F64) => self.0.uniquify("F64"),
-            Primitive(Bool) => self.0.uniquify("Bool"),
-            Primitive(DateTime) => self.0.uniquify("DateTime"),
-            Primitive(UnixTime) => self.0.uniquify("UnixTime"),
-            Primitive(Date) => self.0.uniquify("Date"),
-            Primitive(Url) => self.0.uniquify("Url"),
-            Primitive(Uuid) => self.0.uniquify("Uuid"),
-            Primitive(Bytes) => self.0.uniquify("Bytes"),
-            Primitive(Binary) => self.0.uniquify("Binary"),
-            Array => self.0.uniquify("Array"),
-            Map => self.0.uniquify("Map"),
-            Index(index) => self.0.uniquify(&format!("V{index}")),
-        })
+    pub fn reserve_ident(&mut self, name: &CodegenIdent) -> &'a UniqueIdent {
+        UniqueIdent::new(self.0.uniquify(&name.0))
     }
 }
 
@@ -273,7 +266,7 @@ mod tests {
     fn test_codegen_ident_type() {
         let arena = Arena::new();
         let mut scope = UniqueIdents::new(&arena);
-        let ident = scope.ident("pet_store");
+        let ident = scope.reserve("pet_store");
         let usage = CodegenIdentUsage::Type(ident);
         let actual: syn::Ident = parse_quote!(#usage);
         let expected: syn::Ident = parse_quote!(PetStore);
@@ -284,7 +277,7 @@ mod tests {
     fn test_codegen_ident_field() {
         let arena = Arena::new();
         let mut scope = UniqueIdents::new(&arena);
-        let ident = scope.ident("petStore");
+        let ident = scope.reserve("petStore");
         let usage = CodegenIdentUsage::Field(ident);
         let actual: syn::Ident = parse_quote!(#usage);
         let expected: syn::Ident = parse_quote!(pet_store);
@@ -295,7 +288,7 @@ mod tests {
     fn test_codegen_ident_module() {
         let arena = Arena::new();
         let mut scope = UniqueIdents::new(&arena);
-        let ident = scope.ident("MyModule");
+        let ident = scope.reserve("MyModule");
         let usage = CodegenIdentUsage::Module(ident);
         let actual: syn::Ident = parse_quote!(#usage);
         let expected: syn::Ident = parse_quote!(my_module);
@@ -306,7 +299,7 @@ mod tests {
     fn test_codegen_ident_variant() {
         let arena = Arena::new();
         let mut scope = UniqueIdents::new(&arena);
-        let ident = scope.ident("http_error");
+        let ident = scope.reserve("http_error");
         let usage = CodegenIdentUsage::Variant(ident);
         let actual: syn::Ident = parse_quote!(#usage);
         let expected: syn::Ident = parse_quote!(HttpError);
@@ -317,7 +310,7 @@ mod tests {
     fn test_codegen_ident_param() {
         let arena = Arena::new();
         let mut scope = UniqueIdents::new(&arena);
-        let ident = scope.ident("userId");
+        let ident = scope.reserve("userId");
         let usage = CodegenIdentUsage::Param(ident);
         let actual: syn::Ident = parse_quote!(#usage);
         let expected: syn::Ident = parse_quote!(user_id);
@@ -328,7 +321,7 @@ mod tests {
     fn test_codegen_ident_method() {
         let arena = Arena::new();
         let mut scope = UniqueIdents::new(&arena);
-        let ident = scope.ident("getUserById");
+        let ident = scope.reserve("getUserById");
         let usage = CodegenIdentUsage::Method(ident);
         let actual: syn::Ident = parse_quote!(#usage);
         let expected: syn::Ident = parse_quote!(get_user_by_id);
@@ -339,7 +332,7 @@ mod tests {
     fn test_codegen_ident_method_preserves_numeric_boundary() {
         let arena = Arena::new();
         let mut scope = UniqueIdents::new(&arena);
-        let ident = scope.ident("get_fees1");
+        let ident = scope.reserve("get_fees1");
 
         let usage = CodegenIdentUsage::Method(ident);
         let actual: syn::Ident = parse_quote!(#usage);
@@ -358,7 +351,7 @@ mod tests {
     fn test_codegen_ident_handles_rust_keywords() {
         let arena = Arena::new();
         let mut scope = UniqueIdents::new(&arena);
-        let ident = scope.ident("type");
+        let ident = scope.reserve("type");
         let usage = CodegenIdentUsage::Field(ident);
         let actual: syn::Ident = parse_quote!(#usage);
         let expected: syn::Ident = parse_quote!(r#type);
@@ -369,7 +362,7 @@ mod tests {
     fn test_codegen_ident_handles_invalid_start_chars() {
         let arena = Arena::new();
         let mut scope = UniqueIdents::new(&arena);
-        let ident = scope.ident("123foo");
+        let ident = scope.reserve("123foo");
         let usage = CodegenIdentUsage::Field(ident);
         let actual: syn::Ident = parse_quote!(#usage);
         let expected: syn::Ident = parse_quote!(_123_foo);
@@ -380,7 +373,7 @@ mod tests {
     fn test_codegen_ident_handles_special_chars() {
         let arena = Arena::new();
         let mut scope = UniqueIdents::new(&arena);
-        let ident = scope.ident("foo-bar-baz");
+        let ident = scope.reserve("foo-bar-baz");
         let usage = CodegenIdentUsage::Field(ident);
         let actual: syn::Ident = parse_quote!(#usage);
         let expected: syn::Ident = parse_quote!(foo_bar_baz);
@@ -391,7 +384,7 @@ mod tests {
     fn test_codegen_ident_handles_number_prefix() {
         let arena = Arena::new();
         let mut scope = UniqueIdents::new(&arena);
-        let ident = scope.ident("1099KStatus");
+        let ident = scope.reserve("1099KStatus");
 
         let usage = CodegenIdentUsage::Field(ident);
         let actual: syn::Ident = parse_quote!(#usage);
@@ -401,50 +394,6 @@ mod tests {
         let usage = CodegenIdentUsage::Type(ident);
         let actual: syn::Ident = parse_quote!(#usage);
         let expected: syn::Ident = parse_quote!(_1099KStatus);
-        assert_eq!(actual, expected);
-    }
-
-    // MARK: Untagged variant names
-
-    #[test]
-    fn test_untagged_variant_name_index() {
-        let arena = Arena::new();
-        let mut scope = UniqueIdents::new(&arena);
-
-        let ident = scope.variant_name_hint(UntaggedVariantNameHint::Index(0));
-        assert_eq!(&ident.0, "V");
-
-        let ident = scope.variant_name_hint(UntaggedVariantNameHint::Index(42));
-        assert_eq!(&ident.0, "V_42");
-    }
-
-    // MARK: Struct field names
-
-    #[test]
-    fn test_struct_field_name_index() {
-        let arena = Arena::new();
-        let mut scope = UniqueIdents::new(&arena);
-        let ident0 = scope.field_name_hint(StructFieldNameHint::Index(0));
-        let usage = CodegenIdentUsage::Field(ident0);
-        let actual: syn::Ident = parse_quote!(#usage);
-        let expected: syn::Ident = parse_quote!(variant);
-        assert_eq!(actual, expected);
-
-        let ident5 = scope.field_name_hint(StructFieldNameHint::Index(5));
-        let usage = CodegenIdentUsage::Field(ident5);
-        let actual: syn::Ident = parse_quote!(#usage);
-        let expected: syn::Ident = parse_quote!(variant_5);
-        assert_eq!(actual, expected);
-    }
-
-    #[test]
-    fn test_struct_field_name_additional_properties() {
-        let arena = Arena::new();
-        let mut scope = UniqueIdents::new(&arena);
-        let ident = scope.field_name_hint(StructFieldNameHint::AdditionalProperties);
-        let usage = CodegenIdentUsage::Field(ident);
-        let actual: syn::Ident = parse_quote!(#usage);
-        let expected: syn::Ident = parse_quote!(additional_properties);
         assert_eq!(actual, expected);
     }
 
@@ -487,7 +436,7 @@ mod tests {
     fn test_codegen_ident_scope_handles_empty() {
         let arena = Arena::new();
         let mut scope = UniqueIdents::new(&arena);
-        let ident = scope.ident("");
+        let ident = scope.reserve("");
 
         let usage = CodegenIdentUsage::Field(ident);
         let actual: syn::Ident = parse_quote!(#usage);
@@ -505,13 +454,13 @@ mod tests {
         let arena = Arena::new();
         let mut scope = UniqueIdents::new(&arena);
 
-        let ident = scope.ident("0");
+        let ident = scope.reserve("0");
         let usage = CodegenIdentUsage::Field(ident);
         let actual: syn::Ident = parse_quote!(#usage);
         let expected: syn::Ident = parse_quote!(_1);
         assert_eq!(actual, expected);
 
-        let ident = scope.ident("1");
+        let ident = scope.reserve("1");
         let usage = CodegenIdentUsage::Type(ident);
         let actual: syn::Ident = parse_quote!(#usage);
         let expected: syn::Ident = parse_quote!(_2);
@@ -523,13 +472,13 @@ mod tests {
         let arena = Arena::new();
         let mut scope = UniqueIdents::new(&arena);
 
-        let ident = scope.ident("crate");
+        let ident = scope.reserve("crate");
         let usage = CodegenIdentUsage::Method(ident);
         let actual: syn::Ident = parse_quote!(#usage);
         let expected: syn::Ident = parse_quote!(crate_2);
         assert_eq!(actual, expected);
 
-        let ident = scope.ident("crate2");
+        let ident = scope.reserve("crate2");
         let usage = CodegenIdentUsage::Method(ident);
         let actual: syn::Ident = parse_quote!(#usage);
         let expected: syn::Ident = parse_quote!(crate_3);

--- a/ploidy-codegen-rust/src/naming.rs
+++ b/ploidy-codegen-rust/src/naming.rs
@@ -335,6 +335,23 @@ mod tests {
         assert_eq!(actual, expected);
     }
 
+    #[test]
+    fn test_codegen_ident_method_preserves_numeric_boundary() {
+        let arena = Arena::new();
+        let mut scope = UniqueIdents::new(&arena);
+        let ident = scope.ident("get_fees1");
+
+        let usage = CodegenIdentUsage::Method(ident);
+        let actual: syn::Ident = parse_quote!(#usage);
+        let expected: syn::Ident = parse_quote!(get_fees_1);
+        assert_eq!(actual, expected);
+
+        let usage = CodegenIdentUsage::Type(ident);
+        let actual: syn::Ident = parse_quote!(#usage);
+        let expected: syn::Ident = parse_quote!(GetFees1);
+        assert_eq!(actual, expected);
+    }
+
     // MARK: Special characters
 
     #[test]
@@ -398,7 +415,7 @@ mod tests {
         assert_eq!(&ident.0, "V");
 
         let ident = scope.variant_name_hint(UntaggedVariantNameHint::Index(42));
-        assert_eq!(&ident.0, "V42");
+        assert_eq!(&ident.0, "V_42");
     }
 
     // MARK: Struct field names
@@ -416,7 +433,7 @@ mod tests {
         let ident5 = scope.field_name_hint(StructFieldNameHint::Index(5));
         let usage = CodegenIdentUsage::Field(ident5);
         let actual: syn::Ident = parse_quote!(#usage);
-        let expected: syn::Ident = parse_quote!(variant5);
+        let expected: syn::Ident = parse_quote!(variant_5);
         assert_eq!(actual, expected);
     }
 
@@ -509,13 +526,13 @@ mod tests {
         let ident = scope.ident("crate");
         let usage = CodegenIdentUsage::Method(ident);
         let actual: syn::Ident = parse_quote!(#usage);
-        let expected: syn::Ident = parse_quote!(crate2);
+        let expected: syn::Ident = parse_quote!(crate_2);
         assert_eq!(actual, expected);
 
         let ident = scope.ident("crate2");
         let usage = CodegenIdentUsage::Method(ident);
         let actual: syn::Ident = parse_quote!(#usage);
-        let expected: syn::Ident = parse_quote!(crate3);
+        let expected: syn::Ident = parse_quote!(crate_3);
         assert_eq!(actual, expected);
     }
 }

--- a/ploidy-codegen-rust/src/operation.rs
+++ b/ploidy-codegen-rust/src/operation.rs
@@ -442,7 +442,7 @@ mod tests {
         let expected: syn::ImplItemFn = parse_quote! {
             pub async fn search(
                 &self,
-                query2: &str,
+                query_2: &str,
                 query: &parameters::SearchQuery
             ) -> Result<(), crate::error::Error> {
                 let url = {
@@ -452,7 +452,7 @@ mod tests {
                         .map(|mut segments| {
                             segments.pop_if_empty()
                                 .push("search")
-                                .push(query2);
+                                .push(query_2);
                         });
                     url
                 };

--- a/ploidy-codegen-rust/src/schema.rs
+++ b/ploidy-codegen-rust/src/schema.rs
@@ -570,7 +570,7 @@ mod tests {
                 pub foo_bar: ::ploidy_util::absent::AbsentOr<::std::vec::Vec<crate::types::qux::types::FooBarItem>>,
                 #[serde(rename = "foo_bar", default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent")]
                 #[ploidy(pointer(rename = "foo_bar"))]
-                pub foo_bar2: ::ploidy_util::absent::AbsentOr<::std::vec::Vec<crate::types::qux::types::FooBar2Item>>,
+                pub foo_bar_2: ::ploidy_util::absent::AbsentOr<::std::vec::Vec<crate::types::qux::types::FooBar2Item>>,
             }
             pub mod types {
                 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]

--- a/ploidy-codegen-rust/src/schema.rs
+++ b/ploidy-codegen-rust/src/schema.rs
@@ -407,12 +407,12 @@ mod tests {
         let codegen = CodegenSchemaType::new(&graph, &schema);
         let actual: syn::File = parse_quote!(#codegen);
         let expected: syn::File = parse_quote! {
-            pub type NullableOneOf = ::std::option::Option<crate::types::nullable_one_of::types::Value>;
+            pub type NullableOneOf = ::std::option::Option<crate::types::nullable_one_of::types::NullableOneOf>;
             pub mod types {
                 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
                 #[serde(crate = "::ploidy_util::serde")]
                 #[ploidy(pointer(crate = "::ploidy_util::pointer"))]
-                pub struct Value {
+                pub struct NullableOneOf {
                     #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent")]
                     pub value: ::ploidy_util::absent::AbsentOr<::std::string::String>,
                 }
@@ -457,21 +457,151 @@ mod tests {
 
         let actual: syn::File = parse_quote!(#codegen);
         let expected: syn::File = parse_quote! {
-            pub type NullableThing = ::std::option::Option<crate::types::nullable_thing::types::Value>;
+            pub type NullableThing = ::std::option::Option<crate::types::nullable_thing::types::NullableThing>;
             pub mod types {
+                #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
+                #[serde(crate = "::ploidy_util::serde")]
+                #[ploidy(pointer(crate = "::ploidy_util::pointer"))]
+                pub struct NullableThing {
+                    #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent")]
+                    pub value: ::ploidy_util::absent::AbsentOr<crate::types::nullable_thing::types::Value>,
+                }
                 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
                 #[serde(crate = "::ploidy_util::serde")]
                 #[ploidy(pointer(crate = "::ploidy_util::pointer"))]
                 pub struct Value {
                     #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent")]
-                    pub value: ::ploidy_util::absent::AbsentOr<crate::types::nullable_thing::types::Value2>,
+                    pub id: ::ploidy_util::absent::AbsentOr<::std::string::String>,
+                }
+            }
+        };
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_untagged_inline_variants_use_parent_name() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Pet:
+                  oneOf:
+                    - type: object
+                      properties:
+                        bark:
+                          type: string
+                    - type: object
+                      properties:
+                        meow:
+                          type: string
+        "})
+        .unwrap();
+
+        let arena = Arena::new();
+        let spec = Spec::from_doc(&arena, &doc).unwrap();
+        let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
+
+        let schema = graph.schema("Pet").unwrap();
+        let SchemaTypeView::Untagged(_, _) = &schema else {
+            panic!("expected untagged `Pet`; got `{schema:?}`");
+        };
+
+        let codegen = CodegenSchemaType::new(&graph, &schema);
+
+        let actual: syn::File = parse_quote!(#codegen);
+        let expected: syn::File = parse_quote! {
+            #[derive(Debug, Clone, PartialEq, Eq, Hash, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
+            #[serde(crate = "::ploidy_util::serde", untagged)]
+            #[ploidy(pointer(crate = "::ploidy_util::pointer", untagged))]
+            pub enum Pet {
+                Pet1(crate::types::pet::types::Pet1),
+                Pet2(crate::types::pet::types::Pet2)
+            }
+            pub mod types {
+                #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
+                #[serde(crate = "::ploidy_util::serde")]
+                #[ploidy(pointer(crate = "::ploidy_util::pointer"))]
+                pub struct Pet1 {
+                    #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent")]
+                    pub bark: ::ploidy_util::absent::AbsentOr<::std::string::String>,
                 }
                 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
                 #[serde(crate = "::ploidy_util::serde")]
                 #[ploidy(pointer(crate = "::ploidy_util::pointer"))]
-                pub struct Value2 {
+                pub struct Pet2 {
                     #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent")]
-                    pub id: ::ploidy_util::absent::AbsentOr<::std::string::String>,
+                    pub meow: ::ploidy_util::absent::AbsentOr<::std::string::String>,
+                }
+            }
+        };
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_any_of_inline_fields_use_parent_name() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+            components:
+              schemas:
+                Pet:
+                  anyOf:
+                    - type: object
+                      properties:
+                        bark:
+                          type: string
+                    - type: object
+                      properties:
+                        meow:
+                          type: string
+        "})
+        .unwrap();
+
+        let arena = Arena::new();
+        let spec = Spec::from_doc(&arena, &doc).unwrap();
+        let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
+
+        let schema = graph.schema("Pet").unwrap();
+        let SchemaTypeView::Struct(_, _) = &schema else {
+            panic!("expected struct `Pet`; got `{schema:?}`");
+        };
+
+        let codegen = CodegenSchemaType::new(&graph, &schema);
+
+        let actual: syn::File = parse_quote!(#codegen);
+        let expected: syn::File = parse_quote! {
+            #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
+            #[serde(crate = "::ploidy_util::serde")]
+            #[ploidy(pointer(crate = "::ploidy_util::pointer"))]
+            pub struct Pet {
+                #[serde(flatten, default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent")]
+                #[ploidy(pointer(flatten))]
+                pub pet_1: ::ploidy_util::absent::AbsentOr<crate::types::pet::types::Pet1>,
+                #[serde(flatten, default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent")]
+                #[ploidy(pointer(flatten))]
+                pub pet_2: ::ploidy_util::absent::AbsentOr<crate::types::pet::types::Pet2>,
+            }
+            pub mod types {
+                #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
+                #[serde(crate = "::ploidy_util::serde")]
+                #[ploidy(pointer(crate = "::ploidy_util::pointer"))]
+                pub struct Pet1 {
+                    #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent")]
+                    pub bark: ::ploidy_util::absent::AbsentOr<::std::string::String>,
+                }
+                #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
+                #[serde(crate = "::ploidy_util::serde")]
+                #[ploidy(pointer(crate = "::ploidy_util::pointer"))]
+                pub struct Pet2 {
+                    #[serde(default, skip_serializing_if = "::ploidy_util::absent::AbsentOr::is_absent")]
+                    pub meow: ::ploidy_util::absent::AbsentOr<::std::string::String>,
                 }
             }
         };

--- a/ploidy-codegen-rust/src/struct_.rs
+++ b/ploidy-codegen-rust/src/struct_.rs
@@ -2812,7 +2812,7 @@ mod tests {
                 pub additional_properties: ::ploidy_util::absent::AbsentOr<bool>,
                 #[serde(flatten)]
                 #[ploidy(pointer(flatten))]
-                pub additional_properties2: ::std::collections::BTreeMap<::std::string::String, ::std::string::String>,
+                pub additional_properties_2: ::std::collections::BTreeMap<::std::string::String, ::std::string::String>,
             }
         };
         assert_eq!(actual, expected);

--- a/ploidy-codegen-rust/src/untagged.rs
+++ b/ploidy-codegen-rust/src/untagged.rs
@@ -24,14 +24,13 @@ impl<'a> CodegenUntagged<'a> {
 
 impl ToTokens for CodegenUntagged<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        let variants = self.ty.variants().enumerate().map(|(index, variant)| {
-            let variant_name = CodegenIdentUsage::Variant(
-                self.graph
-                    .ident(IdentMapping::UntaggedVariant(self.ty.id(), index)),
-            );
+        let variants = self.ty.variants().map(|variant| {
+            let variant_name = CodegenIdentUsage::Variant(self.graph.ident(
+                IdentMapping::UntaggedVariant(self.ty.id(), variant.ordinal()),
+            ));
             match variant.ty() {
                 Some(variant) => {
-                    let rust_type = CodegenRef::new(self.graph, &variant.view);
+                    let rust_type = CodegenRef::new(self.graph, &variant);
                     quote! { #variant_name(#rust_type) }
                 }
                 None => quote! { #variant_name },
@@ -201,8 +200,8 @@ mod tests {
             #[serde(crate = "::ploidy_util::serde", untagged)]
             #[ploidy(pointer(crate = "::ploidy_util::pointer", untagged))]
             pub enum Animal {
-                V1(crate::types::Dog),
-                V2(crate::types::Cat)
+                Dog(crate::types::Dog),
+                Cat(crate::types::Cat)
             }
         };
         assert_eq!(actual, expected);
@@ -382,7 +381,7 @@ mod tests {
             pub enum Input {
                 String(::std::string::String),
                 Array(::std::vec::Vec<::std::string::String>),
-                Array2(::std::vec::Vec<crate::types::input::types::V3Item>)
+                Array2(::std::vec::Vec<crate::types::input::types::Array2Item>)
             }
         };
         assert_eq!(actual, expected);

--- a/ploidy-core/src/codegen/unique.rs
+++ b/ploidy-core/src/codegen/unique.rs
@@ -43,9 +43,9 @@ impl<'a> UniqueNames<'a> {
     /// let arena = Arena::new();
     /// let mut names = UniqueNames::new(&arena);
     /// assert_eq!(names.uniquify("HTTPResponse"), "HTTPResponse");
-    /// assert_eq!(names.uniquify("HTTP_Response"), "HTTP_Response2");
-    /// assert_eq!(names.uniquify("httpResponse"), "httpResponse3");
-    /// assert_eq!(names.uniquify("http_response_2"), "http_response4");
+    /// assert_eq!(names.uniquify("HTTP_Response"), "HTTP_Response_2");
+    /// assert_eq!(names.uniquify("httpResponse"), "httpResponse_3");
+    /// assert_eq!(names.uniquify("http_response_2"), "http_response_4");
     /// ```
     pub fn uniquify(&mut self, name: &str) -> &'a str {
         let parsed = ParsedName::parse(name);
@@ -70,7 +70,7 @@ impl<'a> UniqueNames<'a> {
         match parsed {
             ParsedName::Empty | ParsedName::Numeric(_) => self.arena.alloc_str(&suffix.to_string()),
             ParsedName::Stemmed { stem, .. } if suffix > 0 => {
-                self.arena.alloc_str(&format!("{stem}{suffix}"))
+                self.arena.alloc_str(&format!("{stem}_{suffix}"))
             }
             ParsedName::Stemmed { stem, .. } => self.arena.alloc_str(stem),
         }
@@ -472,9 +472,9 @@ mod tests {
         let mut names = UniqueNames::new(&arena);
 
         assert_eq!(names.uniquify("HTTPResponse"), "HTTPResponse");
-        assert_eq!(names.uniquify("HTTP_Response"), "HTTP_Response2");
-        assert_eq!(names.uniquify("httpResponse"), "httpResponse3");
-        assert_eq!(names.uniquify("http_response"), "http_response4");
+        assert_eq!(names.uniquify("HTTP_Response"), "HTTP_Response_2");
+        assert_eq!(names.uniquify("httpResponse"), "httpResponse_3");
+        assert_eq!(names.uniquify("http_response"), "http_response_4");
         // `HTTPRESPONSE` isn't a collision; it's a single word.
         assert_eq!(names.uniquify("HTTPRESPONSE"), "HTTPRESPONSE");
     }
@@ -485,8 +485,8 @@ mod tests {
         let mut names = UniqueNames::new(&arena);
 
         assert_eq!(names.uniquify("XMLHttpRequest"), "XMLHttpRequest");
-        assert_eq!(names.uniquify("xml_http_request"), "xml_http_request2");
-        assert_eq!(names.uniquify("XmlHttpRequest"), "XmlHttpRequest3");
+        assert_eq!(names.uniquify("xml_http_request"), "xml_http_request_2");
+        assert_eq!(names.uniquify("XmlHttpRequest"), "XmlHttpRequest_3");
     }
 
     #[test]
@@ -495,7 +495,7 @@ mod tests {
         let mut names = UniqueNames::new(&arena);
 
         assert_eq!(names.uniquify("HTTP_Response"), "HTTP_Response");
-        assert_eq!(names.uniquify("httpResponse"), "httpResponse2");
+        assert_eq!(names.uniquify("httpResponse"), "httpResponse_2");
     }
 
     #[test]
@@ -513,22 +513,22 @@ mod tests {
         let arena = Arena::new();
         let mut names = UniqueNames::new(&arena);
 
-        assert_eq!(names.uniquify("Response2"), "Response2");
-        assert_eq!(names.uniquify("response_2"), "response3");
+        assert_eq!(names.uniquify("Response2"), "Response_2");
+        assert_eq!(names.uniquify("response_2"), "response_3");
 
         // `0` becomes the bare stem.
         assert_eq!(names.uniquify("Response0"), "Response");
-        assert_eq!(names.uniquify("response"), "response4");
+        assert_eq!(names.uniquify("response"), "response_4");
 
         // Digit-to-uppercase collisions.
         assert_eq!(names.uniquify("1099KStatus"), "1099KStatus");
-        assert_eq!(names.uniquify("1099K_Status"), "1099K_Status2");
-        assert_eq!(names.uniquify("1099KStatus"), "1099KStatus3");
-        assert_eq!(names.uniquify("1099_K_Status"), "1099_K_Status4");
+        assert_eq!(names.uniquify("1099K_Status"), "1099K_Status_2");
+        assert_eq!(names.uniquify("1099KStatus"), "1099KStatus_3");
+        assert_eq!(names.uniquify("1099_K_Status"), "1099_K_Status_4");
 
         // Digit-to-lowercase collisions.
         assert_eq!(names.uniquify("123abc"), "123abc");
-        assert_eq!(names.uniquify("123_abc"), "123_abc2");
+        assert_eq!(names.uniquify("123_abc"), "123_abc_2");
     }
 
     #[test]
@@ -536,10 +536,10 @@ mod tests {
         let arena = Arena::new();
         let mut names = UniqueNames::new(&arena);
 
-        assert_eq!(names.uniquify("OAuth2"), "OAuth2");
-        assert_eq!(names.uniquify("OAuth_2"), "OAuth3");
+        assert_eq!(names.uniquify("OAuth2"), "OAuth_2");
+        assert_eq!(names.uniquify("OAuth_2"), "OAuth_3");
         assert_eq!(names.uniquify("OAuth"), "OAuth");
-        assert_eq!(names.uniquify("OAuth0"), "OAuth4");
+        assert_eq!(names.uniquify("OAuth0"), "OAuth_4");
     }
 
     #[test]
@@ -601,7 +601,7 @@ mod tests {
         let mut names = UniqueNames::with_reserved(&arena, ["_", "reserved"]);
 
         assert_eq!(names.uniquify("_"), "1");
-        assert_eq!(names.uniquify("reserved"), "reserved2");
+        assert_eq!(names.uniquify("reserved"), "reserved_2");
         assert_eq!(names.uniquify("other"), "other");
     }
 
@@ -610,7 +610,7 @@ mod tests {
         let arena = Arena::new();
         let mut names = UniqueNames::with_reserved(&arena, ["crate"]);
 
-        assert_eq!(names.uniquify("crate"), "crate2");
-        assert_eq!(names.uniquify("crate2"), "crate3");
+        assert_eq!(names.uniquify("crate"), "crate_2");
+        assert_eq!(names.uniquify("crate2"), "crate_3");
     }
 }

--- a/ploidy-core/src/ir/graph.rs
+++ b/ploidy-core/src/ir/graph.rs
@@ -2,6 +2,7 @@ use std::{
     any::{Any, TypeId as StdTypeId},
     collections::VecDeque,
     fmt::Debug,
+    num::NonZeroUsize,
 };
 
 use atomic_refcell::AtomicRefCell;
@@ -29,8 +30,8 @@ use super::{
     types::{
         FieldMeta, GraphContainer, GraphInlineType, GraphOperation, GraphSchemaType, GraphStruct,
         GraphTagged, GraphType, InlineTypeId, InlineTypeIds, InlineTypePathRoot, OperationUsage,
-        PrimitiveType, SpecInlineType, SpecSchemaType, SpecType, SpecUntaggedVariant,
-        StructFieldName, TaggedVariantMeta, UntaggedVariantMeta, VariantMeta,
+        PrimitiveType, SpecInlineType, SpecSchemaType, SpecType, StructFieldName,
+        TaggedVariantMeta, UntaggedVariantMeta, VariantMeta,
         shape::{Operation, Parameter, ParameterInfo, Request, Response},
     },
     views::{TypeId, operation::OperationView, primitive::PrimitiveView, schema::SchemaTypeView},
@@ -1273,15 +1274,9 @@ impl<'a> Iterator for SpecTypeVisitor<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         let (parent, top) = self.stack.pop()?;
-        if matches!(
-            parent,
-            Some((
-                _,
-                GraphEdge::Variant(VariantMeta::Untagged(UntaggedVariantMeta::Null))
-            ))
-        ) {
-            // Unit variants form self-edges; skip them
-            // to avoid an infinite loop.
+        if matches!(parent, Some((parent, _)) if parent == top) {
+            // Self-edges have no unvisited target; skip them to avoid an
+            // infinite loop.
             return Some((parent, top));
         }
         match top {
@@ -1325,15 +1320,31 @@ impl<'a> Iterator for SpecTypeVisitor<'a> {
                             },
                             field.ty
                         )),
-                        ty.variants.iter().map(|variant| match variant {
-                            &SpecUntaggedVariant::Some(hint, ty) => {
-                                let meta = UntaggedVariantMeta::Type { hint };
-                                (GraphEdge::Variant(meta.into()), ty)
-                            }
-                            // `null` variants have no target type;
-                            // we represent these variants as self-edges.
-                            SpecUntaggedVariant::Null => {
-                                (GraphEdge::Variant(UntaggedVariantMeta::Null.into()), top)
+                        ty.variants.iter().enumerate().map(|(index, variant)| {
+                            let ordinal = NonZeroUsize::new(index + 1).unwrap();
+                            match variant {
+                                &Some(ty) => (
+                                    GraphEdge::Variant(
+                                        UntaggedVariantMeta {
+                                            ordinal,
+                                            null: false,
+                                        }
+                                        .into(),
+                                    ),
+                                    ty,
+                                ),
+                                // `null` variants have no target type;
+                                // we represent these variants as self-edges.
+                                None => (
+                                    GraphEdge::Variant(
+                                        UntaggedVariantMeta {
+                                            ordinal,
+                                            null: true,
+                                        }
+                                        .into(),
+                                    ),
+                                    top,
+                                ),
                             }
                         }),
                         ty.parents

--- a/ploidy-core/src/ir/tests/graph.rs
+++ b/ploidy-core/src/ir/tests/graph.rs
@@ -2742,7 +2742,7 @@ fn test_collapsing_wrapper_preserves_variant_order() {
     };
     let variant_names = choice
         .variants()
-        .map(|variant| match variant.ty().unwrap().view {
+        .map(|variant| match variant.ty().unwrap() {
             TypeView::Schema(schema) => schema.name(),
             other => panic!("expected schema variant; got `{other:?}`"),
         })

--- a/ploidy-core/src/ir/tests/transform.rs
+++ b/ploidy-core/src/ir/tests/transform.rs
@@ -5,8 +5,7 @@ use crate::{
     ir::{
         Enum, EnumVariant, InlineTypeIds, PrimitiveType, SchemaTypeInfo, SpecContainer,
         SpecInlineType, SpecInner, SpecSchemaType, SpecStruct, SpecStructField, SpecTagged,
-        SpecTaggedVariant, SpecType, SpecUntagged, SpecUntaggedVariant, StructFieldName,
-        StructFieldNameHint, UntaggedVariantNameHint,
+        SpecTaggedVariant, SpecType, SpecUntagged, StructFieldName,
         transform::{TransformContext, TypeInfo, transform_with_context},
     },
     parse::{Document, Schema},
@@ -566,7 +565,7 @@ fn test_struct_with_additional_properties_ref() {
                 fields: [
                     _,
                     SpecStructField {
-                        name: StructFieldName::Hint(StructFieldNameHint::AdditionalProperties),
+                        name: StructFieldName::AdditionalProperties,
                         flattened: true,
                         required: true,
                         ty: SpecType::Inline(SpecInlineType::Container(
@@ -624,7 +623,7 @@ fn test_struct_with_additional_properties_inline() {
                         ..
                     },
                     SpecStructField {
-                        name: StructFieldName::Hint(StructFieldNameHint::AdditionalProperties),
+                        name: StructFieldName::AdditionalProperties,
                         flattened: true,
                         required: true,
                         ty: SpecType::Inline(SpecInlineType::Container(
@@ -673,7 +672,7 @@ fn test_struct_with_additional_properties_true() {
             },
             SpecStruct {
                 fields: [SpecStructField {
-                    name: StructFieldName::Hint(StructFieldNameHint::AdditionalProperties),
+                    name: StructFieldName::AdditionalProperties,
                     flattened: true,
                     required: true,
                     ty: SpecType::Inline(SpecInlineType::Container(
@@ -1228,13 +1227,7 @@ fn test_tagged_filters_non_refs() {
         SpecType::Schema(SpecSchemaType::Untagged(
             SchemaTypeInfo { name: "Animal", .. },
             SpecUntagged {
-                variants: [
-                    SpecUntaggedVariant::Some(UntaggedVariantNameHint::Index(1), SpecType::Ref(_)),
-                    SpecUntaggedVariant::Some(
-                        UntaggedVariantNameHint::Index(2),
-                        SpecType::Inline(_)
-                    ),
-                ],
+                variants: [Some(SpecType::Ref(_)), Some(SpecType::Inline(_)),],
                 ..
             },
         )),
@@ -1491,10 +1484,7 @@ fn test_untagged_basic() {
                 ..
             },
             SpecUntagged {
-                variants: [
-                    SpecUntaggedVariant::Some(UntaggedVariantNameHint::Index(1), SpecType::Ref(_)),
-                    SpecUntaggedVariant::Some(UntaggedVariantNameHint::Index(2), SpecType::Ref(_)),
-                ],
+                variants: [Some(SpecType::Ref(_)), Some(SpecType::Ref(_)),],
                 ..
             },
         )),
@@ -1642,7 +1632,7 @@ fn test_untagged_single_inline_primitive_variant_preserves_schema_identity() {
 }
 
 #[test]
-fn test_untagged_variant_numbering() {
+fn test_untagged_variants_preserve_declaration_count() {
     let doc = Document::from_yaml(indoc::indoc! {"
         openapi: 3.0.0
         info:
@@ -1669,17 +1659,12 @@ fn test_untagged_variant_numbering() {
     let arena = Arena::new();
     let result = transform(&arena, &doc, "ABC", &schema);
 
-    // Variants should have 1-based indices in their name hints.
     assert_matches!(
         result,
         SpecType::Schema(SpecSchemaType::Untagged(
             SchemaTypeInfo { name: "ABC", .. },
             SpecUntagged {
-                variants: [
-                    SpecUntaggedVariant::Some(UntaggedVariantNameHint::Index(1), _),
-                    SpecUntaggedVariant::Some(UntaggedVariantNameHint::Index(2), _),
-                    SpecUntaggedVariant::Some(UntaggedVariantNameHint::Index(3), _),
-                ],
+                variants: [Some(_), Some(_), Some(_),],
                 ..
             },
         )),
@@ -1906,7 +1891,7 @@ fn test_any_of_ref_uses_type_name() {
 }
 
 #[test]
-fn test_any_of_inline_uses_index_hint() {
+fn test_any_of_inline_uses_ordinal_name() {
     let doc = Document::from_yaml(indoc::indoc! {"
         openapi: 3.0.0
         info:
@@ -1930,7 +1915,7 @@ fn test_any_of_inline_uses_index_hint() {
     let arena = Arena::new();
     let result = transform(&arena, &doc, "Mixed", &schema);
 
-    // Both inline schemas should have index hints.
+    // Both inline schemas should have ordinal names.
     assert_matches!(
         result,
         SpecType::Schema(SpecSchemaType::Struct(
@@ -1938,19 +1923,19 @@ fn test_any_of_inline_uses_index_hint() {
             SpecStruct {
                 fields: [
                     SpecStructField {
-                        name: StructFieldName::Hint(StructFieldNameHint::Index(1)),
+                        name: StructFieldName::Ordinal(first),
                         flattened: true,
                         ..
                     },
                     SpecStructField {
-                        name: StructFieldName::Hint(StructFieldNameHint::Index(2)),
+                        name: StructFieldName::Ordinal(second),
                         flattened: true,
                         ..
                     },
                 ],
                 ..
             },
-        )),
+        )) if first.get() == 1 && second.get() == 2,
     );
 }
 
@@ -2437,14 +2422,14 @@ fn test_multiple_types_string_and_integer_untagged() {
             },
             SpecUntagged {
                 variants: [
-                    SpecUntaggedVariant::Some(
-                        UntaggedVariantNameHint::Primitive(PrimitiveType::String),
-                        SpecType::Inline(SpecInlineType::Primitive(_, PrimitiveType::String)),
-                    ),
-                    SpecUntaggedVariant::Some(
-                        UntaggedVariantNameHint::Primitive(PrimitiveType::I32),
-                        SpecType::Inline(SpecInlineType::Primitive(_, PrimitiveType::I32)),
-                    ),
+                    Some(SpecType::Inline(SpecInlineType::Primitive(
+                        _,
+                        PrimitiveType::String
+                    )),),
+                    Some(SpecType::Inline(SpecInlineType::Primitive(
+                        _,
+                        PrimitiveType::I32
+                    )),),
                 ],
                 ..
             },
@@ -2479,14 +2464,14 @@ fn test_type_array_with_format_produces_inline_variants() {
             },
             SpecUntagged {
                 variants: [
-                    SpecUntaggedVariant::Some(
-                        UntaggedVariantNameHint::Primitive(PrimitiveType::DateTime),
-                        SpecType::Inline(SpecInlineType::Primitive(_, PrimitiveType::DateTime)),
-                    ),
-                    SpecUntaggedVariant::Some(
-                        UntaggedVariantNameHint::Primitive(PrimitiveType::I32),
-                        SpecType::Inline(SpecInlineType::Primitive(_, PrimitiveType::I32)),
-                    ),
+                    Some(SpecType::Inline(SpecInlineType::Primitive(
+                        _,
+                        PrimitiveType::DateTime
+                    )),),
+                    Some(SpecType::Inline(SpecInlineType::Primitive(
+                        _,
+                        PrimitiveType::I32
+                    )),),
                 ],
                 ..
             },

--- a/ploidy-core/src/ir/tests/views.rs
+++ b/ploidy-core/src/ir/tests/views.rs
@@ -1,7 +1,5 @@
 //! Tests for the IR view layer, indirection, and extension system.
 
-use std::num::NonZeroUsize;
-
 use itertools::Itertools;
 
 use crate::{
@@ -9,8 +7,8 @@ use crate::{
     ir::{
         ContainerView, EnumVariant, ExtendableView, HasResource, HasTypeId, InlineTypePathRoot,
         InlineTypePathSegment, InlineTypeView, OperationUsage, ParameterStyle, PrimitiveType,
-        RawGraph, RequestView, Required, ResponseView, SchemaTypeInfo, SchemaTypeView,
-        SomeUntaggedVariant, Spec, StructFieldName, TypeView, View,
+        RawGraph, RequestView, Required, ResponseView, SchemaTypeInfo, SchemaTypeView, Spec,
+        StructFieldName, TypeView, View,
     },
     parse::{Document, Method, path::PathFragment},
     tests::assert_matches,
@@ -915,7 +913,7 @@ fn test_inlines_discovers_nested_inline_all_of_parents() {
 #[test]
 fn test_inlines_multiple_inline_all_of_parents_have_distinct_paths() {
     // When a struct has multiple inline `allOf` parents, each parent's path
-    // must carry a distinct `Inherits(n)` segment, so that codegen can
+    // must carry a distinct `Inherits(parent, n)` segment, so that codegen can
     // produce unique names.
     let doc = Document::from_yaml(indoc::indoc! {"
         openapi: 3.0.0
@@ -950,7 +948,7 @@ fn test_inlines_multiple_inline_all_of_parents_have_distinct_paths() {
         other => panic!("expected struct `Combined`; got {other:?}"),
     };
     // Each inline parent struct should have a path with a single
-    // `Inherits(n)` segment.
+    // `Inherits(parent, n)` segment.
     let paths = combined
         .parents()
         .map(|parent| match parent {
@@ -959,19 +957,18 @@ fn test_inlines_multiple_inline_all_of_parents_have_distinct_paths() {
         })
         .collect_vec();
     let paths = paths.iter().map(|path| path.as_slice()).collect_vec();
-    assert_eq!(
+    assert_matches!(
         &*paths,
         [
-            [InlineTypePathSegment::Inherits(
-                NonZeroUsize::new(1).unwrap()
-            )],
-            [InlineTypePathSegment::Inherits(
-                NonZeroUsize::new(2).unwrap()
-            )],
-            [InlineTypePathSegment::Inherits(
-                NonZeroUsize::new(3).unwrap()
-            )],
-        ]
+            [InlineTypePathSegment::Inherits(parent1, index1)],
+            [InlineTypePathSegment::Inherits(parent2, index2)],
+            [InlineTypePathSegment::Inherits(parent3, index3)],
+        ] if *parent1 == combined.id()
+            && index1.get() == 1
+            && *parent2 == combined.id()
+            && index2.get() == 2
+            && *parent3 == combined.id()
+            && index3.get() == 3
     );
 }
 
@@ -1038,13 +1035,13 @@ fn test_nested_type_array_inline_paths_are_distinct() {
         string.path().root(),
         InlineTypePathRoot::Schema(schema.id())
     );
-    assert_eq!(
+    assert_matches!(
         &*string.path().segments().collect_vec(),
         [
             InlineTypePathSegment::Optional,
             InlineTypePathSegment::ArrayItem,
-            InlineTypePathSegment::UntaggedVariant(NonZeroUsize::new(1).unwrap()),
-        ],
+            InlineTypePathSegment::UntaggedVariant(parent, index),
+        ] if *parent == untagged.id() && index.get() == 1,
     );
 
     let integer = schema
@@ -1057,13 +1054,13 @@ fn test_nested_type_array_inline_paths_are_distinct() {
         integer.path().root(),
         InlineTypePathRoot::Schema(schema.id()),
     );
-    assert_eq!(
+    assert_matches!(
         &*integer.path().segments().collect_vec(),
         [
             InlineTypePathSegment::Optional,
             InlineTypePathSegment::ArrayItem,
-            InlineTypePathSegment::UntaggedVariant(NonZeroUsize::new(2).unwrap()),
-        ]
+            InlineTypePathSegment::UntaggedVariant(parent, index),
+        ] if *parent == untagged.id() && index.get() == 2
     );
 }
 
@@ -1276,8 +1273,12 @@ fn test_untagged_variant_iteration() {
         _ => panic!("`Animal` should be an untagged union"),
     };
 
-    // Untagged variants contain `Cat` and `Dog` schema references.
-    assert_eq!(untagged_view.variants().count(), 2);
+    let variants = untagged_view.variants().collect_vec();
+    assert_eq!(variants.len(), 2);
+    assert_matches!(variants[0].ty(), Some(TypeView::Schema(view)) if view.name() == "Cat");
+    assert_matches!(variants[1].ty(), Some(TypeView::Schema(view)) if view.name() == "Dog");
+    assert_eq!(variants[0].ordinal().get(), 1);
+    assert_eq!(variants[1].ordinal().get(), 2);
 }
 
 // MARK: Container views
@@ -1756,24 +1757,57 @@ fn test_untagged_variant_with_null_type() {
     let cat_variant = &variants[0];
     assert_matches!(
         cat_variant.ty(),
-        Some(SomeUntaggedVariant {
-            view: TypeView::Schema(view),
-            ..
-        }) if view.name() == "Cat",
+        Some(TypeView::Schema(view)) if view.name() == "Cat",
     );
 
     let dog_variant = &variants[1];
     assert_matches!(
         dog_variant.ty(),
-        Some(SomeUntaggedVariant {
-            view: TypeView::Schema(view),
-            ..
-        }) if view.name() == "Dog",
+        Some(TypeView::Schema(view)) if view.name() == "Dog",
     );
 
     // The third variant should be `null`, returning `None`.
     let null_variant = &variants[2];
     assert!(null_variant.ty().is_none());
+}
+
+#[test]
+fn test_untagged_self_variant_preserves_type() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test
+          version: 1.0
+        components:
+          schemas:
+            Node:
+              oneOf:
+                - $ref: '#/components/schemas/Node'
+                - type: object
+                  properties:
+                    value:
+                      type: string
+                - type: 'null'
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let spec = Spec::from_doc(&arena, &doc).unwrap();
+    let graph = RawGraph::new(&arena, &spec).cook();
+
+    let node_schema = graph.schema("Node").unwrap();
+    let untagged_view = match node_schema {
+        SchemaTypeView::Untagged(_, view) => view,
+        other => panic!("expected untagged union `Node`; got {other:?}"),
+    };
+
+    let variants = untagged_view.variants().collect_vec();
+    assert_eq!(variants.len(), 3);
+    assert_matches!(
+        variants[0].ty(),
+        Some(TypeView::Schema(view)) if view.name() == "Node",
+    );
+    assert!(variants[2].ty().is_none());
 }
 
 #[test]
@@ -1831,17 +1865,11 @@ fn test_null_variant_demotes_tagged_to_untagged() {
 
     assert_matches!(
         variants[0].ty(),
-        Some(SomeUntaggedVariant {
-            view: TypeView::Schema(view),
-            ..
-        }) if view.name() == "Cat",
+        Some(TypeView::Schema(view)) if view.name() == "Cat",
     );
     assert_matches!(
         variants[1].ty(),
-        Some(SomeUntaggedVariant {
-            view: TypeView::Schema(view),
-            ..
-        }) if view.name() == "Dog",
+        Some(TypeView::Schema(view)) if view.name() == "Dog",
     );
     assert!(variants[2].ty().is_none());
 }

--- a/ploidy-core/src/ir/transform.rs
+++ b/ploidy-core/src/ir/transform.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroUsize;
+
 use itertools::Itertools;
 use rustc_hash::FxHashMap;
 
@@ -10,8 +12,7 @@ use crate::{
 use super::types::{
     Enum, EnumVariant, InlineTypeId, InlineTypeIds, PrimitiveType, SpecContainer, SpecInlineType,
     SpecInner, SpecSchemaType, SpecStruct, SpecStructField, SpecTagged, SpecTaggedVariant,
-    SpecType, SpecUntagged, SpecUntaggedVariant, StructFieldName, StructFieldNameHint,
-    UntaggedVariantNameHint,
+    SpecType, SpecUntagged, StructFieldName,
 };
 
 /// Metadata about a type in the dependency graph.
@@ -168,9 +169,7 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
             }
             variants => variants
                 .iter()
-                .enumerate()
-                .map(|(index, schema)| (index + 1, schema))
-                .map(|(index, schema)| {
+                .map(|schema| {
                     let ty = match schema {
                         RefOrSchema::Ref(r) => Some(SpecType::Ref(r)),
                         RefOrSchema::Inline(s) if matches!(&*s.ty, [Ty::Null]) => None,
@@ -179,33 +178,7 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
                             Some(transform_with_context(self.context, id, schema))
                         }
                     };
-                    ty.map(|ty| {
-                        let hint = match ty {
-                            SpecType::Schema(SpecSchemaType::Primitive(_, p))
-                            | SpecType::Inline(SpecInlineType::Primitive(_, p)) => {
-                                UntaggedVariantNameHint::Primitive(p)
-                            }
-                            SpecType::Schema(SpecSchemaType::Container(
-                                _,
-                                SpecContainer::Array(_),
-                            ))
-                            | SpecType::Inline(SpecInlineType::Container(
-                                _,
-                                SpecContainer::Array(_),
-                            )) => UntaggedVariantNameHint::Array,
-                            SpecType::Schema(SpecSchemaType::Container(
-                                _,
-                                SpecContainer::Map(_),
-                            ))
-                            | SpecType::Inline(SpecInlineType::Container(
-                                _,
-                                SpecContainer::Map(_),
-                            )) => UntaggedVariantNameHint::Map,
-                            _ => UntaggedVariantNameHint::Index(index),
-                        };
-                        SpecUntaggedVariant::Some(hint, self.arena().alloc(ty))
-                    })
-                    .unwrap_or(SpecUntaggedVariant::Null)
+                    ty.map(|ty| &*self.arena().alloc(ty))
                 })
                 .collect_vec(),
         };
@@ -213,8 +186,7 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
         Ok(match &*variants {
             // Simplify two-variant untagged unions, where one is a type
             // and the other is `null`, into optionals.
-            [SpecUntaggedVariant::Some(_, ty), SpecUntaggedVariant::Null]
-            | [SpecUntaggedVariant::Null, SpecUntaggedVariant::Some(_, ty)] => {
+            [Some(ty), None] | [None, Some(ty)] => {
                 let container = SpecContainer::Optional(SpecInner {
                     description: self.schema.description.as_deref(),
                     ty,
@@ -259,6 +231,7 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
             .iter()
             .enumerate()
             .map(|(index, schema)| {
+                let ordinal = NonZeroUsize::new(index + 1).unwrap();
                 let (field_name, ty, description) = match schema {
                     RefOrSchema::Ref(r) => {
                         let name = StructFieldName::Name(self.arena().alloc_str(&r.name()));
@@ -271,7 +244,7 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
                         (name, ty, desc)
                     }
                     RefOrSchema::Inline(schema) => {
-                        let name = StructFieldName::Hint(StructFieldNameHint::Index(index + 1));
+                        let name = StructFieldName::Ordinal(ordinal);
                         let id = self.context.ids.next();
                         let ty: &_ =
                             self.arena()
@@ -516,20 +489,16 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
             (many, nullable) => {
                 let mut variants = many
                     .iter()
-                    .enumerate()
-                    .map(|(index, variant)| (index + 1, variant))
-                    .map(|(index, variant)| {
-                        SpecUntaggedVariant::Some(
-                            variant
-                                .hint()
-                                .unwrap_or(UntaggedVariantNameHint::Index(index)),
-                            self.arena()
+                    .map(|variant| {
+                        Some(
+                            &*self
+                                .arena()
                                 .alloc(variant.to_inline_type(self.context.ids.next()).into()),
                         )
                     })
                     .collect_vec();
                 if nullable {
-                    variants.push(SpecUntaggedVariant::Null);
+                    variants.push(None);
                 }
                 let untagged = SpecUntagged {
                     description: self.schema.description.as_deref(),
@@ -624,8 +593,6 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
     /// Lowers `additionalProperties` into a struct field definition,
     /// if the schema specifies them.
     fn additional_properties(&self) -> Option<SpecStructField<'a>> {
-        let name = StructFieldName::Hint(StructFieldNameHint::AdditionalProperties);
-
         let inner = match &self.schema.additional_properties {
             Some(AdditionalProperties::RefOrSchema(RefOrSchema::Ref(r))) => SpecInner {
                 description: self.schema.description.as_deref(),
@@ -659,7 +626,7 @@ impl<'context, 'a> IrTransformer<'context, 'a> {
         )));
 
         Some(SpecStructField {
-            name,
+            name: StructFieldName::AdditionalProperties,
             ty,
             required: true,
             description: None,
@@ -685,16 +652,6 @@ enum OtherVariant<'a> {
 }
 
 impl<'a> OtherVariant<'a> {
-    /// Returns the name hint for this variant when used in an untagged union.
-    fn hint(self) -> Option<UntaggedVariantNameHint> {
-        Some(match self {
-            Self::Primitive(p) => UntaggedVariantNameHint::Primitive(p),
-            Self::Array(..) => UntaggedVariantNameHint::Array,
-            Self::Map(..) => UntaggedVariantNameHint::Map,
-            Self::Any => return None,
-        })
-    }
-
     /// Converts this variant to a [`SpecSchemaType`].
     fn to_schema_type(self, info: SchemaTypeInfo<'a>) -> SpecSchemaType<'a> {
         match self {

--- a/ploidy-core/src/ir/types/graph.rs
+++ b/ploidy-core/src/ir/types/graph.rs
@@ -1,9 +1,11 @@
 //! IR types with graph node references.
 
+use std::num::NonZeroUsize;
+
 use petgraph::graph::NodeIndex;
 
 use super::{
-    Enum, InlineTypeId, PrimitiveType, SchemaTypeInfo, StructFieldName, UntaggedVariantNameHint,
+    Enum, InlineTypeId, PrimitiveType, SchemaTypeInfo, StructFieldName,
     shape::{Operation, Parameter, ParameterInfo, Request, Response},
     spec::{SpecContainer, SpecInlineType, SpecSchemaType},
 };
@@ -218,9 +220,9 @@ pub struct TaggedVariantMeta<'a> {
 
 /// Metadata for an untagged union variant.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub enum UntaggedVariantMeta {
-    Type { hint: UntaggedVariantNameHint },
-    Null,
+pub struct UntaggedVariantMeta {
+    pub ordinal: NonZeroUsize,
+    pub null: bool,
 }
 
 /// An operation with graph node references.

--- a/ploidy-core/src/ir/types/mod.rs
+++ b/ploidy-core/src/ir/types/mod.rs
@@ -108,8 +108,7 @@ pub enum OperationUsage<'a> {
 
 /// A segment in an inline type path.
 ///
-/// Segments that name fields or variants also carry the parent type,
-/// because those names are scoped to that parent.
+/// Segments scoped to a parent type carry that parent type.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum InlineTypePathSegment<'a> {
     /// Enters an inline type declared as a struct field.
@@ -117,7 +116,7 @@ pub enum InlineTypePathSegment<'a> {
     /// Enters an inline type declared as a tagged union variant.
     TaggedVariant(TypeId, &'a str),
     /// Enters the nth untagged union variant, counted from 1 in declaration order.
-    UntaggedVariant(NonZeroUsize),
+    UntaggedVariant(TypeId, NonZeroUsize),
     /// Enters the item type of an array.
     ArrayItem,
     /// Enters the value type of a map.
@@ -125,7 +124,7 @@ pub enum InlineTypePathSegment<'a> {
     /// Enters the inner type of an optional container.
     Optional,
     /// Enters the nth inherited parent, counted from 1 in declaration order.
-    Inherits(NonZeroUsize),
+    Inherits(TypeId, NonZeroUsize),
 }
 
 /// A primitive type in the dependency graph.
@@ -169,32 +168,14 @@ pub enum EnumVariant<'a> {
     Bool(bool),
 }
 
-/// A hint that's used to generate a more descriptive name
-/// for an untagged union variant. These are emitted for
-/// `oneOf` schemas without a discriminator.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub enum UntaggedVariantNameHint {
-    Primitive(PrimitiveType),
-    Array,
-    Map,
-    Index(usize),
-}
-
-/// A struct field name, either explicit or generated from a hint.
+/// A struct field name.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum StructFieldName<'a> {
-    /// Explicit name from a schema or reference.
+    /// A name declared by a property or schema reference.
     Name(&'a str),
-    /// Generated name, deferred until generation time.
-    Hint(StructFieldNameHint),
-}
-
-/// A hint that's used to generate a name for a struct field.
-/// These are emitted for inline `anyOf` schemas and
-/// additional properties fields.
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub enum StructFieldNameHint {
-    Index(usize),
+    /// A synthetic name, counted from 1 in declaration order.
+    Ordinal(NonZeroUsize),
+    /// The synthetic field for additional properties.
     AdditionalProperties,
 }
 

--- a/ploidy-core/src/ir/types/spec.rs
+++ b/ploidy-core/src/ir/types/spec.rs
@@ -4,7 +4,7 @@
 use crate::parse::SchemaRef;
 
 use super::{
-    Enum, InlineTypeId, PrimitiveType, SchemaTypeInfo, StructFieldName, UntaggedVariantNameHint,
+    Enum, InlineTypeId, PrimitiveType, SchemaTypeInfo, StructFieldName,
     shape::{Operation, Parameter, ParameterInfo, Request, Response},
 };
 
@@ -143,24 +143,17 @@ pub struct SpecTaggedVariant<'a> {
     pub ty: &'a SpecType<'a>,
 }
 
-/// An untagged union, created from a `oneOf` schema
-/// without a discriminator, or an OpenAPI 3.1 schema
-/// with multiple types in its `type` field.
+/// An untagged union, created from a `oneOf` schema without a discriminator,
+/// or an OpenAPI 3.1 schema with multiple types in its `type` field.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct SpecUntagged<'a> {
     pub description: Option<&'a str>,
-    pub variants: &'a [SpecUntaggedVariant<'a>],
+    /// Variants in declaration order. `None` represents a `null` variant.
+    pub variants: &'a [Option<&'a SpecType<'a>>],
     /// Own fields that the union declares as `properties`.
     pub fields: &'a [SpecStructField<'a>],
     /// Immediate parent types from `allOf`, in declaration order.
     pub parents: &'a [&'a SpecType<'a>],
-}
-
-/// A variant of an untagged union.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub enum SpecUntaggedVariant<'a> {
-    Some(UntaggedVariantNameHint, &'a SpecType<'a>),
-    Null,
 }
 
 /// An array, map, or optional type with [`SpecType`] references.

--- a/ploidy-core/src/ir/views/path.rs
+++ b/ploidy-core/src/ir/views/path.rs
@@ -75,15 +75,8 @@ impl<'graph, 'a> InlineTypePathView<'graph, 'a> {
                     GraphEdge::Variant(VariantMeta::Tagged(m)) => {
                         InlineTypePathSegment::TaggedVariant(TypeId(from), m.name)
                     }
-                    GraphEdge::Variant(VariantMeta::Untagged(_)) => {
-                        let (index, _) = cooked
-                            .graph
-                            .edges(from)
-                            .filter(|e| matches!(e.weight(), GraphEdge::Variant(_)))
-                            .find_position(|e| e.target() == to)?;
-                        InlineTypePathSegment::UntaggedVariant(
-                            NonZeroUsize::new(index + 1).unwrap(),
-                        )
+                    GraphEdge::Variant(VariantMeta::Untagged(m)) => {
+                        InlineTypePathSegment::UntaggedVariant(TypeId(from), m.ordinal)
                     }
                     GraphEdge::Inherits { .. } => {
                         let (index, _) = cooked
@@ -91,7 +84,10 @@ impl<'graph, 'a> InlineTypePathView<'graph, 'a> {
                             .edges(from)
                             .filter(|e| matches!(e.weight(), GraphEdge::Inherits { .. }))
                             .find_position(|e| e.target() == to)?;
-                        InlineTypePathSegment::Inherits(NonZeroUsize::new(index + 1).unwrap())
+                        InlineTypePathSegment::Inherits(
+                            TypeId(from),
+                            NonZeroUsize::new(index + 1).unwrap(),
+                        )
                     }
                 })
             })

--- a/ploidy-core/src/ir/views/untagged.rs
+++ b/ploidy-core/src/ir/views/untagged.rs
@@ -18,17 +18,13 @@
 //! ```
 //!
 //! Ploidy represents this as an [`UntaggedView`] with a list of variants.
-//! Each variant is either a typed value or `null`, modeled as
-//! [`Option<SomeUntaggedVariant>`]. The typed case pairs an
-//! [`UntaggedVariantNameHint`] with a [`TypeView`]; the hint helps codegen
-//! produce readable variant names when the schema has no explicit name.
-//!
-//! [`Option<SomeUntaggedVariant>`]: SomeUntaggedVariant
+
+use std::num::NonZeroUsize;
 
 use petgraph::graph::NodeIndex;
 
 use crate::ir::{
-    UntaggedVariantMeta, UntaggedVariantNameHint,
+    UntaggedVariantMeta,
     graph::CookedGraph,
     types::{GraphUntagged, VariantMeta},
 };
@@ -69,13 +65,17 @@ impl<'graph, 'a> UntaggedView<'graph, 'a> {
     }
 
     /// Returns an iterator over this untagged union's variants.
+    #[inline]
     pub fn variants(&self) -> impl Iterator<Item = UntaggedVariantView<'_, 'graph, 'a>> {
         self.cooked
             .variants(self.index)
-            .map(|info| UntaggedVariantView {
-                parent: self,
-                meta: info.meta,
-                index: info.target,
+            .map(|info| match info.meta {
+                VariantMeta::Untagged(meta) => UntaggedVariantView {
+                    parent: self,
+                    meta,
+                    index: info.target,
+                },
+                VariantMeta::Tagged(_) => unreachable!(),
             })
     }
 }
@@ -99,34 +99,20 @@ pub type UntaggedFieldView<'view, 'graph, 'a> = FieldView<'view, 'a, UntaggedVie
 #[derive(Debug)]
 pub struct UntaggedVariantView<'view, 'graph, 'a> {
     parent: &'view UntaggedView<'graph, 'a>,
-    meta: VariantMeta<'a>,
-    /// The node index of this variant's type (from the `Variant` edge).
+    meta: UntaggedVariantMeta,
     index: NodeIndex<usize>,
 }
 
 impl<'view, 'graph, 'a> UntaggedVariantView<'view, 'graph, 'a> {
-    /// Returns a view of this variant's type, if it's not a unit
-    /// variant.
+    /// Returns a view of this variant's type, if it's not a null variant.
     #[inline]
-    pub fn ty(&self) -> Option<SomeUntaggedVariant<'graph, 'a>> {
-        match self.meta {
-            VariantMeta::Untagged(UntaggedVariantMeta::Type { hint }) => {
-                Some(SomeUntaggedVariant {
-                    hint,
-                    view: TypeView::new(self.parent.cooked, self.index),
-                })
-            }
-            _ => None,
-        }
+    pub fn ty(&self) -> Option<TypeView<'graph, 'a>> {
+        (!self.meta.null).then(|| TypeView::new(self.parent.cooked, self.index))
     }
-}
 
-/// A non-unit variant of an untagged union, pairing a name hint
-/// with the variant's type.
-#[derive(Debug)]
-pub struct SomeUntaggedVariant<'graph, 'a> {
-    /// A hint for generating a readable variant name.
-    pub hint: UntaggedVariantNameHint,
-    /// A view of this variant's type.
-    pub view: TypeView<'graph, 'a>,
+    /// Returns this variant's position in declaration order, counted from 1.
+    #[inline]
+    pub fn ordinal(&self) -> NonZeroUsize {
+        self.meta.ordinal
+    }
 }


### PR DESCRIPTION
A small tweak to unique suffixing, and a larger refactor of how we build inline names.

Add a word boundary (`_`) before the unique suffix for readability.

Build inline type names from the uniquified identifiers assigned to their owning schema types, fields, variants, and parents. Inline `oneOf`, `anyOf`, `allOf`, and nullable schemas now get semantic names like `Pet1`, `pet_1`, `Dog`, `Array2Item`; not `Value`, `variant_1`, `V1`, or `V3Item`.

Breaking changes: Generated Rust names may change for inline schemas, untagged variants, inline `allOf` schemas, and inline `anyOf` fields.