### PR TITLE
feat(codegen)!: Implement custom word segmentation for names.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1130,7 +1130,6 @@ dependencies = [
 name = "ploidy-codegen-rust"
 version = "0.13.0"
 dependencies = [
- "heck",
  "indoc",
  "itertools",
  "miette",
@@ -1139,7 +1138,6 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "ref-cast",
  "rustc-hash",
  "semver",
  "serde",
@@ -1178,6 +1176,7 @@ dependencies = [
  "syn",
  "thiserror 2.0.18",
  "unicase",
+ "unicode-normalization",
  "winnow",
 ]
 
@@ -2081,6 +2080,15 @@ name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-width"

--- a/ploidy-codegen-rust/Cargo.toml
+++ b/ploidy-codegen-rust/Cargo.toml
@@ -10,7 +10,6 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-heck = "0.5"
 itertools = "0.14"
 serde = { version = "1", features = ["derive"] }
 miette = "7"
@@ -18,7 +17,6 @@ ploidy-core = { workspace = true, features = ["proc-macro2"] }
 prettyplease = "0.2"
 proc-macro2 = { version = "1", default-features = false }
 quote = { version = "1", default-features = false }
-ref-cast = { workspace = true }
 rustc-hash = { workspace = true }
 semver = "1"
 syn = { version = "2", default-features = false, features = [

--- a/ploidy-codegen-rust/src/cargo.rs
+++ b/ploidy-codegen-rust/src/cargo.rs
@@ -73,10 +73,10 @@ impl<'a> CodegenCargoManifest<'a> {
                 .iter()
                 .map(|(resource, deps)| {
                     (
-                        AsFeatureName(resource).to_string(),
+                        AsFeatureName(*resource).to_string(),
                         FeatureDependencies(
                             deps.iter()
-                                .map(|resource| AsFeatureName(resource).to_string())
+                                .map(|resource| AsFeatureName(*resource).to_string())
                                 .collect_vec(),
                         ),
                     )
@@ -91,7 +91,7 @@ impl<'a> CodegenCargoManifest<'a> {
                     FeatureDependencies(
                         deps_by_resource
                             .keys()
-                            .map(|resource| AsFeatureName(resource).to_string())
+                            .map(|resource| AsFeatureName(*resource).to_string())
                             .collect_vec(),
                     ),
                 );
@@ -742,6 +742,43 @@ mod tests {
         let features = manifest.features();
         let keys = features.keys().copied().collect_vec();
         assert_matches!(&*keys, ["default", "pets"]);
+    }
+
+    #[test]
+    fn test_resource_feature_names_deduplicate_numeric_case_collisions() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test
+              version: 1.0.0
+            paths:
+              /tokens:
+                get:
+                  operationId: listTokens
+                  x-resource-name: oauth_2_token
+                  responses:
+                    '200':
+                      description: OK
+            components:
+              schemas:
+                OAuth2Token:
+                  type: object
+                  x-resourceId: oauth2Token
+                  properties:
+                    id:
+                      type: string
+        "})
+        .unwrap();
+
+        let arena = Arena::new();
+        let spec = Spec::from_doc(&arena, &doc).unwrap();
+        let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
+        let manifest = CodegenCargoManifest::new(&graph, &default_manifest()).to_manifest();
+
+        let features = manifest.features();
+        let keys = features.keys().copied().collect_vec();
+        assert_matches!(&*keys, ["default", "oauth-2-token-2", "oauth2-token"]);
+        assert_eq!(features["default"], ["oauth-2-token-2", "oauth2-token"]);
     }
 
     #[test]

--- a/ploidy-codegen-rust/src/cfg.rs
+++ b/ploidy-codegen-rust/src/cfg.rs
@@ -36,17 +36,17 @@ use super::{
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum CfgFeature<'a> {
     /// A single `feature = "name"` predicate.
-    Single(&'a UniqueIdent),
+    Single(UniqueIdent<'a>),
     /// A compound `any(feature = "a", feature = "b", ...)` predicate.
-    AnyOf(BTreeSet<&'a UniqueIdent>),
+    AnyOf(BTreeSet<UniqueIdent<'a>>),
     /// A compound `all(feature = "a", feature = "b", ...)` predicate.
-    AllOf(BTreeSet<&'a UniqueIdent>),
+    AllOf(BTreeSet<UniqueIdent<'a>>),
     /// A compound `all(feature = "own", any(feature = "a", ...))` predicate,
     /// used for schema types that both specify an `x-resourceId`, and are
     /// used by operations that specify an `x-resource-name`.
     OwnAndUsedBy {
-        own: &'a UniqueIdent,
-        used_by: BTreeSet<&'a UniqueIdent>,
+        own: UniqueIdent<'a>,
+        used_by: BTreeSet<UniqueIdent<'a>>,
     },
 }
 
@@ -178,7 +178,7 @@ impl<'a> CfgFeature<'a> {
     }
 
     /// Builds a `#[cfg(any(...))]` predicate, simplifying if possible.
-    fn any_of(mut features: BTreeSet<&'a UniqueIdent>) -> Option<Self> {
+    fn any_of(mut features: BTreeSet<UniqueIdent<'a>>) -> Option<Self> {
         let first = features.pop_first()?;
         Some(if features.is_empty() {
             // Simplify `any(first)` to `first`.
@@ -190,7 +190,7 @@ impl<'a> CfgFeature<'a> {
     }
 
     /// Builds a `#[cfg(all(...))]` predicate, simplifying if possible.
-    fn all_of(mut features: BTreeSet<&'a UniqueIdent>) -> Option<Self> {
+    fn all_of(mut features: BTreeSet<UniqueIdent<'a>>) -> Option<Self> {
         let first = features.pop_first()?;
         Some(if features.is_empty() {
             // Simplify `all(first)` to `first`.
@@ -202,8 +202,8 @@ impl<'a> CfgFeature<'a> {
     }
 
     /// Builds a `#[cfg(all(own, any(...)))]` predicate, simplifying if possible.
-    fn own_and_used_by(own: &'a UniqueIdent, mut used_by: BTreeSet<&'a UniqueIdent>) -> Self {
-        if used_by.contains(own) {
+    fn own_and_used_by(own: UniqueIdent<'a>, mut used_by: BTreeSet<UniqueIdent<'a>>) -> Self {
+        if used_by.contains(&own) {
             // Simplify `all(own, any(own, ...))` to `own`.
             return Self::Single(own);
         }
@@ -225,27 +225,27 @@ impl<'a> CfgFeature<'a> {
 impl ToTokens for CfgFeature<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let predicate = match self {
-            Self::Single(resource) => {
+            &Self::Single(resource) => {
                 let name = AsFeatureName(resource).to_string();
                 quote! { feature = #name }
             }
             Self::AnyOf(resources) => {
-                let predicates = resources.iter().map(|f| {
+                let predicates = resources.iter().map(|&f| {
                     let name = AsFeatureName(f).to_string();
                     quote! { feature = #name }
                 });
                 quote! { any(#(#predicates),*) }
             }
             Self::AllOf(resources) => {
-                let predicates = resources.iter().map(|f| {
+                let predicates = resources.iter().map(|&f| {
                     let name = AsFeatureName(f).to_string();
                     quote! { feature = #name }
                 });
                 quote! { all(#(#predicates),*) }
             }
             Self::OwnAndUsedBy { own, used_by } => {
-                let own_name = AsFeatureName(own).to_string();
-                let used_by_predicates = used_by.iter().map(|f| {
+                let own_name = AsFeatureName(*own).to_string();
+                let used_by_predicates = used_by.iter().map(|&f| {
                     let name = AsFeatureName(f).to_string();
                     quote! { feature = #name }
                 });
@@ -286,7 +286,7 @@ mod tests {
     fn test_single_feature() {
         let arena = Arena::new();
         let mut scope = UniqueIdents::new(&arena);
-        let cfg = CfgFeature::Single(scope.reserve("pets"));
+        let cfg = CfgFeature::Single(scope.claim("pets"));
 
         let actual: syn::Attribute = parse_quote!(#cfg);
         let expected: syn::Attribute = parse_quote!(#[cfg(feature = "pets")]);
@@ -298,9 +298,9 @@ mod tests {
         let arena = Arena::new();
         let mut scope = UniqueIdents::new(&arena);
         let cfg = CfgFeature::AnyOf(BTreeSet::from_iter([
-            scope.reserve("cats"),
-            scope.reserve("dogs"),
-            scope.reserve("aardvarks"),
+            scope.claim("cats"),
+            scope.claim("dogs"),
+            scope.claim("aardvarks"),
         ]));
 
         let actual: syn::Attribute = parse_quote!(#cfg);
@@ -314,9 +314,9 @@ mod tests {
         let arena = Arena::new();
         let mut scope = UniqueIdents::new(&arena);
         let cfg = CfgFeature::AllOf(BTreeSet::from_iter([
-            scope.reserve("cats"),
-            scope.reserve("dogs"),
-            scope.reserve("aardvarks"),
+            scope.claim("cats"),
+            scope.claim("dogs"),
+            scope.claim("aardvarks"),
         ]));
 
         let actual: syn::Attribute = parse_quote!(#cfg);
@@ -330,8 +330,8 @@ mod tests {
         let arena = Arena::new();
         let mut scope = UniqueIdents::new(&arena);
         let cfg = CfgFeature::OwnAndUsedBy {
-            own: scope.reserve("own"),
-            used_by: BTreeSet::from_iter([scope.reserve("a"), scope.reserve("b")]),
+            own: scope.claim("own"),
+            used_by: BTreeSet::from_iter([scope.claim("a"), scope.claim("b")]),
         };
 
         let actual: syn::Attribute = parse_quote!(#cfg);
@@ -344,7 +344,7 @@ mod tests {
     fn test_any_of_simplifies_single_feature() {
         let arena = Arena::new();
         let mut scope = UniqueIdents::new(&arena);
-        let cfg = CfgFeature::any_of(BTreeSet::from_iter([scope.reserve("pets")]));
+        let cfg = CfgFeature::any_of(BTreeSet::from_iter([scope.claim("pets")]));
 
         let actual: syn::Attribute = parse_quote!(#cfg);
         let expected: syn::Attribute = parse_quote!(#[cfg(feature = "pets")]);
@@ -355,7 +355,7 @@ mod tests {
     fn test_all_of_simplifies_single_feature() {
         let arena = Arena::new();
         let mut scope = UniqueIdents::new(&arena);
-        let cfg = CfgFeature::all_of(BTreeSet::from_iter([scope.reserve("pets")]));
+        let cfg = CfgFeature::all_of(BTreeSet::from_iter([scope.claim("pets")]));
 
         let actual: syn::Attribute = parse_quote!(#cfg);
         let expected: syn::Attribute = parse_quote!(#[cfg(feature = "pets")]);
@@ -378,8 +378,8 @@ mod tests {
     fn test_own_and_used_by_simplifies_single_used_by_to_all_of() {
         let arena = Arena::new();
         let mut scope = UniqueIdents::new(&arena);
-        let own = scope.reserve("own");
-        let other = scope.reserve("other");
+        let own = scope.claim("own");
+        let other = scope.claim("other");
         // `OwnedAndUsedBy` with one `used_by` feature should simplify to `AllOf`.
         let cfg = CfgFeature::own_and_used_by(own, BTreeSet::from_iter([other]));
         assert_eq!(cfg, CfgFeature::AllOf(BTreeSet::from_iter([other, own])),);
@@ -389,7 +389,7 @@ mod tests {
     fn test_own_and_used_by_simplifies_empty_to_single() {
         let arena = Arena::new();
         let mut scope = UniqueIdents::new(&arena);
-        let own = scope.reserve("own");
+        let own = scope.claim("own");
         // `OwnedAndUsedBy` with no `used_by` features should simplify to `Single`.
         let cfg = CfgFeature::own_and_used_by(own, BTreeSet::new());
         assert_eq!(cfg, CfgFeature::Single(own));
@@ -399,8 +399,8 @@ mod tests {
     fn test_own_and_used_by_simplifies_own_used_by_to_single() {
         let arena = Arena::new();
         let mut scope = UniqueIdents::new(&arena);
-        let own = scope.reserve("own");
-        let other = scope.reserve("other");
+        let own = scope.claim("own");
+        let other = scope.claim("other");
         let cfg = CfgFeature::own_and_used_by(own, BTreeSet::from_iter([own, other]));
         assert_eq!(cfg, CfgFeature::Single(own));
     }

--- a/ploidy-codegen-rust/src/client.rs
+++ b/ploidy-codegen-rust/src/client.rs
@@ -182,7 +182,7 @@ struct ResourceModules<'a>(&'a [ResourceGroup<'a>]);
 impl ToTokens for ResourceModules<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         tokens.append_all(self.0.iter().map(|ident| match ident {
-            ResourceGroup::Named(name) => {
+            &ResourceGroup::Named(name) => {
                 let cfg = CfgFeature::Single(name);
                 let mod_name = CodegenIdentUsage::Module(name);
                 quote! {
@@ -213,7 +213,7 @@ mod tests {
         let mut scope = UniqueIdents::new(&arena);
         let resources = [
             ResourceGroup::Default,
-            ResourceGroup::Named(scope.reserve("customer_profiles")),
+            ResourceGroup::Named(scope.claim("customer_profiles")),
         ];
         let modules = ResourceModules(&resources);
 

--- a/ploidy-codegen-rust/src/graph.rs
+++ b/ploidy-codegen-rust/src/graph.rs
@@ -14,7 +14,7 @@ use rustc_hash::FxHashMap;
 
 use super::{
     config::{CodegenConfig, DateTimeFormat},
-    naming::{CodegenIdentUsage, ResourceGroup, UniqueIdent, UniqueIdents, idents},
+    naming::{CodegenIdentUsage, ResourceGroup, UniqueIdent, UniqueIdents},
 };
 
 /// A [`CookedGraph`] decorated with Rust-specific information.
@@ -46,7 +46,7 @@ impl<'a> CodegenGraph<'a> {
     /// Returns the unique Rust identifier for a schema, operation, parameter,
     /// field, or variant.
     #[inline]
-    pub fn ident(&self, key: impl Into<IdentMapping<'a>>) -> &'a UniqueIdent {
+    pub fn ident(&self, key: impl Into<IdentMapping<'a>>) -> UniqueIdent<'a> {
         use {IdentMapKey as Key, IdentMapping::*};
         match key.into() {
             Operation(op) => self.idents[&Key::Operation(op)],
@@ -132,13 +132,13 @@ fn ident_map<'a>(cooked: &CookedGraph<'a>) -> IdentMap<'a> {
         let mut scope = UniqueIdents::new(cooked.arena());
         cooked
             .schemas()
-            .map(move |ty| (IdentMapKey::Type(ty.id()), scope.reserve(ty.name())))
+            .map(move |ty| (IdentMapKey::Type(ty.id()), scope.claim(ty.name())))
     });
     idents.extend({
         let mut scope = UniqueIdents::new(cooked.arena());
         cooked
             .operations()
-            .map(move |op| (IdentMapKey::Operation(op.id()), scope.reserve(op.id())))
+            .map(move |op| (IdentMapKey::Operation(op.id()), scope.claim(op.id())))
     });
     idents.extend({
         let resources: BTreeSet<_> = cooked
@@ -150,7 +150,7 @@ fn ident_map<'a>(cooked: &CookedGraph<'a>) -> IdentMap<'a> {
         let mut scope = UniqueIdents::with_reserved(cooked.arena(), &["default"]);
         resources
             .into_iter()
-            .map(move |name| (IdentMapKey::Resource(name), scope.reserve(name)))
+            .map(move |name| (IdentMapKey::Resource(name), scope.claim(name)))
     });
     for op in cooked.operations() {
         {
@@ -162,7 +162,7 @@ fn ident_map<'a>(cooked: &CookedGraph<'a>) -> IdentMap<'a> {
                 &["query", "request", "form", "url", "response"],
             );
             for param in op.path().params() {
-                let ident = scope.reserve(param.name());
+                let ident = scope.claim(param.name());
                 idents.insert(
                     IdentMapKey::Parameter(op.id(), ParameterLocation::Path, param.name()),
                     ident,
@@ -173,7 +173,7 @@ fn ident_map<'a>(cooked: &CookedGraph<'a>) -> IdentMap<'a> {
             // Query parameters become regular struct fields.
             let mut scope = UniqueIdents::new(cooked.arena());
             for param in op.query() {
-                let ident = scope.reserve(param.name());
+                let ident = scope.claim(param.name());
                 idents.insert(
                     IdentMapKey::Parameter(op.id(), ParameterLocation::Query, param.name()),
                     ident,
@@ -216,7 +216,7 @@ fn ident_map<'a>(cooked: &CookedGraph<'a>) -> IdentMap<'a> {
             let scope = scopes
                 .entry(domain)
                 .or_insert_with(|| UniqueIdents::new(cooked.arena()));
-            idents.insert(IdentMapKey::Type(inline.id()), scope.reserve(&name));
+            idents.insert(IdentMapKey::Type(inline.id()), scope.claim(&name));
             if let Some(domain) = MemberIdentDomain::from_inline_type(inline) {
                 let map = domain.into_idents(cooked.arena(), &idents);
                 idents.extend(map);
@@ -226,7 +226,7 @@ fn ident_map<'a>(cooked: &CookedGraph<'a>) -> IdentMap<'a> {
     idents
 }
 
-type IdentMap<'a> = FxHashMap<IdentMapKey<'a>, &'a UniqueIdent>;
+type IdentMap<'a> = FxHashMap<IdentMapKey<'a>, UniqueIdent<'a>>;
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 enum IdentMapKey<'a> {
@@ -286,16 +286,16 @@ impl<'graph, 'a> MemberIdentDomain<'graph, 'a> {
                 for field in view.fields() {
                     let name = field.name();
                     let ident = match name {
-                        StructFieldName::Name(name) => scope.reserve(name),
+                        StructFieldName::Name(name) => scope.claim(name),
                         StructFieldName::Ordinal(ordinal) => {
                             let ident = idents[&IdentMapKey::Type(id)];
-                            scope.reserve(&format!(
+                            scope.claim(&format!(
                                 "{}_{ordinal}",
                                 CodegenIdentUsage::Type(ident).display()
                             ))
                         }
                         StructFieldName::AdditionalProperties => {
-                            scope.reserve_ident(idents::ADDITIONAL_PROPERTIES)
+                            scope.claim("additional_properties")
                         }
                     };
                     map.insert(IdentMapKey::StructField(id, name), ident);
@@ -305,7 +305,7 @@ impl<'graph, 'a> MemberIdentDomain<'graph, 'a> {
                 let mut scope = UniqueIdents::new(arena);
                 for &variant in view.variants() {
                     if let EnumVariant::String(name) = variant {
-                        let ident = scope.reserve(name);
+                        let ident = scope.claim(name);
                         map.insert(IdentMapKey::EnumVariant(id, name), ident);
                     }
                 }
@@ -317,23 +317,23 @@ impl<'graph, 'a> MemberIdentDomain<'graph, 'a> {
                 let mut scope = UniqueIdents::new(arena);
                 for variant in view.variants() {
                     let name = variant.name();
-                    let ident = scope.reserve(name);
+                    let ident = scope.claim(name);
                     map.insert(IdentMapKey::TaggedVariant(id, name), ident);
                 }
                 let mut scope = UniqueIdents::new(arena);
                 for field in view.fields() {
                     let name = field.name();
                     let ident = match name {
-                        StructFieldName::Name(name) => scope.reserve(name),
+                        StructFieldName::Name(name) => scope.claim(name),
                         StructFieldName::Ordinal(ordinal) => {
                             let ident = idents[&IdentMapKey::Type(id)];
-                            scope.reserve(&format!(
+                            scope.claim(&format!(
                                 "{}_{ordinal}",
                                 CodegenIdentUsage::Type(ident).display()
                             ))
                         }
                         StructFieldName::AdditionalProperties => {
-                            scope.reserve_ident(idents::ADDITIONAL_PROPERTIES)
+                            scope.claim("additional_properties")
                         }
                     };
                     map.insert(IdentMapKey::StructField(id, name), ident);
@@ -347,42 +347,41 @@ impl<'graph, 'a> MemberIdentDomain<'graph, 'a> {
                     let ident = match variant.ty() {
                         Some(Schema(schema)) => {
                             let ident = idents[&IdentMapKey::Type(schema.id())];
-                            scope.reserve_ident(ident)
+                            scope.adopt(ident)
                         }
                         Some(Inline(Primitive(_, primitive))) => {
-                            let ident = match primitive.ty() {
-                                PrimitiveType::String => idents::STRING,
-                                PrimitiveType::I8 => idents::I8,
-                                PrimitiveType::U8 => idents::U8,
-                                PrimitiveType::I16 => idents::I16,
-                                PrimitiveType::U16 => idents::U16,
-                                PrimitiveType::I32 => idents::I32,
-                                PrimitiveType::U32 => idents::U32,
-                                PrimitiveType::I64 => idents::I64,
-                                PrimitiveType::U64 => idents::U64,
-                                PrimitiveType::F32 => idents::F32,
-                                PrimitiveType::F64 => idents::F64,
-                                PrimitiveType::Bool => idents::BOOL,
-                                PrimitiveType::DateTime => idents::DATE_TIME,
-                                PrimitiveType::UnixTime => idents::UNIX_TIME,
-                                PrimitiveType::Date => idents::DATE,
-                                PrimitiveType::Url => idents::URL,
-                                PrimitiveType::Uuid => idents::UUID,
-                                PrimitiveType::Bytes => idents::BYTES,
-                                PrimitiveType::Binary => idents::BINARY,
-                            };
-                            scope.reserve_ident(ident)
+                            scope.claim(match primitive.ty() {
+                                PrimitiveType::String => "String",
+                                PrimitiveType::I8 => "I8",
+                                PrimitiveType::U8 => "U8",
+                                PrimitiveType::I16 => "I16",
+                                PrimitiveType::U16 => "U16",
+                                PrimitiveType::I32 => "I32",
+                                PrimitiveType::U32 => "U32",
+                                PrimitiveType::I64 => "I64",
+                                PrimitiveType::U64 => "U64",
+                                PrimitiveType::F32 => "F32",
+                                PrimitiveType::F64 => "F64",
+                                PrimitiveType::Bool => "Bool",
+                                PrimitiveType::DateTime => "DateTime",
+                                PrimitiveType::UnixTime => "UnixTime",
+                                PrimitiveType::Date => "Date",
+                                PrimitiveType::Url => "Url",
+                                PrimitiveType::Uuid => "Uuid",
+                                PrimitiveType::Bytes => "Bytes",
+                                PrimitiveType::Binary => "Binary",
+                            })
                         }
-                        Some(Inline(Container(_, Array(_)))) => scope.reserve_ident(idents::ARRAY),
-                        Some(Inline(Container(_, Map(_)))) => scope.reserve_ident(idents::MAP),
+                        Some(Inline(Container(_, Array(_)))) => scope.claim("Array"),
+                        Some(Inline(Container(_, Map(_)))) => scope.claim("Map"),
                         Some(Inline(..)) => {
                             let ident = idents[&IdentMapKey::Type(id)];
-                            scope.reserve(&format!(
+                            scope.claim(&format!(
                                 "{}_{ordinal}",
                                 CodegenIdentUsage::Type(ident).display()
                             ))
                         }
-                        None => scope.reserve_ident(idents::NONE),
+                        None => scope.claim("None"),
                     };
                     map.insert(IdentMapKey::UntaggedVariant(id, ordinal), ident);
                 }
@@ -391,16 +390,16 @@ impl<'graph, 'a> MemberIdentDomain<'graph, 'a> {
                 for field in view.fields() {
                     let name = field.name();
                     let ident = match name {
-                        StructFieldName::Name(name) => scope.reserve(name),
+                        StructFieldName::Name(name) => scope.claim(name),
                         StructFieldName::Ordinal(ordinal) => {
                             let ident = idents[&IdentMapKey::Type(id)];
-                            scope.reserve(&format!(
+                            scope.claim(&format!(
                                 "{}_{ordinal}",
                                 CodegenIdentUsage::Type(ident).display()
                             ))
                         }
                         StructFieldName::AdditionalProperties => {
-                            scope.reserve_ident(idents::ADDITIONAL_PROPERTIES)
+                            scope.claim("additional_properties")
                         }
                     };
                     map.insert(IdentMapKey::StructField(id, name), ident);

--- a/ploidy-codegen-rust/src/naming.rs
+++ b/ploidy-codegen-rust/src/naming.rs
@@ -1,85 +1,26 @@
-use std::{
-    fmt::{Display, Write},
-    ops::Deref,
-};
+use std::fmt::{Display, Formatter, Result as FmtResult, Write};
 
-use heck::{AsKebabCase, AsPascalCase, AsSnekCase};
-use itertools::Itertools;
 use ploidy_core::{
     arena::Arena,
-    codegen::{UniqueNames, unique::WordSegments},
+    codegen::{AsKebabCase, AsPascalCase, AsSnakeCase, NamePart, UniqueName, UniqueNames},
 };
 
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{IdentFragment, ToTokens, TokenStreamExt};
-use ref_cast::{RefCastCustom, ref_cast_custom};
-
-/// Static identifiers for type and field names.
-pub mod idents {
-    use super::CodegenIdent;
-
-    pub const ADDITIONAL_PROPERTIES: &CodegenIdent = CodegenIdent::new("additional_properties");
-    pub const ARRAY: &CodegenIdent = CodegenIdent::new("Array");
-    pub const BINARY: &CodegenIdent = CodegenIdent::new("Binary");
-    pub const BOOL: &CodegenIdent = CodegenIdent::new("Bool");
-    pub const BYTES: &CodegenIdent = CodegenIdent::new("Bytes");
-    pub const DATE: &CodegenIdent = CodegenIdent::new("Date");
-    pub const DATE_TIME: &CodegenIdent = CodegenIdent::new("DateTime");
-    pub const F32: &CodegenIdent = CodegenIdent::new("F32");
-    pub const F64: &CodegenIdent = CodegenIdent::new("F64");
-    pub const I8: &CodegenIdent = CodegenIdent::new("I8");
-    pub const I16: &CodegenIdent = CodegenIdent::new("I16");
-    pub const I32: &CodegenIdent = CodegenIdent::new("I32");
-    pub const I64: &CodegenIdent = CodegenIdent::new("I64");
-    pub const MAP: &CodegenIdent = CodegenIdent::new("Map");
-    pub const NONE: &CodegenIdent = CodegenIdent::new("None");
-    pub const STRING: &CodegenIdent = CodegenIdent::new("String");
-    pub const U8: &CodegenIdent = CodegenIdent::new("U8");
-    pub const U16: &CodegenIdent = CodegenIdent::new("U16");
-    pub const U32: &CodegenIdent = CodegenIdent::new("U32");
-    pub const U64: &CodegenIdent = CodegenIdent::new("U64");
-    pub const UNIX_TIME: &CodegenIdent = CodegenIdent::new("UnixTime");
-    pub const URL: &CodegenIdent = CodegenIdent::new("Url");
-    pub const UUID: &CodegenIdent = CodegenIdent::new("Uuid");
-}
+use unicode_ident::{is_xid_continue, is_xid_start};
 
 // Keywords that can't be used as identifiers, even with `r#`.
 const KEYWORDS: &[&str] = &["crate", "self", "super", "Self"];
-
-/// A cleaned string that's valid for use as a Rust identifier.
-#[derive(Debug, Eq, Hash, Ord, PartialEq, PartialOrd, RefCastCustom)]
-#[repr(transparent)]
-pub struct CodegenIdent(str);
-
-impl CodegenIdent {
-    #[ref_cast_custom]
-    const fn new(s: &str) -> &Self;
-}
 
 /// An identifier that's unique within its [`UniqueIdents`] scope.
 ///
 /// Only a scope can construct these, ensuring that identifiers won't collide
 /// within that scope. Pass a [`UniqueIdent`] to a [`CodegenIdentUsage`] variant
 /// to emit it as an [`Ident`] token.
-#[derive(Debug, Eq, Hash, Ord, PartialEq, PartialOrd, RefCastCustom)]
-#[repr(transparent)]
-pub struct UniqueIdent(str);
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct UniqueIdent<'a>(UniqueName<'a>);
 
-impl UniqueIdent {
-    #[ref_cast_custom]
-    fn new(s: &str) -> &Self;
-}
-
-impl Deref for UniqueIdent {
-    type Target = CodegenIdent;
-
-    #[inline]
-    fn deref(&self) -> &Self::Target {
-        CodegenIdent::new(&self.0)
-    }
-}
-
-/// Emits a [`CodegenIdent`] as an idiomatic Rust identifier.
+/// Emits a [`UniqueIdent`] as an idiomatic Rust identifier.
 ///
 /// Each [`CodegenIdentUsage`] variant determines the case transformation
 /// applied to the identifier: module, field, parameter, and method names
@@ -89,12 +30,12 @@ impl Deref for UniqueIdent {
 /// use [`display`](Self::display).
 #[derive(Clone, Copy, Debug)]
 pub enum CodegenIdentUsage<'a> {
-    Module(&'a CodegenIdent),
-    Type(&'a CodegenIdent),
-    Field(&'a UniqueIdent),
-    Variant(&'a UniqueIdent),
-    Param(&'a UniqueIdent),
-    Method(&'a UniqueIdent),
+    Module(UniqueIdent<'a>),
+    Type(UniqueIdent<'a>),
+    Field(UniqueIdent<'a>),
+    Variant(UniqueIdent<'a>),
+    Param(UniqueIdent<'a>),
+    Method(UniqueIdent<'a>),
 }
 
 impl<'a> CodegenIdentUsage<'a> {
@@ -106,21 +47,25 @@ impl<'a> CodegenIdentUsage<'a> {
     pub fn display(self) -> impl Display {
         struct DisplayUsage<'a>(CodegenIdentUsage<'a>);
         impl Display for DisplayUsage<'_> {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                let s = self.0.as_str();
-                if !s.starts_with(unicode_ident::is_xid_start) {
-                    // `s` is an identifier fragment; ensure it starts with
-                    // `XID_Start` to make it a valid identifier.
+            fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+                let name = self.0.to_name();
+                if !name.first_char().is_some_and(is_xid_start) {
+                    // Rust identifiers must start with an `XID_Start` character
+                    // or `_`. `clean()` explicitly treats `_` as a separator,
+                    // so prepending `_` to the unique name here is guaranteed
+                    // not to collide with any other identifier.
                     f.write_char('_')?;
                 }
                 match self.0 {
                     CodegenIdentUsage::Type(_) | CodegenIdentUsage::Variant(_) => {
-                        write!(f, "{}", AsPascalCase(s))
+                        write!(f, "{}", AsPascalCase(name))
                     }
                     CodegenIdentUsage::Module(_)
                     | CodegenIdentUsage::Field(_)
                     | CodegenIdentUsage::Param(_)
-                    | CodegenIdentUsage::Method(_) => write!(f, "{}", AsSnekCase(s)),
+                    | CodegenIdentUsage::Method(_) => {
+                        write!(f, "{}", AsSnakeCase(name))
+                    }
                 }
             }
         }
@@ -128,21 +73,21 @@ impl<'a> CodegenIdentUsage<'a> {
     }
 
     #[inline]
-    fn as_str(&self) -> &str {
+    fn to_name(self) -> UniqueName<'a> {
         match self {
-            CodegenIdentUsage::Type(s) => &s.0,
-            CodegenIdentUsage::Variant(s) => &s.0,
-            CodegenIdentUsage::Module(s) => &s.0,
-            CodegenIdentUsage::Field(s) => &s.0,
-            CodegenIdentUsage::Param(s) => &s.0,
-            CodegenIdentUsage::Method(s) => &s.0,
+            CodegenIdentUsage::Type(s) => s.0,
+            CodegenIdentUsage::Variant(s) => s.0,
+            CodegenIdentUsage::Module(s) => s.0,
+            CodegenIdentUsage::Field(s) => s.0,
+            CodegenIdentUsage::Param(s) => s.0,
+            CodegenIdentUsage::Method(s) => s.0,
         }
     }
 }
 
 impl IdentFragment for CodegenIdentUsage<'_> {
     #[inline]
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         write!(f, "{}", self.display())
     }
 }
@@ -169,7 +114,7 @@ impl ToTokens for CodegenIdentUsage<'_> {
 /// [`Default`]: Self::Default
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum ResourceGroup<'a> {
-    Named(&'a UniqueIdent),
+    Named(UniqueIdent<'a>),
     #[default]
     Default,
 }
@@ -177,7 +122,7 @@ pub enum ResourceGroup<'a> {
 impl<'a> ResourceGroup<'a> {
     /// Returns the resource name for a [`Named`][Self::Named] group.
     #[inline]
-    pub fn name(self) -> Option<&'a UniqueIdent> {
+    pub fn name(self) -> Option<UniqueIdent<'a>> {
         match self {
             Self::Named(name) => Some(name),
             Self::Default => None,
@@ -194,12 +139,12 @@ impl<'a> ResourceGroup<'a> {
 
 /// Formats a uniquified resource name as a Cargo feature name.
 #[derive(Clone, Copy, Debug)]
-pub struct AsFeatureName<'a>(pub &'a UniqueIdent);
+pub struct AsFeatureName<'a>(pub UniqueIdent<'a>);
 
 impl Display for AsFeatureName<'_> {
     #[inline]
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", AsKebabCase(&self.0.0))
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "{}", AsKebabCase(self.0.0))
     }
 }
 
@@ -218,45 +163,48 @@ impl<'a> UniqueIdents<'a> {
     /// with additional pre-reserved names.
     #[inline]
     pub fn with_reserved(arena: &'a Arena, reserved: &[&str]) -> Self {
-        Self(UniqueNames::with_reserved(
+        let names = UniqueNames::with_reserved(
             arena,
-            reserved.iter().chain(KEYWORDS).copied(),
-        ))
+            reserved.iter().chain(KEYWORDS).map(|name| clean(name)),
+        );
+        Self(names)
     }
 
-    /// Cleans and uniquifies an identifier.
+    /// Uniquifies an identifier fragment.
     #[inline]
-    pub fn reserve(&mut self, name: &str) -> &'a UniqueIdent {
-        UniqueIdent::new(self.0.uniquify(&clean(name)))
+    pub fn claim(&mut self, name: &str) -> UniqueIdent<'a> {
+        UniqueIdent(self.0.claim(clean(name)))
     }
 
-    /// Uniquifies an already-cleaned identifier.
+    /// Uniquifies an identifier from another scope.
     #[inline]
-    pub fn reserve_ident(&mut self, name: &CodegenIdent) -> &'a UniqueIdent {
-        UniqueIdent::new(self.0.uniquify(&name.0))
+    pub fn adopt(&mut self, ident: UniqueIdent<'a>) -> UniqueIdent<'a> {
+        UniqueIdent(self.0.adopt(ident.0))
     }
 }
 
-/// Makes a valid Rust identifier fragment from a string.
+/// Splits an identifier fragment into name parts for [`UniqueNames`].
 ///
-/// Cleaning segments the string on word boundaries and collapses all
-/// non-`XID_Continue` characters into new boundaries. This makes the fragment
-/// resilient to Heck's case transformations, which also collapse boundaries,
-/// and so can produce duplicates.
-///
-/// The result is a valid identifier fragment, but may not be a valid [`Ident`],
-/// because Rust identifiers must start with `XID_Start`.
+/// Returns non-empty text spans as text parts, with one boundary
+/// between adjacent spans. Text spans contain all `XID_Continue` characters
+/// except `_`; all others are separators. Leading, trailing, and repeated
+/// separators are discarded.
 #[inline]
-fn clean(s: &str) -> String {
-    WordSegments::new(s)
-        .flat_map(|(_, s)| s.split(|c| !unicode_ident::is_xid_continue(c)))
-        .join("_")
+fn clean(s: &str) -> impl Iterator<Item = NamePart<'_>> {
+    use itertools::intersperse;
+    intersperse(
+        s.split(|c| c == '_' || !is_xid_continue(c))
+            .filter(|s| !s.is_empty())
+            .map(NamePart::Text),
+        NamePart::Boundary,
+    )
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    use itertools::Itertools;
     use pretty_assertions::assert_eq;
     use syn::parse_quote;
 
@@ -266,7 +214,7 @@ mod tests {
     fn test_codegen_ident_type() {
         let arena = Arena::new();
         let mut scope = UniqueIdents::new(&arena);
-        let ident = scope.reserve("pet_store");
+        let ident = scope.claim("pet_store");
         let usage = CodegenIdentUsage::Type(ident);
         let actual: syn::Ident = parse_quote!(#usage);
         let expected: syn::Ident = parse_quote!(PetStore);
@@ -277,7 +225,7 @@ mod tests {
     fn test_codegen_ident_field() {
         let arena = Arena::new();
         let mut scope = UniqueIdents::new(&arena);
-        let ident = scope.reserve("petStore");
+        let ident = scope.claim("petStore");
         let usage = CodegenIdentUsage::Field(ident);
         let actual: syn::Ident = parse_quote!(#usage);
         let expected: syn::Ident = parse_quote!(pet_store);
@@ -288,7 +236,7 @@ mod tests {
     fn test_codegen_ident_module() {
         let arena = Arena::new();
         let mut scope = UniqueIdents::new(&arena);
-        let ident = scope.reserve("MyModule");
+        let ident = scope.claim("MyModule");
         let usage = CodegenIdentUsage::Module(ident);
         let actual: syn::Ident = parse_quote!(#usage);
         let expected: syn::Ident = parse_quote!(my_module);
@@ -299,7 +247,7 @@ mod tests {
     fn test_codegen_ident_variant() {
         let arena = Arena::new();
         let mut scope = UniqueIdents::new(&arena);
-        let ident = scope.reserve("http_error");
+        let ident = scope.claim("http_error");
         let usage = CodegenIdentUsage::Variant(ident);
         let actual: syn::Ident = parse_quote!(#usage);
         let expected: syn::Ident = parse_quote!(HttpError);
@@ -310,7 +258,7 @@ mod tests {
     fn test_codegen_ident_param() {
         let arena = Arena::new();
         let mut scope = UniqueIdents::new(&arena);
-        let ident = scope.reserve("userId");
+        let ident = scope.claim("userId");
         let usage = CodegenIdentUsage::Param(ident);
         let actual: syn::Ident = parse_quote!(#usage);
         let expected: syn::Ident = parse_quote!(user_id);
@@ -321,27 +269,10 @@ mod tests {
     fn test_codegen_ident_method() {
         let arena = Arena::new();
         let mut scope = UniqueIdents::new(&arena);
-        let ident = scope.reserve("getUserById");
+        let ident = scope.claim("getUserById");
         let usage = CodegenIdentUsage::Method(ident);
         let actual: syn::Ident = parse_quote!(#usage);
         let expected: syn::Ident = parse_quote!(get_user_by_id);
-        assert_eq!(actual, expected);
-    }
-
-    #[test]
-    fn test_codegen_ident_method_preserves_numeric_boundary() {
-        let arena = Arena::new();
-        let mut scope = UniqueIdents::new(&arena);
-        let ident = scope.reserve("get_fees1");
-
-        let usage = CodegenIdentUsage::Method(ident);
-        let actual: syn::Ident = parse_quote!(#usage);
-        let expected: syn::Ident = parse_quote!(get_fees_1);
-        assert_eq!(actual, expected);
-
-        let usage = CodegenIdentUsage::Type(ident);
-        let actual: syn::Ident = parse_quote!(#usage);
-        let expected: syn::Ident = parse_quote!(GetFees1);
         assert_eq!(actual, expected);
     }
 
@@ -351,7 +282,7 @@ mod tests {
     fn test_codegen_ident_handles_rust_keywords() {
         let arena = Arena::new();
         let mut scope = UniqueIdents::new(&arena);
-        let ident = scope.reserve("type");
+        let ident = scope.claim("type");
         let usage = CodegenIdentUsage::Field(ident);
         let actual: syn::Ident = parse_quote!(#usage);
         let expected: syn::Ident = parse_quote!(r#type);
@@ -362,10 +293,10 @@ mod tests {
     fn test_codegen_ident_handles_invalid_start_chars() {
         let arena = Arena::new();
         let mut scope = UniqueIdents::new(&arena);
-        let ident = scope.reserve("123foo");
+        let ident = scope.claim("123foo");
         let usage = CodegenIdentUsage::Field(ident);
         let actual: syn::Ident = parse_quote!(#usage);
-        let expected: syn::Ident = parse_quote!(_123_foo);
+        let expected: syn::Ident = parse_quote!(_123foo);
         assert_eq!(actual, expected);
     }
 
@@ -373,7 +304,7 @@ mod tests {
     fn test_codegen_ident_handles_special_chars() {
         let arena = Arena::new();
         let mut scope = UniqueIdents::new(&arena);
-        let ident = scope.reserve("foo-bar-baz");
+        let ident = scope.claim("foo-bar-baz");
         let usage = CodegenIdentUsage::Field(ident);
         let actual: syn::Ident = parse_quote!(#usage);
         let expected: syn::Ident = parse_quote!(foo_bar_baz);
@@ -384,11 +315,11 @@ mod tests {
     fn test_codegen_ident_handles_number_prefix() {
         let arena = Arena::new();
         let mut scope = UniqueIdents::new(&arena);
-        let ident = scope.reserve("1099KStatus");
+        let ident = scope.claim("1099KStatus");
 
         let usage = CodegenIdentUsage::Field(ident);
         let actual: syn::Ident = parse_quote!(#usage);
-        let expected: syn::Ident = parse_quote!(_1099_k_status);
+        let expected: syn::Ident = parse_quote!(_1099k_status);
         assert_eq!(actual, expected);
 
         let usage = CodegenIdentUsage::Type(ident);
@@ -400,43 +331,61 @@ mod tests {
     // MARK: `clean()`
 
     #[test]
-    fn test_clean() {
-        assert_eq!(clean("foo-bar"), "foo_bar");
-        assert_eq!(clean("foo.bar"), "foo_bar");
-        assert_eq!(clean("foo bar"), "foo_bar");
-        assert_eq!(clean("foo@bar"), "foo_bar");
-        assert_eq!(clean("foo#bar"), "foo_bar");
-        assert_eq!(clean("foo!bar"), "foo_bar");
+    fn test_clean_classifies_identifier_parts() {
+        use NamePart::{Boundary, Text};
 
-        assert_eq!(clean("foo_bar"), "foo_bar");
-        assert_eq!(clean("FooBar"), "Foo_Bar");
-        assert_eq!(clean("foo123"), "foo_123");
-        assert_eq!(clean("_foo"), "foo");
+        assert_eq!(
+            clean("foo-bar").collect_vec(),
+            [Text("foo"), Boundary, Text("bar")]
+        );
+        assert_eq!(
+            clean("foo.bar").collect_vec(),
+            [Text("foo"), Boundary, Text("bar")]
+        );
+        assert_eq!(
+            clean("foo bar").collect_vec(),
+            [Text("foo"), Boundary, Text("bar")]
+        );
+        assert_eq!(
+            clean("foo@bar").collect_vec(),
+            [Text("foo"), Boundary, Text("bar")]
+        );
 
-        assert_eq!(clean("_foo"), "foo");
-        assert_eq!(clean("__foo"), "foo");
+        assert_eq!(
+            clean("foo_bar").collect_vec(),
+            [Text("foo"), Boundary, Text("bar")]
+        );
+        assert_eq!(clean("FooBar").collect_vec(), [Text("FooBar")]);
+        assert_eq!(clean("foo123").collect_vec(), [Text("foo123")]);
+        assert_eq!(clean("_foo").collect_vec(), [Text("foo")]);
+        assert_eq!(clean("__foo").collect_vec(), [Text("foo")]);
 
-        // Digits are in `XID_Continue`, so they should be preserved.
-        assert_eq!(clean("123foo"), "123_foo");
-        assert_eq!(clean("9bar"), "9_bar");
+        assert_eq!(clean("123foo").collect_vec(), [Text("123foo")]);
+        assert_eq!(clean("9bar").collect_vec(), [Text("9bar")]);
 
-        // Non-ASCII characters that are valid in identifiers should be preserved;
-        // characters that aren't should be replaced.
-        assert_eq!(clean("café"), "café");
-        assert_eq!(clean("foo™bar"), "foo_bar");
+        assert_eq!(clean("caf\u{e9}").collect_vec(), [Text("caf\u{e9}")]);
+        assert_eq!(
+            clean("foo\u{2122}bar").collect_vec(),
+            [Text("foo"), Boundary, Text("bar")]
+        );
 
-        // Invalid characters should be collapsed.
-        assert_eq!(clean("foo---bar"), "foo_bar");
-        assert_eq!(clean("foo...bar"), "foo_bar");
+        assert_eq!(
+            clean("foo---bar").collect_vec(),
+            [Text("foo"), Boundary, Text("bar")]
+        );
+        assert_eq!(
+            clean("foo...bar").collect_vec(),
+            [Text("foo"), Boundary, Text("bar")]
+        );
     }
 
-    // MARK: Scopes
+    // MARK: Edge cases
 
     #[test]
-    fn test_codegen_ident_scope_handles_empty() {
+    fn test_codegen_ident_empty() {
         let arena = Arena::new();
         let mut scope = UniqueIdents::new(&arena);
-        let ident = scope.reserve("");
+        let ident = scope.claim("");
 
         let usage = CodegenIdentUsage::Field(ident);
         let actual: syn::Ident = parse_quote!(#usage);
@@ -450,17 +399,17 @@ mod tests {
     }
 
     #[test]
-    fn test_codegen_ident_scope_handles_numeric_names() {
+    fn test_codegen_ident_numeric_names() {
         let arena = Arena::new();
         let mut scope = UniqueIdents::new(&arena);
 
-        let ident = scope.reserve("0");
+        let ident = scope.claim("0");
         let usage = CodegenIdentUsage::Field(ident);
         let actual: syn::Ident = parse_quote!(#usage);
         let expected: syn::Ident = parse_quote!(_1);
         assert_eq!(actual, expected);
 
-        let ident = scope.reserve("1");
+        let ident = scope.claim("1");
         let usage = CodegenIdentUsage::Type(ident);
         let actual: syn::Ident = parse_quote!(#usage);
         let expected: syn::Ident = parse_quote!(_2);
@@ -468,20 +417,174 @@ mod tests {
     }
 
     #[test]
-    fn test_codegen_ident_scope_handles_reserved_suffixes() {
+    fn test_codegen_ident_reserved_suffixes() {
         let arena = Arena::new();
         let mut scope = UniqueIdents::new(&arena);
 
-        let ident = scope.reserve("crate");
+        let ident = scope.claim("crate");
         let usage = CodegenIdentUsage::Method(ident);
         let actual: syn::Ident = parse_quote!(#usage);
         let expected: syn::Ident = parse_quote!(crate_2);
         assert_eq!(actual, expected);
 
-        let ident = scope.reserve("crate2");
+        let ident = scope.claim("crate2");
         let usage = CodegenIdentUsage::Method(ident);
         let actual: syn::Ident = parse_quote!(#usage);
-        let expected: syn::Ident = parse_quote!(crate_3);
+        let expected: syn::Ident = parse_quote!(crate3);
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_codegen_ident_respects_existing_numeric_suffix_boundary() {
+        let arena = Arena::new();
+        let mut scope = UniqueIdents::new(&arena);
+        let ident = scope.claim("get_fees1");
+
+        let usage = CodegenIdentUsage::Method(ident);
+        let actual: syn::Ident = parse_quote!(#usage);
+        let expected: syn::Ident = parse_quote!(get_fees1);
+        assert_eq!(actual, expected);
+
+        let usage = CodegenIdentUsage::Type(ident);
+        let actual: syn::Ident = parse_quote!(#usage);
+        let expected: syn::Ident = parse_quote!(GetFees1);
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_codegen_ident_collapses_letter_digit_boundaries() {
+        let arena = Arena::new();
+        let mut scope = UniqueIdents::new(&arena);
+
+        let ident = scope.claim("s3Upload");
+        let usage = CodegenIdentUsage::Method(ident);
+        let actual: syn::Ident = parse_quote!(#usage);
+        let expected: syn::Ident = parse_quote!(s3_upload);
+        assert_eq!(actual, expected);
+
+        let ident = scope.claim("x509Cert");
+        let usage = CodegenIdentUsage::Method(ident);
+        let actual: syn::Ident = parse_quote!(#usage);
+        let expected: syn::Ident = parse_quote!(x509_cert);
+        assert_eq!(actual, expected);
+
+        let ident = scope.claim("sha256Digest");
+        let usage = CodegenIdentUsage::Method(ident);
+        let actual: syn::Ident = parse_quote!(#usage);
+        let expected: syn::Ident = parse_quote!(sha256_digest);
+        assert_eq!(actual, expected);
+
+        let ident = scope.claim("http2Protocol");
+        let usage = CodegenIdentUsage::Type(ident);
+        let actual: syn::Ident = parse_quote!(#usage);
+        let expected: syn::Ident = parse_quote!(Http2Protocol);
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_codegen_ident_reserves_numeric_suffix_slots() {
+        let arena = Arena::new();
+        let mut scope = UniqueIdents::new(&arena);
+
+        let first = scope.claim("Response2");
+        let usage = CodegenIdentUsage::Type(first);
+        let actual: syn::Ident = parse_quote!(#usage);
+        let expected: syn::Ident = parse_quote!(Response2);
+        assert_eq!(actual, expected);
+
+        let second = scope.claim("Response_2");
+        let usage = CodegenIdentUsage::Type(second);
+        let actual: syn::Ident = parse_quote!(#usage);
+        let expected: syn::Ident = parse_quote!(Response3);
+        assert_eq!(actual, expected);
+
+        let usage = CodegenIdentUsage::Method(first);
+        let actual: syn::Ident = parse_quote!(#usage);
+        let expected: syn::Ident = parse_quote!(response2);
+        assert_eq!(actual, expected);
+
+        let usage = CodegenIdentUsage::Method(second);
+        let actual: syn::Ident = parse_quote!(#usage);
+        let expected: syn::Ident = parse_quote!(response_3);
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_codegen_ident_deduplicates_internal_numeric_boundaries() {
+        let arena = Arena::new();
+        let mut scope = UniqueIdents::new(&arena);
+
+        let compact = scope.claim("Http2Protocol");
+        let usage = CodegenIdentUsage::Type(compact);
+        let actual: syn::Ident = parse_quote!(#usage);
+        let expected: syn::Ident = parse_quote!(Http2Protocol);
+        assert_eq!(actual, expected);
+
+        let explicit = scope.claim("Http_2Protocol");
+        let usage = CodegenIdentUsage::Type(explicit);
+        let actual: syn::Ident = parse_quote!(#usage);
+        let expected: syn::Ident = parse_quote!(Http2Protocol2);
+        assert_eq!(actual, expected);
+
+        let compact = scope.claim("Http2ProtocolVariant");
+        let usage = CodegenIdentUsage::Variant(compact);
+        let actual: syn::Ident = parse_quote!(#usage);
+        let expected: syn::Ident = parse_quote!(Http2ProtocolVariant);
+        assert_eq!(actual, expected);
+
+        let explicit = scope.claim("Http_2ProtocolVariant");
+        let usage = CodegenIdentUsage::Variant(explicit);
+        let actual: syn::Ident = parse_quote!(#usage);
+        let expected: syn::Ident = parse_quote!(Http2ProtocolVariant2);
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_codegen_ident_adopt_preserves_numeric_suffix_boundary() {
+        let arena = Arena::new();
+        let mut schema_scope = UniqueIdents::new(&arena);
+        let schema_ident = schema_scope.claim("Response_2");
+
+        let mut variant_scope = UniqueIdents::new(&arena);
+        let response = variant_scope.claim("Response");
+        let variant_ident = variant_scope.adopt(schema_ident);
+
+        let usage = CodegenIdentUsage::Variant(response);
+        let actual: syn::Ident = parse_quote!(#usage);
+        let expected: syn::Ident = parse_quote!(Response);
+        assert_eq!(actual, expected);
+
+        let usage = CodegenIdentUsage::Variant(variant_ident);
+        let actual: syn::Ident = parse_quote!(#usage);
+        let expected: syn::Ident = parse_quote!(Response2);
+        assert_eq!(actual, expected);
+
+        let usage = CodegenIdentUsage::Method(variant_ident);
+        let actual: syn::Ident = parse_quote!(#usage);
+        let expected: syn::Ident = parse_quote!(response_2);
+        assert_eq!(actual, expected);
+    }
+
+    // MARK: Cargo features
+
+    #[test]
+    fn test_feature_name_respects_existing_numeric_suffix_boundary() {
+        let arena = Arena::new();
+        let mut scope = UniqueIdents::new(&arena);
+        let ident = scope.claim("get_fees1");
+
+        assert_eq!(AsFeatureName(ident).to_string(), "get-fees1");
+    }
+
+    #[test]
+    fn test_feature_name_collapses_letter_digit_boundaries() {
+        let arena = Arena::new();
+        let mut scope = UniqueIdents::new(&arena);
+
+        let compact = scope.claim("oauth2Token");
+        assert_eq!(AsFeatureName(compact).to_string(), "oauth2-token");
+
+        let explicit = scope.claim("oauth_2_token");
+        assert_eq!(AsFeatureName(explicit).to_string(), "oauth-2-token-2");
     }
 }

--- a/ploidy-core/Cargo.toml
+++ b/ploidy-core/Cargo.toml
@@ -32,6 +32,7 @@ rustc-hash = { workspace = true }
 syn = { version = "2", default-features = false, optional = true }
 thiserror = "2"
 unicase = "2"
+unicode-normalization = "0.1"
 winnow = "1.0"
 
 [dev-dependencies]

--- a/ploidy-core/src/arena.rs
+++ b/ploidy-core/src/arena.rs
@@ -66,6 +66,12 @@ impl Arena {
     pub(crate) fn alloc_str(&self, s: &str) -> &mut str {
         self.0.alloc_str(s)
     }
+
+    /// Allocates and returns a reference to a formatted string.
+    #[inline]
+    pub(crate) fn alloc_fmt(&self, f: std::fmt::Arguments<'_>) -> &str {
+        bumpalo::format!(in &self.0, "{}", f).into_bump_str()
+    }
 }
 
 // Atomics aren't `Copy`, but are trivially droppable, and so OK to allocate

--- a/ploidy-core/src/codegen/mod.rs
+++ b/ploidy-core/src/codegen/mod.rs
@@ -25,7 +25,7 @@ use miette::{Context, IntoDiagnostic};
 
 pub mod unique;
 
-pub use unique::{UniqueNames, WordSegments};
+pub use unique::{AsKebabCase, AsPascalCase, AsSnakeCase, NamePart, UniqueName, UniqueNames};
 
 pub fn write_to_disk(output: &Path, code: impl IntoCode) -> miette::Result<()> {
     let code = code.into_code();

--- a/ploidy-core/src/codegen/unique.rs
+++ b/ploidy-core/src/codegen/unique.rs
@@ -1,19 +1,41 @@
-use std::{iter::Peekable, str::CharIndices};
+//! Naming support for generated code.
+//!
+//! OpenAPI specs use different naming conventions for their types, operations,
+//! and resources. When codegen emits these names, it needs to transform them
+//! into identifiers that conform to the grammar and idiomatic case style of
+//! each target language.
+//!
+//! Codegen segments OpenAPI names into [`NamePart`] segments. A [`UniqueNames`]
+//! scope turns these segment sequences into a representation that's unique
+//! within that scope, and stable regardless of whether it's rendered
+//! [`AsPascalCase`], [`AsSnakeCase`], or [`AsKebabCase`].
+
+use std::{
+    fmt::{Display, Formatter, Result as FmtResult, Write},
+    iter::{self, Peekable},
+    mem,
+};
 
 use itertools::Itertools;
 use rustc_hash::{FxHashMap, FxHashSet};
 use unicase::UniCase;
+use unicode_normalization::UnicodeNormalization;
 
 use crate::arena::Arena;
 
-/// Deduplicates names across case conventions.
+/// A scope that claims target language names before final case rendering.
+///
+/// [`UniqueNames`] canonicalizes source name parts into word segments,
+/// assigns collision suffixes for already-claimed names, and returns
+/// opaque [`UniqueName`] handles for codegen to render in any case style.
 #[derive(Debug)]
 pub struct UniqueNames<'a> {
     arena: &'a Arena,
-    space: FxHashMap<&'a [UniCase<&'a str>], FxHashSet<usize>>,
+    space: FxHashMap<Box<[UniCase<&'a str>]>, FxHashSet<SuffixSlot>>,
 }
 
 impl<'a> UniqueNames<'a> {
+    /// Creates an empty name scope.
     pub fn new(arena: &'a Arena) -> Self {
         Self {
             arena,
@@ -21,242 +43,388 @@ impl<'a> UniqueNames<'a> {
         }
     }
 
-    pub fn with_reserved<S: AsRef<str>>(
-        arena: &'a Arena,
-        reserved: impl IntoIterator<Item = S>,
-    ) -> Self {
-        let mut names = Self::new(arena);
-        for name in reserved {
-            names.reserve(name.as_ref());
+    /// Creates a name scope that reserves existing names.
+    pub fn with_reserved<'part, R>(arena: &'a Arena, reserved: R) -> Self
+    where
+        R: IntoIterator,
+        R::Item: IntoIterator<Item = NamePart<'part>>,
+    {
+        let mut space = FxHashMap::<_, FxHashSet<_>>::default();
+        for parts in reserved {
+            let segments = segments(parts)
+                .map(|WordSegment(text, boundary)| WordSegment(&*arena.alloc_str(&text), boundary))
+                .collect_vec();
+            let decomposed = DecomposedName::new(&segments);
+            space
+                .entry(decomposed.prefix().map(|s| UniCase::new(s.0)).collect())
+                .or_default()
+                .insert(decomposed.slot());
         }
-        names
+        Self { arena, space }
     }
 
-    /// Adds a name to this scope and returns a unique form.
+    /// Claims a segmented source name, and returns a name that's
+    /// unique within this scope.
     ///
-    /// Names without word content use numeric forms starting at `1`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use ploidy_core::{arena::Arena, codegen::UniqueNames};
-    /// let arena = Arena::new();
-    /// let mut names = UniqueNames::new(&arena);
-    /// assert_eq!(names.uniquify("HTTPResponse"), "HTTPResponse");
-    /// assert_eq!(names.uniquify("HTTP_Response"), "HTTP_Response_2");
-    /// assert_eq!(names.uniquify("httpResponse"), "httpResponse_3");
-    /// assert_eq!(names.uniquify("http_response_2"), "http_response_4");
-    /// ```
-    pub fn uniquify(&mut self, name: &str) -> &'a str {
-        let parsed = ParsedName::parse(name);
-        let segments = self.arena.alloc_slice_exact(
-            parsed
-                .segments()
-                .iter()
-                .map(|(_, segment)| UniCase::new(&*self.arena.alloc_str(segment))),
-        );
-        let occupied = self.space.entry(segments).or_default();
-
-        let suffix = if occupied.insert(parsed.suffix()) {
-            parsed.suffix()
-        } else {
-            let mut suffix = parsed.min_suffix();
-            while !occupied.insert(suffix) {
-                suffix = suffix.checked_add(1).unwrap();
-            }
-            suffix
-        };
-
-        match parsed {
-            ParsedName::Empty | ParsedName::Numeric(_) => self.arena.alloc_str(&suffix.to_string()),
-            ParsedName::Stemmed { stem, .. } if suffix > 0 => {
-                self.arena.alloc_str(&format!("{stem}_{suffix}"))
-            }
-            ParsedName::Stemmed { stem, .. } => self.arena.alloc_str(stem),
-        }
+    /// If the name has already been claimed, the returned name receives
+    /// the next free unique numeric suffix.
+    pub fn claim<'part>(
+        &mut self,
+        parts: impl IntoIterator<Item = NamePart<'part>>,
+    ) -> UniqueName<'a> {
+        let segments = segments(parts)
+            .map(|WordSegment(text, boundary)| WordSegment(&*self.arena.alloc_str(&text), boundary))
+            .collect_vec();
+        UniqueName(self.claim_from_segments(&segments))
     }
 
-    fn reserve(&mut self, name: &str) {
-        let parsed = ParsedName::parse(name);
-        let segments = self.arena.alloc_slice_exact(
-            parsed
-                .segments()
-                .iter()
-                .map(|(_, segment)| UniCase::new(&*self.arena.alloc_str(segment))),
-        );
-        self.space
-            .entry(segments)
-            .or_default()
-            .insert(parsed.reserved_suffix());
+    /// Claims a name that's already unique in another scope, and returns
+    /// a unique form of that name in this scope.
+    pub fn adopt(&mut self, name: UniqueName<'a>) -> UniqueName<'a> {
+        UniqueName(self.claim_from_segments(name.0))
+    }
+
+    fn claim_from_segments(
+        &mut self,
+        segments: &[WordSegment<&'a str>],
+    ) -> &'a [WordSegment<&'a str>] {
+        let decomposed = DecomposedName::new(segments);
+        let occupied = self
+            .space
+            .entry(decomposed.prefix().map(|s| UniCase::new(s.0)).collect())
+            .or_default();
+
+        match decomposed {
+            DecomposedName::Empty { mut slot } => {
+                // An empty or digit-only name becomes a single word
+                // that's just the unique suffix.
+                while !occupied.insert(SuffixSlot::Number(slot)) {
+                    slot = slot.checked_add(1).unwrap();
+                }
+                std::slice::from_ref(self.arena.alloc(WordSegment(
+                    self.arena.alloc_fmt(format_args!("{slot}")),
+                    WordBoundary::First,
+                )))
+            }
+            DecomposedName::Text {
+                suffix: DecomposedSuffix::Source { mut slot, boundary },
+                ..
+            } => {
+                // A name with an existing numeric suffix reuses the
+                // boundary between the last stem and original suffix,
+                // then adds the unique suffix.
+                while !occupied.insert(SuffixSlot::Number(slot)) {
+                    slot = slot.checked_add(1).unwrap();
+                }
+                self.arena
+                    .alloc_slice(decomposed.prefix().chain(iter::once(WordSegment(
+                        self.arena.alloc_fmt(format_args!("{slot}")),
+                        boundary,
+                    ))))
+            }
+            DecomposedName::Text {
+                suffix: DecomposedSuffix::Absent,
+                ..
+            } => {
+                let mut slot = SuffixSlot::Absent;
+                while !occupied.insert(slot) {
+                    slot = match slot {
+                        SuffixSlot::Absent => SuffixSlot::Number(2),
+                        SuffixSlot::Number(slot) => {
+                            SuffixSlot::Number(slot.checked_add(1).unwrap())
+                        }
+                    };
+                }
+                match slot {
+                    // A unique name doesn't need a suffix.
+                    SuffixSlot::Absent => self.arena.alloc_slice(decomposed.prefix()),
+                    // An unsuffixed name adds a separator, then the unique suffix.
+                    SuffixSlot::Number(slot) => {
+                        self.arena
+                            .alloc_slice(decomposed.prefix().chain(iter::once(WordSegment(
+                                self.arena.alloc_fmt(format_args!("{slot}")),
+                                WordBoundary::After(SegmentBoundary::Separator),
+                            ))))
+                    }
+                }
+            }
+        }
     }
 }
 
-/// Segments a string into words and their byte offsets,
-/// detecting word boundaries for case transformations.
+/// A segment of an OpenAPI source name.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum NamePart<'a> {
+    /// Text to normalize and split into [`UniqueName`] segments.
+    Text(&'a str),
+    /// An explicit word boundary.
+    Boundary,
+}
+
+/// A name that's unique within a scope, and that can be rendered in any case.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct UniqueName<'a>(&'a [WordSegment<&'a str>]);
+
+impl<'a> UniqueName<'a> {
+    /// Returns the first character of this name's segment text.
+    #[inline]
+    pub fn first_char(&self) -> Option<char> {
+        self.0.first().and_then(|s| s.0.chars().next())
+    }
+
+    /// Returns the segments that make up this name.
+    #[inline]
+    fn segments(&self) -> impl Iterator<Item = NameSegment<'a>> {
+        self.0.iter().flat_map(|&WordSegment(text, boundary)| {
+            either!(match boundary {
+                WordBoundary::First => [NameSegment::Text(text)],
+                WordBoundary::After(boundary) =>
+                    [NameSegment::Boundary(boundary), NameSegment::Text(text)],
+            })
+            .into_iter()
+        })
+    }
+}
+
+/// A canonical text or boundary segment in a [`UniqueName`].
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+enum NameSegment<'a> {
+    /// The canonicalized segment text.
+    Text(&'a str),
+    /// A segment boundary.
+    Boundary(SegmentBoundary),
+}
+
+/// Formats a [`UniqueName`] as `PascalCase`.
+///
+/// Each segment starts with an uppercase character and continues in lowercase.
+pub struct AsPascalCase<'a>(pub UniqueName<'a>);
+
+impl Display for AsPascalCase<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        for segment in self.0.segments() {
+            if let NameSegment::Text(text) = segment {
+                let mut chars = text.chars();
+                if let Some(c) = chars.next() {
+                    write!(f, "{}", c.to_uppercase())?;
+                    chars.try_for_each(|c| write!(f, "{}", c.to_lowercase()))?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Formats a [`UniqueName`] as `snake_case`.
+///
+/// Case and separator boundaries become `_`.
+/// Letter-to-digit and digit-to-letter boundaries collapse to preserve
+/// common names like `sha256`, `http2`, `x509`, and `s3`.
+pub struct AsSnakeCase<'a>(pub UniqueName<'a>);
+
+impl Display for AsSnakeCase<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        for segment in self.0.segments() {
+            match segment {
+                NameSegment::Boundary(
+                    SegmentBoundary::LetterDigit | SegmentBoundary::DigitLetter,
+                ) => continue,
+                NameSegment::Boundary(_) => f.write_char('_')?,
+                NameSegment::Text(text) => text
+                    .chars()
+                    .try_for_each(|c| write!(f, "{}", c.to_lowercase()))?,
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Formats a name as `kebab-case`.
+///
+/// Case and separator boundaries become `-`.
+/// Letter-to-digit and digit-to-letter boundaries collapse, like
+/// [`AsSnakeCase`].
+pub struct AsKebabCase<'a>(pub UniqueName<'a>);
+
+impl Display for AsKebabCase<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        for segment in self.0.segments() {
+            match segment {
+                NameSegment::Boundary(
+                    SegmentBoundary::LetterDigit | SegmentBoundary::DigitLetter,
+                ) => continue,
+                NameSegment::Boundary(_) => f.write_char('-')?,
+                NameSegment::Text(text) => text
+                    .chars()
+                    .try_for_each(|c| write!(f, "{}", c.to_lowercase()))?,
+            }
+        }
+        Ok(())
+    }
+}
+
+/// A boundary between word segments.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+enum SegmentBoundary {
+    /// The segment follows one or more separator parts.
+    Separator,
+    /// The segment follows a case transition.
+    Case,
+    /// The segment follows a letter-to-digit transition.
+    LetterDigit,
+    /// The segment follows a digit-to-letter transition.
+    DigitLetter,
+}
+
+enum DecomposedName<'segments, 'text> {
+    Empty {
+        slot: usize,
+    },
+    Text {
+        init: &'segments [WordSegment<&'text str>],
+        last: Option<WordSegment<&'text str>>,
+        suffix: DecomposedSuffix,
+    },
+}
+
+impl<'segments, 'text> DecomposedName<'segments, 'text> {
+    fn new(segments: &'segments [WordSegment<&'text str>]) -> Self {
+        if segments.is_empty() {
+            return Self::Empty { slot: 1 };
+        }
+        if let Some((&WordSegment(last, boundary), head)) = segments.split_last() {
+            let stem = last.trim_end_matches(|c: char| c.is_ascii_digit());
+            if let Some(slot) = last.strip_prefix(stem)
+                && let Ok(slot) = slot.parse::<usize>()
+            {
+                if stem.is_empty() {
+                    if head.is_empty() {
+                        return Self::Empty { slot: slot.max(1) };
+                    }
+                    return Self::Text {
+                        init: head,
+                        last: None,
+                        suffix: DecomposedSuffix::Source { slot, boundary },
+                    };
+                }
+                let last = match head {
+                    [] => WordSegment(stem, WordBoundary::First),
+                    [..] => WordSegment(stem, WordBoundary::After(SegmentBoundary::Separator)),
+                };
+                return Self::Text {
+                    init: head,
+                    last: Some(last),
+                    suffix: DecomposedSuffix::Source {
+                        slot,
+                        boundary: WordBoundary::After(SegmentBoundary::LetterDigit),
+                    },
+                };
+            }
+        }
+        Self::Text {
+            init: segments,
+            last: None,
+            suffix: DecomposedSuffix::Absent,
+        }
+    }
+
+    fn prefix(&self) -> impl Iterator<Item = WordSegment<&'text str>> {
+        let (init, last): (&'segments [_], Option<_>) = match self {
+            Self::Empty { .. } => (&[], None),
+            &Self::Text { init, last, .. } => (init, last),
+        };
+        init.iter().copied().chain(last)
+    }
+
+    fn slot(&self) -> SuffixSlot {
+        match *self {
+            Self::Empty { slot } => SuffixSlot::Number(slot),
+            Self::Text {
+                suffix: DecomposedSuffix::Absent,
+                ..
+            } => SuffixSlot::Absent,
+            Self::Text {
+                suffix: DecomposedSuffix::Source { slot, .. },
+                ..
+            } => SuffixSlot::Number(slot),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum DecomposedSuffix {
+    Absent,
+    Source { slot: usize, boundary: WordBoundary },
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+enum SuffixSlot {
+    Absent,
+    Number(usize),
+}
+
+/// Segments name parts into words.
+///
+/// Text parts are normalized to NFC before segmentation.
 ///
 /// Word boundaries occur on:
 ///
-/// * Non-alphanumeric characters: underscores, hyphens, etc.
+/// * Whitespace, `-`, `_`, and explicit [`NamePart::Boundary`] parts.
 /// * Lowercase-to-uppercase transitions (`httpResponse`).
 /// * Uppercase-to-lowercase after an uppercase run (`XMLHttp`).
-/// * Letter-to-digit and digit-to-letter transitions (`Response2`, `250g`).
-///
-/// The digit transition rules are stricter than Heck's segmentation,
-/// to ensure that names like (`Response2`, `Response_2`) and
-/// (`1099KStatus`, `1099_K_Status`) collide. Without this rule, these cases
-/// would produce similar-but-distinct names differing only in their
-/// internal capitalization.
-///
-/// # Examples
-///
-/// ```
-/// # use itertools::Itertools;
-/// # use ploidy_core::codegen::WordSegments;
-/// assert_eq!(
-///     WordSegments::new("HTTPResponse").collect_vec(),
-///     vec![(0, "HTTP"), (4, "Response")]
-/// );
-/// assert_eq!(
-///     WordSegments::new("HTTP_Response").collect_vec(),
-///     vec![(0, "HTTP"), (5, "Response")]
-/// );
-/// assert_eq!(
-///     WordSegments::new("httpResponse").collect_vec(),
-///     vec![(0, "http"), (4, "Response")]
-/// );
-/// assert_eq!(
-///     WordSegments::new("XMLHttpRequest").collect_vec(),
-///     vec![(0, "XML"), (3, "Http"), (7, "Request")]
-/// );
-/// assert_eq!(
-///     WordSegments::new("Response2").collect_vec(),
-///     vec![(0, "Response"), (8, "2")]
-/// );
-/// assert_eq!(
-///     WordSegments::new("250g").collect_vec(),
-///     vec![(0, "250"), (3, "g")]
-/// );
-/// ```
-pub struct WordSegments<'a> {
-    input: &'a str,
-    chars: Peekable<CharIndices<'a>>,
-    current_word_starts_at: Option<usize>,
-    mode: WordMode,
+/// * Letter-to-ASCII-digit transitions (`sha256`).
+/// * ASCII digit-to-letter transitions (`250g`).
+fn segments<'a>(
+    input: impl IntoIterator<Item = NamePart<'a>>,
+) -> impl Iterator<Item = WordSegment<String>> {
+    WordSegments {
+        input: input
+            .into_iter()
+            .flat_map(|part| {
+                either!(match part {
+                    NamePart::Text(text) => text.nfc().map(NameChar::from),
+                    NamePart::Boundary => iter::once(NameChar::Separator),
+                })
+            })
+            .peekable(),
+        state: WordState::Start,
+    }
 }
 
-impl<'a> WordSegments<'a> {
-    #[inline]
-    pub fn new(input: &'a str) -> Self {
-        Self {
-            input,
-            chars: input.char_indices().peekable(),
-            current_word_starts_at: None,
-            mode: WordMode::Boundary,
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum NameChar {
+    Continue(char),
+    Separator,
+}
+
+impl From<char> for NameChar {
+    fn from(c: char) -> Self {
+        match c {
+            c if c.is_whitespace() => Self::Separator,
+            // Explicitly treat snake_case and kebab-case separators
+            // as word boundaries.
+            '_' | '-' => Self::Separator,
+            c => Self::Continue(c),
         }
     }
 }
 
-impl<'a> Iterator for WordSegments<'a> {
-    type Item = (usize, &'a str);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        while let Some((index, c)) = self.chars.next() {
-            if c.is_uppercase() {
-                match self.mode {
-                    WordMode::Boundary | WordMode::Digit => {
-                        // Start a new word with this uppercase character.
-                        let start = self.current_word_starts_at.replace(index);
-                        self.mode = WordMode::Uppercase;
-                        if let Some(start) = start {
-                            return Some((start, &self.input[start..index]));
-                        }
-                    }
-                    WordMode::Lowercase => {
-                        // camelCased word (previous was lowercase;
-                        // current is uppercase), start a new word.
-                        let start = self.current_word_starts_at.replace(index);
-                        self.mode = WordMode::Uppercase;
-                        if let Some(start) = start {
-                            return Some((start, &self.input[start..index]));
-                        }
-                    }
-                    WordMode::Uppercase => {
-                        let next_is_lowercase = self
-                            .chars
-                            .peek()
-                            .map(|&(_, next)| next.is_lowercase())
-                            .unwrap_or(false);
-                        if next_is_lowercase && let Some(start) = self.current_word_starts_at {
-                            // `XMLHttp` case; start a new word with this uppercase
-                            // character (the "H" in "Http").
-                            self.current_word_starts_at = Some(index);
-                            return Some((start, &self.input[start..index]));
-                        }
-                        // (Stay in uppercase mode).
-                    }
-                }
-            } else if c.is_lowercase() {
-                match self.mode {
-                    WordMode::Boundary | WordMode::Digit => {
-                        // Start a new word with this lowercase character.
-                        let start = self.current_word_starts_at.replace(index);
-                        self.mode = WordMode::Lowercase;
-                        if let Some(start) = start {
-                            return Some((start, &self.input[start..index]));
-                        }
-                    }
-                    WordMode::Lowercase | WordMode::Uppercase => {
-                        if self.current_word_starts_at.is_none() {
-                            // Start or continue the current word.
-                            self.current_word_starts_at = Some(index);
-                        }
-                        self.mode = WordMode::Lowercase;
-                    }
-                }
-            } else if c.is_ascii_digit() {
-                match self.mode {
-                    WordMode::Boundary | WordMode::Digit => {
-                        if self.current_word_starts_at.is_none() {
-                            self.current_word_starts_at = Some(index);
-                        }
-                        self.mode = WordMode::Digit;
-                    }
-                    WordMode::Lowercase | WordMode::Uppercase => {
-                        let start = self.current_word_starts_at.replace(index);
-                        self.mode = WordMode::Digit;
-                        if let Some(start) = start {
-                            return Some((start, &self.input[start..index]));
-                        }
-                    }
-                }
-            } else if !c.is_alphanumeric() {
-                // Start a new word at this non-alphanumeric character.
-                let start = std::mem::take(&mut self.current_word_starts_at);
-                self.mode = WordMode::Boundary;
-                if let Some(start) = start {
-                    return Some((start, &self.input[start..index]));
-                }
-            } else {
-                // Other alphanumeric character: continue the current word.
-                if self.current_word_starts_at.is_none() {
-                    self.current_word_starts_at = Some(index);
-                }
-            }
-        }
-        if let Some(start) = std::mem::take(&mut self.current_word_starts_at) {
-            // Trailing word.
-            return Some((start, &self.input[start..]));
-        }
-        None
-    }
+/// The active or pending word state in a [`WordSegments`].
+#[derive(Clone)]
+enum WordState {
+    /// Before the first word.
+    Start,
+    /// Between words, with the boundary to apply to the next word.
+    Between(SegmentBoundary),
+    /// Inside a word that can be emitted by the next boundary.
+    InWord(String, WordBoundary, WordMode),
 }
 
-/// The current state of a [`WordSegments`] iterator.
+/// The character class of the active [`WordState::InWord`] state.
 #[derive(Clone, Copy)]
 enum WordMode {
-    /// At a word boundary: either at the start of a new word, or
-    /// after a non-alphanumeric character.
-    Boundary,
+    /// Currently in an uncased alphanumeric segment.
+    Uncased,
     /// Currently in a lowercase segment.
     Lowercase,
     /// Currently in an uppercase segment.
@@ -265,204 +433,440 @@ enum WordMode {
     Digit,
 }
 
-enum ParsedName<'a> {
-    Empty,
-    Numeric(usize),
-    Stemmed {
-        segments: Vec<(usize, &'a str)>,
-        stem: &'a str,
-        suffix: usize,
-    },
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+enum WordBoundary {
+    First,
+    After(SegmentBoundary),
 }
 
-impl<'a> ParsedName<'a> {
-    fn parse(name: &'a str) -> Self {
-        let mut segments = WordSegments::new(name).collect_vec();
-        if segments.is_empty() {
-            return Self::Empty;
-        }
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+struct WordSegment<T>(T, WordBoundary);
 
-        let Some((suffix_start, suffix)) = segments
-            .iter()
-            .last()
-            .and_then(|&(offset, segment)| Some((offset, segment.parse::<usize>().ok()?)))
-        else {
-            return Self::Stemmed {
-                segments,
-                stem: name,
-                suffix: 0,
-            };
-        };
+struct WordSegments<I: Iterator<Item = NameChar>> {
+    input: Peekable<I>,
+    state: WordState,
+}
 
-        segments.pop();
-        if segments.is_empty() {
-            return Self::Numeric(suffix);
-        }
+impl<I: Iterator<Item = NameChar>> Iterator for WordSegments<I> {
+    type Item = WordSegment<String>;
 
-        let stem = name[..suffix_start].trim_end_matches(|c: char| !c.is_alphanumeric());
-        Self::Stemmed {
-            segments,
-            stem,
-            suffix,
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some(c) = self.input.next() {
+            match c {
+                NameChar::Separator => {
+                    // Start a new word at this separator character.
+                    match mem::replace(
+                        &mut self.state,
+                        WordState::Between(SegmentBoundary::Separator),
+                    ) {
+                        WordState::InWord(text, boundary, _) => {
+                            while let Some(NameChar::Separator) = self.input.peek() {
+                                self.input.next();
+                            }
+                            self.state = WordState::Between(SegmentBoundary::Separator);
+                            return Some(WordSegment(text, boundary));
+                        }
+                        state => {
+                            self.state = state;
+                        }
+                    }
+                }
+                NameChar::Continue(c) if c.is_uppercase() => {
+                    match mem::replace(
+                        &mut self.state,
+                        WordState::Between(SegmentBoundary::Separator),
+                    ) {
+                        WordState::Start => {
+                            self.state = WordState::InWord(
+                                c.to_string(),
+                                WordBoundary::First,
+                                WordMode::Uppercase,
+                            );
+                        }
+                        WordState::Between(next_boundary) => {
+                            self.state = WordState::InWord(
+                                c.to_string(),
+                                WordBoundary::After(next_boundary),
+                                WordMode::Uppercase,
+                            );
+                        }
+                        WordState::InWord(
+                            mut text,
+                            boundary,
+                            WordMode::Uncased | WordMode::Uppercase,
+                        ) => {
+                            let next_is_lowercase = self.input.peek().is_some_and(|next| {
+                                matches!(next, NameChar::Continue(next) if next.is_lowercase())
+                            });
+                            if next_is_lowercase {
+                                // `XMLHttp` case; start a new word with this uppercase
+                                // character (the "H" in "Http").
+                                self.state = WordState::InWord(
+                                    c.to_string(),
+                                    WordBoundary::After(SegmentBoundary::Case),
+                                    WordMode::Uppercase,
+                                );
+                                return Some(WordSegment(text, boundary));
+                            }
+                            text.push(c);
+                            self.state = WordState::InWord(text, boundary, WordMode::Uppercase);
+                        }
+                        WordState::InWord(text, boundary, WordMode::Digit) => {
+                            let next_is_lowercase = self.input.peek().is_some_and(|next| {
+                                matches!(next, NameChar::Continue(next) if next.is_lowercase())
+                            });
+                            self.state = WordState::InWord(
+                                c.to_string(),
+                                WordBoundary::After(if next_is_lowercase {
+                                    SegmentBoundary::Case
+                                } else {
+                                    SegmentBoundary::DigitLetter
+                                }),
+                                WordMode::Uppercase,
+                            );
+                            return Some(WordSegment(text, boundary));
+                        }
+                        WordState::InWord(text, boundary, WordMode::Lowercase) => {
+                            // Start a new word at the uppercase side of a case boundary.
+                            self.state = WordState::InWord(
+                                c.to_string(),
+                                WordBoundary::After(SegmentBoundary::Case),
+                                WordMode::Uppercase,
+                            );
+                            return Some(WordSegment(text, boundary));
+                        }
+                    }
+                }
+                NameChar::Continue(c) if c.is_lowercase() => {
+                    match mem::replace(
+                        &mut self.state,
+                        WordState::Between(SegmentBoundary::Separator),
+                    ) {
+                        WordState::Start => {
+                            self.state = WordState::InWord(
+                                c.to_string(),
+                                WordBoundary::First,
+                                WordMode::Lowercase,
+                            );
+                        }
+                        WordState::Between(next_boundary) => {
+                            self.state = WordState::InWord(
+                                c.to_string(),
+                                WordBoundary::After(next_boundary),
+                                WordMode::Lowercase,
+                            );
+                        }
+                        WordState::InWord(
+                            mut text,
+                            boundary,
+                            WordMode::Uncased | WordMode::Lowercase | WordMode::Uppercase,
+                        ) => {
+                            text.push(c);
+                            self.state = WordState::InWord(text, boundary, WordMode::Lowercase);
+                        }
+                        WordState::InWord(text, boundary, WordMode::Digit) => {
+                            // Start a new word after a digit segment.
+                            self.state = WordState::InWord(
+                                c.to_string(),
+                                WordBoundary::After(SegmentBoundary::DigitLetter),
+                                WordMode::Lowercase,
+                            );
+                            return Some(WordSegment(text, boundary));
+                        }
+                    }
+                }
+                NameChar::Continue(c) if c.is_ascii_digit() => {
+                    match mem::replace(
+                        &mut self.state,
+                        WordState::Between(SegmentBoundary::Separator),
+                    ) {
+                        WordState::Start => {
+                            self.state = WordState::InWord(
+                                c.to_string(),
+                                WordBoundary::First,
+                                WordMode::Digit,
+                            );
+                        }
+                        WordState::Between(next_boundary) => {
+                            self.state = WordState::InWord(
+                                c.to_string(),
+                                WordBoundary::After(next_boundary),
+                                WordMode::Digit,
+                            );
+                        }
+                        WordState::InWord(mut text, boundary, WordMode::Digit) => {
+                            text.push(c);
+                            self.state = WordState::InWord(text, boundary, WordMode::Digit);
+                        }
+                        WordState::InWord(
+                            text,
+                            boundary,
+                            WordMode::Uncased | WordMode::Lowercase | WordMode::Uppercase,
+                        ) => {
+                            // Start a new word after a letter segment.
+                            self.state = WordState::InWord(
+                                c.to_string(),
+                                WordBoundary::After(SegmentBoundary::LetterDigit),
+                                WordMode::Digit,
+                            );
+                            return Some(WordSegment(text, boundary));
+                        }
+                    }
+                }
+                NameChar::Continue(c) => {
+                    // All other characters continue the current word.
+                    match mem::replace(
+                        &mut self.state,
+                        WordState::Between(SegmentBoundary::Separator),
+                    ) {
+                        WordState::Start => {
+                            self.state = WordState::InWord(
+                                c.to_string(),
+                                WordBoundary::First,
+                                WordMode::Uncased,
+                            );
+                        }
+                        WordState::Between(next_boundary) => {
+                            self.state = WordState::InWord(
+                                c.to_string(),
+                                WordBoundary::After(next_boundary),
+                                WordMode::Uncased,
+                            );
+                        }
+                        WordState::InWord(mut text, boundary, mode) => {
+                            text.push(c);
+                            self.state = WordState::InWord(text, boundary, mode);
+                        }
+                    }
+                }
+            }
         }
-    }
-
-    fn segments(&self) -> &[(usize, &'a str)] {
-        match self {
-            Self::Empty | Self::Numeric(_) => &[],
-            Self::Stemmed { segments, .. } => segments,
+        if let WordState::InWord(text, boundary, _) = mem::replace(
+            &mut self.state,
+            WordState::Between(SegmentBoundary::Separator),
+        ) {
+            // Trailing word.
+            self.state = WordState::Between(SegmentBoundary::Separator);
+            return Some(WordSegment(text, boundary));
         }
-    }
-
-    fn suffix(&self) -> usize {
-        match self {
-            Self::Empty | Self::Numeric(0) => 1,
-            &(Self::Numeric(suffix) | Self::Stemmed { suffix, .. }) => suffix,
-        }
-    }
-
-    fn reserved_suffix(&self) -> usize {
-        match self {
-            Self::Empty | Self::Numeric(0) => 0,
-            &(Self::Numeric(suffix) | Self::Stemmed { suffix, .. }) => suffix,
-        }
-    }
-
-    fn min_suffix(&self) -> usize {
-        match self {
-            Self::Empty => 1,
-            &Self::Numeric(suffix) => suffix.max(1),
-            &Self::Stemmed { suffix, .. } => suffix.max(2),
-        }
+        None
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use NamePart::{Boundary, Text};
+
     use itertools::Itertools;
+
+    fn segments(parts: &[NamePart<'_>]) -> Vec<String> {
+        super::segments(parts.iter().copied())
+            .map(|WordSegment(text, _)| text)
+            .collect_vec()
+    }
 
     #[test]
     fn test_segment_camel_case() {
-        assert_eq!(
-            WordSegments::new("camelCase").collect_vec(),
-            vec![(0, "camel"), (5, "Case")]
-        );
-        assert_eq!(
-            WordSegments::new("httpResponse").collect_vec(),
-            vec![(0, "http"), (4, "Response")]
-        );
+        assert_eq!(segments(&[Text("camelCase")]), vec!["camel", "Case"]);
+        assert_eq!(segments(&[Text("httpResponse")]), vec!["http", "Response"]);
     }
 
     #[test]
     fn test_segment_pascal_case() {
-        assert_eq!(
-            WordSegments::new("PascalCase").collect_vec(),
-            vec![(0, "Pascal"), (6, "Case")]
-        );
-        assert_eq!(
-            WordSegments::new("HttpResponse").collect_vec(),
-            vec![(0, "Http"), (4, "Response")]
-        );
+        assert_eq!(segments(&[Text("PascalCase")]), vec!["Pascal", "Case"]);
+        assert_eq!(segments(&[Text("HttpResponse")]), vec!["Http", "Response"]);
     }
 
     #[test]
     fn test_segment_snake_case() {
         assert_eq!(
-            WordSegments::new("snake_case").collect_vec(),
-            vec![(0, "snake"), (6, "case")]
+            segments(&[Text("snake"), Boundary, Text("case")]),
+            vec!["snake", "case"]
         );
         assert_eq!(
-            WordSegments::new("http_response").collect_vec(),
-            vec![(0, "http"), (5, "response")]
+            segments(&[Text("http"), Boundary, Text("response")]),
+            vec!["http", "response"]
         );
     }
 
     #[test]
     fn test_segment_screaming_snake() {
         assert_eq!(
-            WordSegments::new("SCREAMING_SNAKE").collect_vec(),
-            vec![(0, "SCREAMING"), (10, "SNAKE")]
+            segments(&[Text("SCREAMING"), Boundary, Text("SNAKE")]),
+            vec!["SCREAMING", "SNAKE"]
         );
         assert_eq!(
-            WordSegments::new("HTTP_RESPONSE").collect_vec(),
-            vec![(0, "HTTP"), (5, "RESPONSE")]
+            segments(&[Text("HTTP"), Boundary, Text("RESPONSE")]),
+            vec!["HTTP", "RESPONSE"]
         );
     }
 
     #[test]
     fn test_segment_consecutive_uppercase() {
         assert_eq!(
-            WordSegments::new("XMLHttpRequest").collect_vec(),
-            vec![(0, "XML"), (3, "Http"), (7, "Request")]
+            segments(&[Text("XMLHttpRequest")]),
+            vec!["XML", "Http", "Request"]
+        );
+        assert_eq!(segments(&[Text("HTTPResponse")]), vec!["HTTP", "Response"]);
+        assert_eq!(
+            segments(&[Text("HTTP"), Boundary, Text("Response")]),
+            vec!["HTTP", "Response"]
+        );
+        assert_eq!(segments(&[Text("ALLCAPS")]), vec!["ALLCAPS"]);
+    }
+
+    #[test]
+    fn test_segment_unicode_case_boundaries() {
+        assert_eq!(segments(&[Text("\u{e9}clair")]), vec!["\u{e9}clair"]);
+        assert_eq!(segments(&[Text("\u{c9}clair")]), vec!["\u{c9}clair"]);
+        assert_eq!(
+            segments(&[Text("XML\u{c9}clair")]),
+            vec!["XML", "\u{c9}clair"]
         );
         assert_eq!(
-            WordSegments::new("HTTPResponse").collect_vec(),
-            vec![(0, "HTTP"), (4, "Response")]
+            segments(&[Text("CAF\u{c9}Token")]),
+            vec!["CAF\u{c9}", "Token"]
+        );
+        assert_eq!(segments(&[Text("\u{e9}Tag")]), vec!["\u{e9}", "Tag"]);
+        assert_eq!(segments(&[Text("\u{c9}Token")]), vec!["\u{c9}", "Token"]);
+        assert_eq!(segments(&[Text("\u{e9}HTTP")]), vec!["\u{e9}", "HTTP"]);
+        assert_eq!(
+            segments(&[Text("foo"), Boundary, Text("bar")]),
+            vec!["foo", "bar"]
         );
         assert_eq!(
-            WordSegments::new("HTTP_Response").collect_vec(),
-            vec![(0, "HTTP"), (5, "Response")]
+            segments(&[Text("foo"), Boundary, Boundary, Text("bar")]),
+            vec!["foo", "bar"]
         );
+        assert_eq!(segments(&[Boundary, Text("foo"), Boundary]), vec!["foo"]);
         assert_eq!(
-            WordSegments::new("ALLCAPS").collect_vec(),
-            vec![(0, "ALLCAPS")]
+            segments(&[Text("foo"), Boundary, Text("2")]),
+            vec!["foo", "2"]
         );
     }
 
     #[test]
     fn test_segment_with_numbers() {
+        assert_eq!(segments(&[Text("Response2")]), vec!["Response", "2"]);
         assert_eq!(
-            WordSegments::new("Response2").collect_vec(),
-            vec![(0, "Response"), (8, "2")]
+            segments(&[Text("response"), Boundary, Text("2")]),
+            vec!["response", "2"]
         );
         assert_eq!(
-            WordSegments::new("response_2").collect_vec(),
-            vec![(0, "response"), (9, "2")]
+            segments(&[Text("HTTP2Protocol")]),
+            vec!["HTTP", "2", "Protocol"]
         );
         assert_eq!(
-            WordSegments::new("HTTP2Protocol").collect_vec(),
-            vec![(0, "HTTP"), (4, "2"), (5, "Protocol")]
+            segments(&[Text("OAuth2Token")]),
+            vec!["O", "Auth", "2", "Token"]
         );
+        assert_eq!(segments(&[Text("HTTP2XML")]), vec!["HTTP", "2", "XML"]);
         assert_eq!(
-            WordSegments::new("OAuth2Token").collect_vec(),
-            vec![(0, "O"), (1, "Auth"), (5, "2"), (6, "Token")]
+            segments(&[Text("1099KStatus")]),
+            vec!["1099", "K", "Status"]
         );
+        assert_eq!(segments(&[Text("123abc")]), vec!["123", "abc"]);
+        assert_eq!(segments(&[Text("123ABC")]), vec!["123", "ABC"]);
         assert_eq!(
-            WordSegments::new("HTTP2XML").collect_vec(),
-            vec![(0, "HTTP"), (4, "2"), (5, "XML")]
-        );
-        assert_eq!(
-            WordSegments::new("1099KStatus").collect_vec(),
-            vec![(0, "1099"), (4, "K"), (5, "Status")]
-        );
-        assert_eq!(
-            WordSegments::new("123abc").collect_vec(),
-            vec![(0, "123"), (3, "abc")]
-        );
-        assert_eq!(
-            WordSegments::new("123ABC").collect_vec(),
-            vec![(0, "123"), (3, "ABC")]
+            segments(&[Text("Sha2"), Boundary, Text("56Digest")]),
+            vec!["Sha", "2", "56", "Digest"]
         );
     }
 
     #[test]
     fn test_segment_empty_and_special() {
-        assert!(WordSegments::new("").collect_vec().is_empty());
-        assert!(WordSegments::new("___").collect_vec().is_empty());
-        assert_eq!(WordSegments::new("a").collect_vec(), vec![(0, "a")]);
-        assert_eq!(WordSegments::new("A").collect_vec(), vec![(0, "A")]);
+        assert!(segments(&[]).is_empty());
+        assert!(segments(&[Boundary, Boundary, Boundary]).is_empty());
+        assert_eq!(segments(&[Text("a")]), vec!["a"]);
+        assert_eq!(segments(&[Text("A")]), vec!["A"]);
     }
 
     #[test]
     fn test_segment_mixed_separators() {
         assert_eq!(
-            WordSegments::new("foo-bar_baz").collect_vec(),
-            vec![(0, "foo"), (4, "bar"), (8, "baz")]
+            segments(&[Text("foo"), Boundary, Text("bar"), Boundary, Text("baz"),]),
+            vec!["foo", "bar", "baz"]
         );
         assert_eq!(
-            WordSegments::new("foo--bar").collect_vec(),
-            vec![(0, "foo"), (5, "bar")]
+            segments(&[Text("foo"), Boundary, Boundary, Text("bar")]),
+            vec!["foo", "bar"]
+        );
+    }
+
+    #[test]
+    fn test_segment_boundaries() {
+        let arena = Arena::new();
+        let mut names = UniqueNames::new(&arena);
+
+        let name = names.claim([Text("fooBar2"), Boundary, Text("baz3Qux")]);
+        assert_eq!(
+            name.segments().collect_vec(),
+            [
+                NameSegment::Text("foo"),
+                NameSegment::Boundary(SegmentBoundary::Case),
+                NameSegment::Text("Bar"),
+                NameSegment::Boundary(SegmentBoundary::LetterDigit),
+                NameSegment::Text("2"),
+                NameSegment::Boundary(SegmentBoundary::Separator),
+                NameSegment::Text("baz"),
+                NameSegment::Boundary(SegmentBoundary::LetterDigit),
+                NameSegment::Text("3"),
+                NameSegment::Boundary(SegmentBoundary::Case),
+                NameSegment::Text("Qux"),
+            ]
+        );
+
+        let name = names.claim([Text("foo"), Boundary, Text("2Bar")]);
+        assert_eq!(
+            name.segments().collect_vec(),
+            [
+                NameSegment::Text("foo"),
+                NameSegment::Boundary(SegmentBoundary::Separator),
+                NameSegment::Text("2"),
+                NameSegment::Boundary(SegmentBoundary::Case),
+                NameSegment::Text("Bar"),
+            ]
+        );
+
+        let arena = Arena::new();
+        let mut names = UniqueNames::new(&arena);
+        let name = names.claim([Text("foo2bar")]);
+        assert_eq!(
+            name.segments().collect_vec(),
+            [
+                NameSegment::Text("foo"),
+                NameSegment::Boundary(SegmentBoundary::LetterDigit),
+                NameSegment::Text("2"),
+                NameSegment::Boundary(SegmentBoundary::DigitLetter),
+                NameSegment::Text("bar"),
+            ]
+        );
+
+        let name = names.claim([Text("Vector3D")]);
+        assert_eq!(
+            name.segments().collect_vec(),
+            [
+                NameSegment::Text("Vector"),
+                NameSegment::Boundary(SegmentBoundary::LetterDigit),
+                NameSegment::Text("3"),
+                NameSegment::Boundary(SegmentBoundary::DigitLetter),
+                NameSegment::Text("D"),
+            ]
+        );
+
+        let name = names.claim([Text("50GBPerSecond")]);
+        assert_eq!(
+            name.segments().collect_vec(),
+            [
+                NameSegment::Text("50"),
+                NameSegment::Boundary(SegmentBoundary::DigitLetter),
+                NameSegment::Text("GB"),
+                NameSegment::Boundary(SegmentBoundary::Case),
+                NameSegment::Text("Per"),
+                NameSegment::Boundary(SegmentBoundary::Case),
+                NameSegment::Text("Second"),
+            ]
         );
     }
 
@@ -471,12 +875,27 @@ mod tests {
         let arena = Arena::new();
         let mut names = UniqueNames::new(&arena);
 
-        assert_eq!(names.uniquify("HTTPResponse"), "HTTPResponse");
-        assert_eq!(names.uniquify("HTTP_Response"), "HTTP_Response_2");
-        assert_eq!(names.uniquify("httpResponse"), "httpResponse_3");
-        assert_eq!(names.uniquify("http_response"), "http_response_4");
+        assert_eq!(
+            AsPascalCase(names.claim([Text("HTTPResponse")])).to_string(),
+            "HttpResponse"
+        );
+        assert_eq!(
+            AsPascalCase(names.claim([Text("HTTP"), Boundary, Text("Response"),])).to_string(),
+            "HttpResponse2"
+        );
+        assert_eq!(
+            AsPascalCase(names.claim([Text("httpResponse")])).to_string(),
+            "HttpResponse3"
+        );
+        assert_eq!(
+            AsPascalCase(names.claim([Text("http"), Boundary, Text("response"),])).to_string(),
+            "HttpResponse4"
+        );
         // `HTTPRESPONSE` isn't a collision; it's a single word.
-        assert_eq!(names.uniquify("HTTPRESPONSE"), "HTTPRESPONSE");
+        assert_eq!(
+            AsPascalCase(names.claim([Text("HTTPRESPONSE")])).to_string(),
+            "Httpresponse"
+        );
     }
 
     #[test]
@@ -484,18 +903,60 @@ mod tests {
         let arena = Arena::new();
         let mut names = UniqueNames::new(&arena);
 
-        assert_eq!(names.uniquify("XMLHttpRequest"), "XMLHttpRequest");
-        assert_eq!(names.uniquify("xml_http_request"), "xml_http_request_2");
-        assert_eq!(names.uniquify("XmlHttpRequest"), "XmlHttpRequest_3");
+        assert_eq!(
+            AsSnakeCase(names.claim([Text("XMLHttpRequest")])).to_string(),
+            "xml_http_request"
+        );
+        assert_eq!(
+            AsSnakeCase(names.claim([
+                Text("xml"),
+                Boundary,
+                Text("http"),
+                Boundary,
+                Text("request"),
+            ]))
+            .to_string(),
+            "xml_http_request_2"
+        );
+        assert_eq!(
+            AsSnakeCase(names.claim([Text("XmlHttpRequest")])).to_string(),
+            "xml_http_request_3"
+        );
     }
 
     #[test]
-    fn test_deduplication_preserves_original_casing() {
+    fn test_deduplication_separator_parts() {
         let arena = Arena::new();
         let mut names = UniqueNames::new(&arena);
 
-        assert_eq!(names.uniquify("HTTP_Response"), "HTTP_Response");
-        assert_eq!(names.uniquify("httpResponse"), "httpResponse_2");
+        assert_eq!(
+            AsSnakeCase(names.claim([Text("foo"), Boundary, Text("bar")])).to_string(),
+            "foo_bar",
+        );
+        assert_eq!(
+            AsSnakeCase(names.claim([Text("foo"), Boundary, Text("bar")])).to_string(),
+            "foo_bar_2"
+        );
+        assert_eq!(
+            AsSnakeCase(names.claim([Text("foo"), Boundary, Boundary, Boundary, Text("bar"),]))
+                .to_string(),
+            "foo_bar_3"
+        );
+    }
+
+    #[test]
+    fn test_deduplication_preserves_first_slot() {
+        let arena = Arena::new();
+        let mut names = UniqueNames::new(&arena);
+
+        assert_eq!(
+            AsPascalCase(names.claim([Text("HTTP"), Boundary, Text("Response"),])).to_string(),
+            "HttpResponse"
+        );
+        assert_eq!(
+            AsPascalCase(names.claim([Text("httpResponse")])).to_string(),
+            "HttpResponse2"
+        );
     }
 
     #[test]
@@ -503,9 +964,18 @@ mod tests {
         let arena = Arena::new();
         let mut names = UniqueNames::new(&arena);
 
-        assert_eq!(names.uniquify("HttpRequest"), "HttpRequest");
-        assert_eq!(names.uniquify("HttpResponse"), "HttpResponse");
-        assert_eq!(names.uniquify("HttpError"), "HttpError");
+        assert_eq!(
+            AsPascalCase(names.claim([Text("HttpRequest")])).to_string(),
+            "HttpRequest"
+        );
+        assert_eq!(
+            AsPascalCase(names.claim([Text("HttpResponse")])).to_string(),
+            "HttpResponse"
+        );
+        assert_eq!(
+            AsPascalCase(names.claim([Text("HttpError")])).to_string(),
+            "HttpError"
+        );
     }
 
     #[test]
@@ -513,22 +983,88 @@ mod tests {
         let arena = Arena::new();
         let mut names = UniqueNames::new(&arena);
 
-        assert_eq!(names.uniquify("Response2"), "Response_2");
-        assert_eq!(names.uniquify("response_2"), "response_3");
+        assert_eq!(
+            AsSnakeCase(names.claim([Text("Response2")])).to_string(),
+            "response2"
+        );
+        assert_eq!(
+            AsSnakeCase(names.claim([Text("response"), Boundary, Text("2"),])).to_string(),
+            "response_3"
+        );
 
-        // `0` becomes the bare stem.
-        assert_eq!(names.uniquify("Response0"), "Response");
-        assert_eq!(names.uniquify("response"), "response_4");
+        assert_eq!(
+            AsSnakeCase(names.claim([Text("Response0")])).to_string(),
+            "response0"
+        );
+        assert_eq!(
+            AsSnakeCase(names.claim([Text("response")])).to_string(),
+            "response"
+        );
+
+        // Internal digit boundaries collapse in PascalCase.
+        assert_eq!(
+            AsPascalCase(names.claim([Text("Http2Protocol")])).to_string(),
+            "Http2Protocol"
+        );
+        assert_eq!(
+            AsPascalCase(names.claim([Text("Http"), Boundary, Text("2Protocol"),])).to_string(),
+            "Http2Protocol2"
+        );
+        assert_eq!(
+            AsSnakeCase(names.claim([Text("Sha2"), Boundary, Text("56Digest"),])).to_string(),
+            "sha2_56_digest"
+        );
+        assert_eq!(
+            AsSnakeCase(names.claim([Text("Sha256Digest")])).to_string(),
+            "sha256_digest"
+        );
+        assert_eq!(
+            AsSnakeCase(names.claim([Text("Vector3D")])).to_string(),
+            "vector3d"
+        );
+        assert_eq!(
+            AsSnakeCase(names.claim([Text("50GBPerSecond")])).to_string(),
+            "50gb_per_second"
+        );
+        assert_eq!(
+            AsSnakeCase(names.claim([Text("Caf\u{e9}2")])).to_string(),
+            "caf\u{e9}2"
+        );
 
         // Digit-to-uppercase collisions.
-        assert_eq!(names.uniquify("1099KStatus"), "1099KStatus");
-        assert_eq!(names.uniquify("1099K_Status"), "1099K_Status_2");
-        assert_eq!(names.uniquify("1099KStatus"), "1099KStatus_3");
-        assert_eq!(names.uniquify("1099_K_Status"), "1099_K_Status_4");
+        assert_eq!(
+            AsPascalCase(names.claim([Text("1099KStatus")])).to_string(),
+            "1099KStatus"
+        );
+        assert_eq!(
+            AsPascalCase(names.claim([Text("1099K"), Boundary, Text("Status"),])).to_string(),
+            "1099KStatus2"
+        );
+        assert_eq!(
+            AsPascalCase(names.claim([Text("1099KStatus")])).to_string(),
+            "1099KStatus3"
+        );
+        assert_eq!(
+            AsPascalCase(names.claim([
+                Text("1099"),
+                Boundary,
+                Text("K"),
+                Boundary,
+                Text("Status"),
+            ]))
+            .to_string(),
+            "1099KStatus4"
+        );
 
         // Digit-to-lowercase collisions.
-        assert_eq!(names.uniquify("123abc"), "123abc");
-        assert_eq!(names.uniquify("123_abc"), "123_abc_2");
+        assert_eq!(
+            AsSnakeCase(names.claim([Text("123abc")])).to_string(),
+            "123abc"
+        );
+        assert_eq!(
+            AsSnakeCase(names.claim([Text("123"), Boundary, Text("abc"),])).to_string(),
+            "123_abc_2"
+        );
     }
 
     #[test]
@@ -536,10 +1072,155 @@ mod tests {
         let arena = Arena::new();
         let mut names = UniqueNames::new(&arena);
 
-        assert_eq!(names.uniquify("OAuth2"), "OAuth_2");
-        assert_eq!(names.uniquify("OAuth_2"), "OAuth_3");
-        assert_eq!(names.uniquify("OAuth"), "OAuth");
-        assert_eq!(names.uniquify("OAuth0"), "OAuth_4");
+        assert_eq!(
+            AsSnakeCase(names.claim([Text("OAuth2")])).to_string(),
+            "o_auth2"
+        );
+        assert_eq!(
+            AsSnakeCase(names.claim([Text("OAuth"), Boundary, Text("2")])).to_string(),
+            "o_auth_3"
+        );
+        assert_eq!(
+            AsSnakeCase(names.claim([Text("OAuth")])).to_string(),
+            "o_auth"
+        );
+        assert_eq!(
+            AsSnakeCase(names.claim([Text("OAuth0")])).to_string(),
+            "o_auth0"
+        );
+    }
+
+    #[test]
+    fn test_deduplication_numeric_suffix_preserves_source_boundary() {
+        let arena = Arena::new();
+        let mut names = UniqueNames::new(&arena);
+        assert_eq!(
+            names
+                .claim([NamePart::Text("Response2")])
+                .segments()
+                .collect_vec(),
+            &[
+                NameSegment::Text("Response"),
+                NameSegment::Boundary(SegmentBoundary::LetterDigit),
+                NameSegment::Text("2"),
+            ]
+        );
+
+        let arena = Arena::new();
+        let mut names = UniqueNames::new(&arena);
+        assert_eq!(
+            names
+                .claim([NamePart::Text("Response0")])
+                .segments()
+                .collect_vec(),
+            &[
+                NameSegment::Text("Response"),
+                NameSegment::Boundary(SegmentBoundary::LetterDigit),
+                NameSegment::Text("0"),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_deduplication_numeric_suffix_slots() {
+        let arena = Arena::new();
+        let mut names = UniqueNames::new(&arena);
+
+        assert_eq!(AsSnakeCase(names.claim([Text("v2")])).to_string(), "v2");
+        assert_eq!(
+            AsSnakeCase(names.claim([Text("v"), Boundary, Text("2")])).to_string(),
+            "v_3"
+        );
+        assert_eq!(AsSnakeCase(names.claim([Text("v")])).to_string(), "v");
+        assert_eq!(AsSnakeCase(names.claim([Text("v")])).to_string(), "v_4");
+
+        let arena = Arena::new();
+        let mut names = UniqueNames::new(&arena);
+
+        assert_eq!(
+            AsKebabCase(names.claim([Text("response")])).to_string(),
+            "response"
+        );
+        assert_eq!(
+            AsKebabCase(names.claim([Text("response")])).to_string(),
+            "response-2"
+        );
+        assert_eq!(
+            AsKebabCase(names.claim([Text("response2")])).to_string(),
+            "response3"
+        );
+        assert_eq!(
+            AsKebabCase(names.claim([Text("response")])).to_string(),
+            "response-4"
+        );
+    }
+
+    #[test]
+    fn test_deduplication_source_zero_suffix_uses_own_slot() {
+        let arena = Arena::new();
+        let mut names = UniqueNames::new(&arena);
+
+        assert_eq!(
+            AsSnakeCase(names.claim([Text("Response")])).to_string(),
+            "response"
+        );
+        assert_eq!(
+            AsSnakeCase(names.claim([Text("Response0")])).to_string(),
+            "response0"
+        );
+        assert_eq!(
+            AsSnakeCase(names.claim([Text("Response")])).to_string(),
+            "response_2"
+        );
+
+        let arena = Arena::new();
+        let mut names = UniqueNames::new(&arena);
+
+        assert_eq!(
+            AsSnakeCase(names.claim([Text("Response0")])).to_string(),
+            "response0"
+        );
+        assert_eq!(
+            AsSnakeCase(names.claim([Text("Response")])).to_string(),
+            "response"
+        );
+        assert_eq!(
+            AsSnakeCase(names.claim([Text("Response0")])).to_string(),
+            "response1"
+        );
+    }
+
+    #[test]
+    fn test_deduplication_unicode_case_family() {
+        let arena = Arena::new();
+        let mut names = UniqueNames::new(&arena);
+
+        assert_eq!(AsSnakeCase(names.claim([Text("ß")])).to_string(), "ß");
+        assert_eq!(AsSnakeCase(names.claim([Text("SS")])).to_string(), "ss_2");
+        assert_eq!(AsSnakeCase(names.claim([Text("ss")])).to_string(), "ss_3");
+        assert_eq!(
+            AsSnakeCase(names.claim([Text("İ")])).to_string(),
+            "i\u{307}"
+        );
+        assert_eq!(
+            AsSnakeCase(names.claim([Text("i\u{307}")])).to_string(),
+            "i\u{307}_2"
+        );
+    }
+
+    #[test]
+    fn test_deduplication_normalizes_unicode_to_nfc() {
+        let arena = Arena::new();
+        let mut names = UniqueNames::new(&arena);
+
+        assert_eq!(
+            AsSnakeCase(names.claim([Text("cafe\u{301}")])).to_string(),
+            "caf\u{e9}"
+        );
+        assert_eq!(
+            AsSnakeCase(names.claim([Text("caf\u{e9}")])).to_string(),
+            "caf\u{e9}_2"
+        );
     }
 
     #[test]
@@ -547,9 +1228,12 @@ mod tests {
         let arena = Arena::new();
         let mut names = UniqueNames::new(&arena);
 
-        assert_eq!(names.uniquify(""), "1");
-        assert_eq!(names.uniquify("_"), "2");
-        assert_eq!(names.uniquify("---"), "3");
+        assert_eq!(AsSnakeCase(names.claim([])).to_string(), "1");
+        assert_eq!(AsSnakeCase(names.claim([Boundary])).to_string(), "2");
+        assert_eq!(
+            AsSnakeCase(names.claim([Boundary, Boundary, Boundary])).to_string(),
+            "3"
+        );
     }
 
     #[test]
@@ -557,60 +1241,75 @@ mod tests {
         let arena = Arena::new();
         let mut names = UniqueNames::new(&arena);
 
-        assert_eq!(names.uniquify("2"), "2");
-        assert_eq!(names.uniquify(""), "1");
-        assert_eq!(names.uniquify("2"), "3");
+        assert_eq!(AsSnakeCase(names.claim([Text("2")])).to_string(), "2");
+        assert_eq!(AsSnakeCase(names.claim([])).to_string(), "1");
+        assert_eq!(AsSnakeCase(names.claim([Text("2")])).to_string(), "3");
 
         let arena = Arena::new();
         let mut names = UniqueNames::new(&arena);
 
-        assert_eq!(names.uniquify("0"), "1");
-        assert_eq!(names.uniquify(""), "2");
+        assert_eq!(AsSnakeCase(names.claim([Text("0")])).to_string(), "1");
+        assert_eq!(AsSnakeCase(names.claim([])).to_string(), "2");
     }
 
     #[test]
-    fn test_with_reserved_empty_stem_uses_zero_slot() {
+    fn test_reserved_digit_only_names_share_empty_stem_sequence() {
         let arena = Arena::new();
-        let mut names = UniqueNames::with_reserved(&arena, [""]);
+        let mut names = UniqueNames::with_reserved(&arena, [[Text("0")]]);
 
-        assert_eq!(names.uniquify(""), "1");
-        assert_eq!(names.uniquify(""), "2");
-
-        let arena = Arena::new();
-        let mut names = UniqueNames::with_reserved(&arena, [""]);
-
-        assert_eq!(names.uniquify("0"), "1");
-        assert_eq!(names.uniquify(""), "2");
-
-        let arena = Arena::new();
-        let mut names = UniqueNames::with_reserved(&arena, ["0"]);
-
-        assert_eq!(names.uniquify("0"), "1");
-        assert_eq!(names.uniquify(""), "2");
-
-        let arena = Arena::new();
-        let mut names = UniqueNames::with_reserved(&arena, ["_"]);
-
-        assert_eq!(names.uniquify("_"), "1");
-        assert_eq!(names.uniquify("_"), "2");
+        assert_eq!(AsSnakeCase(names.claim([Text("0")])).to_string(), "2");
+        assert_eq!(AsSnakeCase(names.claim([])).to_string(), "3");
     }
 
     #[test]
-    fn test_with_reserved_multiple() {
+    fn test_reserved_boundary_only_shares_empty_stem_sequence() {
         let arena = Arena::new();
-        let mut names = UniqueNames::with_reserved(&arena, ["_", "reserved"]);
+        let mut names = UniqueNames::with_reserved(&arena, [[Boundary]]);
 
-        assert_eq!(names.uniquify("_"), "1");
-        assert_eq!(names.uniquify("reserved"), "reserved_2");
-        assert_eq!(names.uniquify("other"), "other");
+        assert_eq!(AsSnakeCase(names.claim([Boundary])).to_string(), "2");
+        assert_eq!(AsSnakeCase(names.claim([Boundary])).to_string(), "3");
     }
 
     #[test]
-    fn test_with_reserved_numeric_suffixes() {
+    fn test_reserved_multiple() {
         let arena = Arena::new();
-        let mut names = UniqueNames::with_reserved(&arena, ["crate"]);
+        let mut names = UniqueNames::with_reserved(&arena, [[Boundary], [Text("reserved")]]);
 
-        assert_eq!(names.uniquify("crate"), "crate_2");
-        assert_eq!(names.uniquify("crate2"), "crate_3");
+        assert_eq!(AsSnakeCase(names.claim([Boundary])).to_string(), "2");
+        assert_eq!(
+            AsSnakeCase(names.claim([Text("reserved")])).to_string(),
+            "reserved_2"
+        );
+        assert_eq!(
+            AsSnakeCase(names.claim([Text("other")])).to_string(),
+            "other"
+        );
+    }
+
+    #[test]
+    fn test_reserved_numeric_suffixes() {
+        let arena = Arena::new();
+        let mut names = UniqueNames::with_reserved(&arena, [[Text("crate")]]);
+
+        assert_eq!(
+            AsSnakeCase(names.claim([Text("crate")])).to_string(),
+            "crate_2"
+        );
+        assert_eq!(
+            AsSnakeCase(names.claim([Text("crate2")])).to_string(),
+            "crate3"
+        );
+
+        let arena = Arena::new();
+        let mut names = UniqueNames::with_reserved(&arena, [[Text("Response0")]]);
+
+        assert_eq!(
+            AsSnakeCase(names.claim([Text("Response")])).to_string(),
+            "response"
+        );
+        assert_eq!(
+            AsSnakeCase(names.claim([Text("Response0")])).to_string(),
+            "response1"
+        );
     }
 }


### PR DESCRIPTION
Replace Heck with custom `As{Snake, Pascal, Kebab}Case` formatters. Separate Rust-specific identifier cleaning from word segmentation. Normalize word segments with NFC. Emit word boundaries for letter-to-digit and digit-to-letter transitions, and case transitions when a capitalized word follows a number.