### PR TITLE
feat(codegen): Include the endpoint path in docs; improve formatting.

### DIFF
--- a/ploidy-codegen-rust/src/lib.rs
+++ b/ploidy-codegen-rust/src/lib.rs
@@ -80,8 +80,15 @@ pub fn write_client_to_disk(output: &Path, graph: &CodegenGraph<'_>) -> miette::
 /// Generates one or more `#[doc]` attributes for a schema description,
 /// wrapping at 80 characters for readability.
 pub fn doc_attrs(description: &str) -> TokenStream {
-    let lines = textwrap::wrap(description, 80)
-        .into_iter()
-        .map(|line| quote!(#[doc = #line]));
+    use textwrap::{Options, wrap};
+    let lines = wrap(
+        description,
+        &Options::new(80)
+            .initial_indent(" ")
+            .subsequent_indent(" ")
+            .break_words(false),
+    )
+    .into_iter()
+    .map(|line| quote!(#[doc = #line]));
     quote! { #(#lines)* }
 }

--- a/ploidy-codegen-rust/src/operation.rs
+++ b/ploidy-codegen-rust/src/operation.rs
@@ -215,7 +215,23 @@ impl ToTokens for CodegenOperation<'_> {
         };
 
         let method_name = CodegenIdentUsage::Method(self.graph.ident(self.op.id()));
-        let doc = self.op.description().map(doc_attrs);
+
+        let doc = {
+            let url = format!(" {} {}", self.op.method().as_str(), self.op.path());
+            match self.op.description() {
+                Some(description) => {
+                    let attrs = doc_attrs(description);
+                    quote! {
+                        #attrs
+                        #[doc = ""]
+                        #[doc = #url]
+                    }
+                }
+                None => {
+                    quote!(#[doc = #url])
+                }
+            }
+        };
 
         tokens.append_all(quote! {
             #doc
@@ -274,6 +290,7 @@ mod tests {
               /items/{item_id}:
                 get:
                   operationId: getItem
+                  description: Gets an item.
                   parameters:
                     - name: item_id
                       in: path
@@ -299,6 +316,9 @@ mod tests {
 
         let actual: syn::ImplItemFn = parse_quote!(#codegen);
         let expected: syn::ImplItemFn = parse_quote! {
+            #[doc = " Gets an item."]
+            #[doc = ""]
+            #[doc = " GET /items/{item_id}"]
             pub async fn get_item(
                 &self,
                 item_id: &str,
@@ -368,6 +388,7 @@ mod tests {
 
         let actual: syn::ImplItemFn = parse_quote!(#codegen);
         let expected: syn::ImplItemFn = parse_quote! {
+            #[doc = " GET /items"]
             pub async fn get_items(
                 &self,
                 query: &parameters::GetItemsQuery
@@ -440,6 +461,7 @@ mod tests {
 
         let actual: syn::ImplItemFn = parse_quote!(#codegen);
         let expected: syn::ImplItemFn = parse_quote! {
+            #[doc = " GET /search/{query}"]
             pub async fn search(
                 &self,
                 query_2: &str,
@@ -531,6 +553,7 @@ mod tests {
 
         let actual: syn::ImplItemFn = parse_quote!(#codegen);
         let expected: syn::ImplItemFn = parse_quote! {
+            #[doc = " PUT /items/{item_id}"]
             pub async fn update_item(
                 &self,
                 item_id: &str,
@@ -607,6 +630,7 @@ mod tests {
 
         let actual: syn::ImplItemFn = parse_quote!(#codegen);
         let expected: syn::ImplItemFn = parse_quote! {
+            #[doc = " GET /items/{item_id}"]
             pub async fn get_item(
                 &self,
                 item_id: &str
@@ -664,6 +688,7 @@ mod tests {
 
         let actual: syn::ImplItemFn = parse_quote!(#codegen);
         let expected: syn::ImplItemFn = parse_quote! {
+            #[doc = " GET /items/{item_id}"]
             pub async fn get_item(
                 &self,
                 item_id: &str
@@ -737,6 +762,7 @@ mod tests {
 
         let actual: syn::ImplItemFn = parse_quote!(#codegen);
         let expected: syn::ImplItemFn = parse_quote! {
+            #[doc = " POST /v1/messages?beta=true&expand="]
             pub async fn beta_create_message(
                 &self,
                 request: impl Into<crate::types::Message>
@@ -821,6 +847,7 @@ mod tests {
 
         let actual: syn::ImplItemFn = parse_quote!(#codegen);
         let expected: syn::ImplItemFn = parse_quote! {
+            #[doc = " POST /v1/messages?beta=true"]
             pub async fn beta_create_message(
                 &self,
                 query: &parameters::BetaCreateMessageQuery,
@@ -911,6 +938,7 @@ mod tests {
 
         let actual: syn::ImplItemFn = parse_quote!(#codegen);
         let expected: syn::ImplItemFn = parse_quote! {
+            #[doc = " GET /v1/models/{model_id}?beta=true"]
             pub async fn beta_get_model(
                 &self,
                 model_id: &str,

--- a/ploidy-codegen-rust/src/resource.rs
+++ b/ploidy-codegen-rust/src/resource.rs
@@ -185,6 +185,7 @@ mod tests {
         let actual: syn::File = parse_quote!(#resource);
         let expected: syn::File = parse_quote! {
             impl crate::client::Client {
+                #[doc = " GET /customers"]
                 pub async fn list_customers(
                     &self,
                 ) -> Result<::std::vec::Vec<crate::types::Customer>, crate::error::Error> {
@@ -270,6 +271,7 @@ mod tests {
         let expected: syn::File = parse_quote! {
             impl crate::client::Client {
                 #[cfg(feature = "customer")]
+                #[doc = " GET /orders"]
                 pub async fn list_orders(
                     &self,
                 ) -> Result<::std::vec::Vec<crate::types::Order>, crate::error::Error> {
@@ -341,6 +343,7 @@ mod tests {
         let actual: syn::File = parse_quote!(#resource);
         let expected: syn::File = parse_quote! {
             impl crate::client::Client {
+                #[doc = " GET /customers"]
                 pub async fn list_customers(
                     &self,
                     query: &parameters::ListCustomersQuery
@@ -443,6 +446,7 @@ mod tests {
         let actual: syn::File = parse_quote!(#resource);
         let expected: syn::File = parse_quote! {
             impl crate::client::Client {
+                #[doc = " GET /customers"]
                 pub async fn list_customers(
                     &self,
                     query: &parameters::ListCustomersQuery
@@ -474,6 +478,7 @@ mod tests {
                     let _ = response;
                     Ok(())
                 }
+                #[doc = " GET /customers/search"]
                 pub async fn search_customers(
                     &self,
                     query: &parameters::SearchCustomersQuery
@@ -568,6 +573,7 @@ mod tests {
         let actual: syn::File = parse_quote!(#resource);
         let expected: syn::File = parse_quote! {
             impl crate::client::Client {
+                #[doc = " GET /customers"]
                 pub async fn list_customers(
                     &self,
                 ) -> Result<(), crate::error::Error> {

--- a/ploidy-codegen-rust/src/schema.rs
+++ b/ploidy-codegen-rust/src/schema.rs
@@ -639,7 +639,7 @@ mod tests {
 
         let actual: syn::File = parse_quote!(#codegen);
         let expected: syn::File = parse_quote! {
-            #[doc = "A list of tags."]
+            #[doc = " A list of tags."]
             pub type Tags = ::std::vec::Vec<::std::string::String>;
         };
         assert_eq!(actual, expected);

--- a/ploidy-codegen-rust/src/tagged.rs
+++ b/ploidy-codegen-rust/src/tagged.rs
@@ -362,7 +362,7 @@ mod tests {
 
         let actual: syn::File = parse_quote!(#codegen);
         let expected: syn::File = parse_quote! {
-            #[doc = "Represents different types of pets"]
+            #[doc = " Represents different types of pets"]
             #[derive(Debug, Clone, PartialEq, Eq, Hash, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
             #[serde(crate = "::ploidy_util::serde", tag = "type")]
             #[ploidy(pointer(crate = "::ploidy_util::pointer", tag = "type"))]

--- a/ploidy-codegen-rust/src/untagged.rs
+++ b/ploidy-codegen-rust/src/untagged.rs
@@ -317,7 +317,7 @@ mod tests {
 
         let actual: syn::ItemEnum = parse_quote!(#untagged);
         let expected: syn::ItemEnum = parse_quote! {
-            #[doc = "A union that can be either a string or an integer."]
+            #[doc = " A union that can be either a string or an integer."]
             #[derive(Debug, Clone, PartialEq, Eq, Hash, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
             #[serde(crate = "::ploidy_util::serde", untagged)]
             #[ploidy(pointer(crate = "::ploidy_util::pointer", untagged))]

--- a/ploidy-core/src/ir/views/operation.rs
+++ b/ploidy-core/src/ir/views/operation.rs
@@ -54,7 +54,11 @@
 //! [response]: OperationView::response
 //! [resource name]: OperationView::resource
 
-use std::{collections::VecDeque, marker::PhantomData};
+use std::{
+    collections::VecDeque,
+    fmt::{Display, Formatter, Result as FmtResult},
+    marker::PhantomData,
+};
 
 use petgraph::{
     graph::NodeIndex,
@@ -248,6 +252,12 @@ impl<'view, 'graph, 'a> OperationViewPath<'view, 'graph, 'a> {
             GraphParameter::Path(info) => Some(ParameterView::new(self.0, info)),
             _ => None,
         })
+    }
+}
+
+impl Display for OperationViewPath<'_, '_, '_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "{}", self.0.op.path)
     }
 }
 

--- a/ploidy-core/src/parse/path.rs
+++ b/ploidy-core/src/parse/path.rs
@@ -1,4 +1,7 @@
+use std::fmt::{Display, Formatter, Result as FmtResult, Write};
+
 use miette::SourceSpan;
+use percent_encoding::{AsciiSet, CONTROLS, utf8_percent_encode};
 use winnow::{
     Parser, Stateful,
     combinator::eof,
@@ -6,6 +9,20 @@ use winnow::{
 };
 
 use crate::arena::Arena;
+
+// The WHATWG URL path percent-encode set, plus `/`.
+const PATH_SEGMENT_PERCENT_ENCODE_SET: &AsciiSet = &CONTROLS
+    .add(b' ')
+    .add(b'"')
+    .add(b'#')
+    .add(b'<')
+    .add(b'>')
+    .add(b'?')
+    .add(b'^')
+    .add(b'`')
+    .add(b'{')
+    .add(b'}')
+    .add(b'/');
 
 /// Parser input threaded with an allocation [`Arena`].
 type Input<'a> = Stateful<&'a str, &'a Arena>;
@@ -38,6 +55,38 @@ pub struct ParsedPath<'a> {
     pub segments: &'a [PathSegment<'a>],
     /// Literal query parameters that follow the path.
     pub query: &'a [PathQueryParameter<'a>],
+}
+
+impl Display for ParsedPath<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        for segment in self.segments {
+            f.write_char('/')?;
+            segment
+                .fragments()
+                .iter()
+                .try_for_each(|fragment| match fragment {
+                    PathFragment::Literal(text) => {
+                        write!(
+                            f,
+                            "{}",
+                            utf8_percent_encode(text, PATH_SEGMENT_PERCENT_ENCODE_SET)
+                        )
+                    }
+                    PathFragment::Param(name) => write!(f, "{{{name}}}"),
+                })?;
+        }
+
+        if !self.query.is_empty() {
+            let mut serializer = form_urlencoded::Serializer::new(String::new());
+            for param in self.query {
+                serializer.append_pair(param.name, param.value);
+            }
+            f.write_char('?')?;
+            f.write_str(&serializer.finish())?;
+        }
+
+        Ok(())
+    }
 }
 
 /// A literal query parameter parsed from the path template.
@@ -402,6 +451,36 @@ mod test {
                     value: "true",
                 }],
             },
+        );
+    }
+
+    #[test]
+    fn test_display_preserves_path_params() {
+        let arena = Arena::new();
+        let result = parse(
+            &arena,
+            "/v1/storage/{workspace}/documents/report-{documentId}.pdf?beta=true&expand",
+        )
+        .unwrap();
+
+        assert_eq!(
+            result.to_string(),
+            "/v1/storage/{workspace}/documents/report-{documentId}.pdf?beta=true&expand="
+        );
+    }
+
+    #[test]
+    fn test_display_encodes_literals() {
+        let arena = Arena::new();
+        let result = parse(
+            &arena,
+            "/foo%20bar/a%2Fb?name=John%20Doe&filter=%7Bactive%7D",
+        )
+        .unwrap();
+
+        assert_eq!(
+            result.to_string(),
+            "/foo%20bar/a%2Fb?name=John+Doe&filter=%7Bactive%7D"
         );
     }
 

--- a/ploidy-core/src/parse/types.rs
+++ b/ploidy-core/src/parse/types.rs
@@ -93,6 +93,18 @@ pub enum Method {
     Patch,
 }
 
+impl Method {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Get => "GET",
+            Self::Post => "POST",
+            Self::Put => "PUT",
+            Self::Patch => "PATCH",
+            Self::Delete => "DELETE",
+        }
+    }
+}
+
 impl PathItem {
     /// Returns an iterator over the operations for each HTTP method.
     pub fn operations(&self) -> impl Iterator<Item = (Method, &Operation)> {


### PR DESCRIPTION
Include the method and path in the Rustdocs for each generated method, so that Claude, et al. (and humans!) can find them. Add a leading space to each wrapped line for prettier output.