### PR TITLE
fix(codegen): Dedent first, then use SMAWK to wrap descriptions.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1770,6 +1770,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
 name = "socket2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1878,6 +1884,7 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 dependencies = [
+ "smawk",
  "unicode-linebreak",
  "unicode-width 0.2.2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1162,6 +1162,7 @@ dependencies = [
  "either",
  "fixedbitset",
  "form_urlencoded",
+ "icu_normalizer",
  "indexmap",
  "indoc",
  "itertools",
@@ -1181,7 +1182,6 @@ dependencies = [
  "syn",
  "thiserror",
  "unicase",
- "unicode-normalization",
  "winnow",
 ]
 
@@ -2097,15 +2097,6 @@ name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
-dependencies = [
- "tinyvec",
-]
 
 [[package]]
 name = "unicode-width"

--- a/ploidy-codegen-rust/Cargo.toml
+++ b/ploidy-codegen-rust/Cargo.toml
@@ -23,10 +23,7 @@ syn = { version = "2", default-features = false, features = [
     "parsing",
     "printing",
 ] }
-textwrap = { version = "0.16", default-features = false, features = [
-    "unicode-linebreak",
-    "unicode-width",
-] }
+textwrap = "0.16"
 thiserror = "2"
 toml_edit = { workspace = true }
 unicode-ident = "1"

--- a/ploidy-codegen-rust/src/lib.rs
+++ b/ploidy-codegen-rust/src/lib.rs
@@ -80,9 +80,10 @@ pub fn write_client_to_disk(output: &Path, graph: &CodegenGraph<'_>) -> miette::
 /// Generates one or more `#[doc]` attributes for a schema description,
 /// wrapping at 80 characters for readability.
 pub fn doc_attrs(description: &str) -> TokenStream {
-    use textwrap::{Options, wrap};
+    use textwrap::{Options, dedent, wrap};
+    let dedented = dedent(description);
     let lines = wrap(
-        description,
+        &dedented,
         &Options::new(80)
             .initial_indent(" ")
             .subsequent_indent(" ")

--- a/ploidy-core/Cargo.toml
+++ b/ploidy-core/Cargo.toml
@@ -32,7 +32,9 @@ rustc-hash = { workspace = true }
 syn = { version = "2", default-features = false, optional = true }
 thiserror = "2"
 unicase = "2"
-unicode-normalization = "0.1"
+icu_normalizer = { version = "2", default-features = false, features = [
+    "compiled_data",
+] }
 winnow = "1.0"
 
 [dev-dependencies]

--- a/ploidy-core/src/codegen/unique.rs
+++ b/ploidy-core/src/codegen/unique.rs
@@ -16,12 +16,14 @@ use std::{
     mem,
 };
 
+use icu_normalizer::{ComposingNormalizer, ComposingNormalizerBorrowed};
 use itertools::Itertools;
 use rustc_hash::{FxHashMap, FxHashSet};
 use unicase::UniCase;
-use unicode_normalization::UnicodeNormalization;
 
 use crate::arena::Arena;
+
+static NFC: ComposingNormalizerBorrowed<'_> = ComposingNormalizer::new_nfc();
 
 /// A scope that claims target language names before final case rendering.
 ///
@@ -382,7 +384,7 @@ fn segments<'a>(
             .into_iter()
             .flat_map(|part| {
                 either!(match part {
-                    NamePart::Text(text) => text.nfc().map(NameChar::from),
+                    NamePart::Text(text) => NFC.normalize_iter(text.chars()).map(NameChar::from),
                     NamePart::Boundary => iter::once(NameChar::Separator),
                 })
             })


### PR DESCRIPTION
Dedenting is more conservative than removing all leading whitespace, or collapsing all whitespace, so there's less risk of garbling multiline text. For wrapping, SMAWK gives better results than the first-fit we used before.