### PR TITLE
fix: dispatch distinct success responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,12 +101,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
 name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,9 +137,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -153,14 +147,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -207,15 +202,15 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cc"
-version = "1.2.64"
+version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -234,6 +229,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core",
+]
 
 [[package]]
 name = "chrono"
@@ -329,6 +335,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "diff"
@@ -506,15 +521,16 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
- "wasip2",
- "wasip3",
+ "rand_core",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -778,12 +794,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -919,9 +929,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -933,12 +943,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -969,9 +973,9 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru-slab"
@@ -1158,6 +1162,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "ploidy"
 version = "0.15.0"
 dependencies = [
@@ -1291,15 +1301,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "pretty_assertions"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1330,9 +1331,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -1350,15 +1351,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
  "rand",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1372,16 +1374,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1407,31 +1409,28 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
+ "chacha20",
+ "getrandom 0.4.3",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.5"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
- "getrandom 0.3.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -1517,9 +1516,9 @@ checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -1545,9 +1544,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -1571,9 +1570,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "web-time",
  "zeroize",
@@ -1827,9 +1826,9 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "smawk"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+checksum = "e8e2fb0f499abb4d162f2bedad68f5ef91a1682b5a03596ddb67efd37768d100"
 
 [[package]]
 name = "socket2"
@@ -1918,7 +1917,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2214,12 +2213,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2252,11 +2245,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.3"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -2305,23 +2298,14 @@ version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen 0.46.0",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2332,9 +2316,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.75"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2342,9 +2326,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2352,9 +2336,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2365,52 +2349,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2428,9 +2378,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -2509,16 +2459,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2536,31 +2477,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -2570,22 +2494,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2594,22 +2506,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2618,22 +2518,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2642,22 +2530,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -2673,94 +2549,6 @@ name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1169,7 +1169,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "ploidy"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "clap",
  "indoc",
@@ -1186,7 +1186,7 @@ dependencies = [
 
 [[package]]
 name = "ploidy-codegen-rust"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "indoc",
  "itertools",
@@ -1208,7 +1208,7 @@ dependencies = [
 
 [[package]]
 name = "ploidy-core"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "atomic_refcell",
  "bumpalo",
@@ -1240,7 +1240,7 @@ dependencies = [
 
 [[package]]
 name = "ploidy-pointer"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "chrono",
  "indexmap",
@@ -1257,7 +1257,7 @@ dependencies = [
 
 [[package]]
 name = "ploidy-pointer-derive"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "heck",
  "itertools",
@@ -1269,7 +1269,7 @@ dependencies = [
 
 [[package]]
 name = "ploidy-util"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.15.0"
+version = "0.16.0"
 license = "Apache-2.0"
 edition = "2024"
 repository = "https://github.com/linabutler/ploidy"
@@ -24,10 +24,10 @@ opentelemetry = { version = "0.32", default-features = false, features = [
     "trace",
 ] }
 opentelemetry-http = { version = "0.32", default-features = false }
-ploidy-codegen-rust = { path = "ploidy-codegen-rust", version = "0.15.0" }
-ploidy-core = { path = "ploidy-core", version = "0.15.0" }
-ploidy-pointer = { path = "ploidy-pointer", version = "0.15.0" }
-ploidy-pointer-derive = { path = "ploidy-pointer-derive", version = "0.15.0" }
+ploidy-codegen-rust = { path = "ploidy-codegen-rust", version = "0.16.0" }
+ploidy-core = { path = "ploidy-core", version = "0.16.0" }
+ploidy-pointer = { path = "ploidy-pointer", version = "0.16.0" }
+ploidy-pointer-derive = { path = "ploidy-pointer-derive", version = "0.16.0" }
 pretty_assertions = "1"
 ref-cast = "1"
 rustc-hash = "2"

--- a/ploidy-codegen-rust/src/client.rs
+++ b/ploidy-codegen-rust/src/client.rs
@@ -44,9 +44,16 @@ impl ToTokens for CodegenClientModule<'_> {
 
             impl Client {
                 /// Creates a new client.
+                ///
+                /// The client never follows redirects, so operations can
+                /// surface documented 3xx responses. Use
+                /// [`Self::with_reqwest_client`] to supply a client with a
+                /// different redirect policy.
                 pub fn new(base_url: impl AsRef<str>) -> Result<Self, crate::error::Error> {
                     Ok(Self::with_reqwest_client(
-                        ::ploidy_util::reqwest::Client::new(),
+                        ::ploidy_util::reqwest::Client::builder()
+                            .redirect(::ploidy_util::reqwest::redirect::Policy::none())
+                            .build()?,
                         base_url.as_ref().parse()?,
                     ))
                 }
@@ -196,7 +203,11 @@ impl ToTokens for ResourceModules<'_> {
 mod tests {
     use super::*;
 
-    use ploidy_core::arena::Arena;
+    use ploidy_core::{
+        arena::Arena,
+        ir::{RawGraph, Spec},
+        parse::Document,
+    };
     use pretty_assertions::assert_eq;
     use syn::parse_quote;
 
@@ -220,5 +231,53 @@ mod tests {
             pub mod customer_profiles;
         };
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_client_new_disables_redirects() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths: {}
+        "})
+        .unwrap();
+
+        let arena = Arena::new();
+        let spec = Spec::from_doc(&arena, &doc).unwrap();
+        let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
+
+        let module = CodegenClientModule::new(&graph, &[]);
+        let file: syn::File = parse_quote!(#module);
+        let new_fn = file
+            .items
+            .iter()
+            .find_map(|item| match item {
+                syn::Item::Impl(impl_) => impl_.items.iter().find_map(|item| match item {
+                    syn::ImplItem::Fn(f) if f.sig.ident == "new" => Some(f),
+                    _ => None,
+                }),
+                _ => None,
+            })
+            .unwrap_or_else(|| panic!("expected `fn new` in `impl Client`; got `{file:?}`"));
+
+        let expected: syn::ImplItemFn = parse_quote! {
+            /// Creates a new client.
+            ///
+            /// The client never follows redirects, so operations can
+            /// surface documented 3xx responses. Use
+            /// [`Self::with_reqwest_client`] to supply a client with a
+            /// different redirect policy.
+            pub fn new(base_url: impl AsRef<str>) -> Result<Self, crate::error::Error> {
+                Ok(Self::with_reqwest_client(
+                    ::ploidy_util::reqwest::Client::builder()
+                        .redirect(::ploidy_util::reqwest::redirect::Policy::none())
+                        .build()?,
+                    base_url.as_ref().parse()?,
+                ))
+            }
+        };
+        assert_eq!(*new_fn, expected);
     }
 }

--- a/ploidy-codegen-rust/src/graph.rs
+++ b/ploidy-codegen-rust/src/graph.rs
@@ -14,7 +14,7 @@ use rustc_hash::FxHashMap;
 
 use super::{
     config::{CodegenConfig, DateTimeFormat},
-    naming::{CodegenIdentUsage, ResourceGroup, UniqueIdent, UniqueIdents},
+    naming::{CodegenIdentUsage, ResourceGroup, UniqueIdent, UniqueIdents, status_variant_name},
 };
 
 /// A [`CookedGraph`] decorated with Rust-specific information.
@@ -479,21 +479,7 @@ fn inline_type_candidate_name<'a>(
                 OperationUsage::Response { status } => {
                     full.push_str("Response");
                     if let Some(status) = status {
-                        match status {
-                            200 => full.push_str("Ok"),
-                            201 => full.push_str("Created"),
-                            202 => full.push_str("Accepted"),
-                            203 => full.push_str("NonAuthoritativeInformation"),
-                            204 => full.push_str("NoContent"),
-                            205 => full.push_str("ResetContent"),
-                            206 => full.push_str("PartialContent"),
-                            207 => full.push_str("MultiStatus"),
-                            208 => full.push_str("AlreadyReported"),
-                            226 => full.push_str("ImUsed"),
-                            _ => {
-                                write!(full, "Status{status}").unwrap();
-                            }
-                        }
+                        full.push_str(&status_variant_name(status));
                     }
                 }
             }

--- a/ploidy-codegen-rust/src/graph.rs
+++ b/ploidy-codegen-rust/src/graph.rs
@@ -476,7 +476,26 @@ fn inline_type_candidate_name<'a>(
                     write!(full, "Query{}", CodegenIdentUsage::Type(ident).display()).unwrap();
                 }
                 OperationUsage::Request => full.push_str("Request"),
-                OperationUsage::Response => full.push_str("Response"),
+                OperationUsage::Response { status } => {
+                    full.push_str("Response");
+                    if let Some(status) = status {
+                        match status {
+                            200 => full.push_str("Ok"),
+                            201 => full.push_str("Created"),
+                            202 => full.push_str("Accepted"),
+                            203 => full.push_str("NonAuthoritativeInformation"),
+                            204 => full.push_str("NoContent"),
+                            205 => full.push_str("ResetContent"),
+                            206 => full.push_str("PartialContent"),
+                            207 => full.push_str("MultiStatus"),
+                            208 => full.push_str("AlreadyReported"),
+                            226 => full.push_str("ImUsed"),
+                            _ => {
+                                write!(full, "Status{status}").unwrap();
+                            }
+                        }
+                    }
+                }
             }
             full.push_str(&name);
 

--- a/ploidy-codegen-rust/src/inlines.rs
+++ b/ploidy-codegen-rust/src/inlines.rs
@@ -1,5 +1,5 @@
 use itertools::Itertools;
-use ploidy_core::ir::{HasTypeId, InlineTypeView};
+use ploidy_core::ir::{HasTypeId, InlineTypeView, OperationView, View};
 use proc_macro2::TokenStream;
 use quote::{ToTokens, TokenStreamExt, quote};
 
@@ -8,7 +8,7 @@ use super::{
     struct_::CodegenStruct, tagged::CodegenTagged, untagged::CodegenUntagged,
 };
 
-/// Generates a `mod types` for inline structs, enums, and unions.
+/// Generates a `mod types` for operation-local types.
 #[derive(Debug)]
 pub struct CodegenInlines<'a> {
     graph: &'a CodegenGraph<'a>,
@@ -30,6 +30,7 @@ impl<'a> CodegenInlines<'a> {
     }
 
     /// Creates a codegen node for a resource module's inline types.
+    #[cfg(test)]
     pub fn for_resource_inlines(
         graph: &'a CodegenGraph<'a>,
         inlines: Vec<InlineTypeView<'a, 'a>>,
@@ -37,6 +38,18 @@ impl<'a> CodegenInlines<'a> {
         Self {
             graph,
             inlines,
+            cfg: true,
+        }
+    }
+
+    /// Creates a codegen node for a resource module's `types` submodule.
+    pub fn for_resource_types(
+        graph: &'a CodegenGraph<'a>,
+        ops: &'a [OperationView<'a, 'a>],
+    ) -> Self {
+        Self {
+            graph,
+            inlines: ops.iter().flat_map(|op| op.inlines()).collect(),
             cfg: true,
         }
     }

--- a/ploidy-codegen-rust/src/inlines.rs
+++ b/ploidy-codegen-rust/src/inlines.rs
@@ -189,6 +189,61 @@ mod tests {
     }
 
     #[test]
+    fn test_resource_types_include_header_struct() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths:
+              /jobs:
+                get:
+                  operationId: getJob
+                  responses:
+                    '304':
+                      description: Not modified.
+                      headers:
+                        etag:
+                          required: true
+                          schema:
+                            type: string
+                        cache-control:
+                          schema:
+                            type: string
+        "})
+        .unwrap();
+
+        let arena = Arena::new();
+        let spec = Spec::from_doc(&arena, &doc).unwrap();
+        let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
+
+        let inlines = CodegenInlines::for_resource_inlines(
+            &graph,
+            graph.operations().flat_map(|op| op.inlines()).collect(),
+        );
+
+        let actual: syn::File = parse_quote!(#inlines);
+        let expected: syn::File = parse_quote! {
+            pub mod types {
+                mod get_job_response {
+                    #[doc = " Not modified."]
+                    #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, ::ploidy_util::serde::Serialize, ::ploidy_util::serde::Deserialize, ::ploidy_util::pointer::JsonPointee, ::ploidy_util::pointer::JsonPointerTarget)]
+                    #[serde(crate = "::ploidy_util::serde")]
+                    #[ploidy(pointer(crate = "::ploidy_util::pointer"))]
+                    pub struct GetJobResponse {
+                        pub etag: ::std::string::String,
+                        #[serde(rename = "cache-control")]
+                        #[ploidy(pointer(rename = "cache-control"))]
+                        pub cache_control: ::std::option::Option<::std::string::String>,
+                    }
+                }
+                pub use get_job_response::*;
+            }
+        };
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
     fn test_operation_parameter_inline_type_names_do_not_collide_across_roles() {
         let doc = Document::from_yaml(indoc::indoc! {"
             openapi: 3.0.0

--- a/ploidy-codegen-rust/src/lib.rs
+++ b/ploidy-codegen-rust/src/lib.rs
@@ -4,7 +4,10 @@ use itertools::Itertools;
 use proc_macro2::TokenStream;
 use quote::quote;
 
-use ploidy_core::codegen::{IntoCode, WrittenFile, write_to_disk};
+use ploidy_core::{
+    codegen::{IntoCode, WrittenFile, write_to_disk},
+    ir::{HasTypeId, ResponseView, TypeId, TypeView},
+};
 
 mod cargo;
 mod cfg;
@@ -54,6 +57,25 @@ pub fn write_types_to_disk(
     for schema in graph.schemas() {
         let code = CodegenSchemaType::new(graph, &schema).into_code();
         written.push(write_to_disk(output, code)?);
+    }
+
+    for op in graph.operations() {
+        let mut shapes: Vec<Option<TypeId>> = vec![];
+        for case in op.response_cases() {
+            let shape = case.body().map(|body| match body {
+                ResponseView::Json(view) => match view {
+                    TypeView::Schema(view) => view.id(),
+                    TypeView::Inline(view) => view.id(),
+                },
+            });
+            if !shapes.contains(&shape) {
+                shapes.push(shape);
+            }
+        }
+        if shapes.len() > 1 {
+            let code = CodegenOperationResult::new(graph, &op).into_code();
+            written.push(write_to_disk(output, code)?);
+        }
     }
 
     written.push(write_to_disk(output, CodegenTypesModule::new(graph))?);

--- a/ploidy-codegen-rust/src/lib.rs
+++ b/ploidy-codegen-rust/src/lib.rs
@@ -63,7 +63,7 @@ pub fn write_types_to_disk(
         let mut shapes: Vec<Option<TypeId>> = vec![];
         for case in op.response_cases() {
             let shape = case.body().map(|body| match body {
-                ResponseView::Json(view) => match view {
+                ResponseView::Json(view) | ResponseView::Headers(view) => match view {
                     TypeView::Schema(view) => view.id(),
                     TypeView::Inline(view) => view.id(),
                 },

--- a/ploidy-codegen-rust/src/naming.rs
+++ b/ploidy-codegen-rust/src/naming.rs
@@ -200,6 +200,40 @@ fn clean(s: &str) -> impl Iterator<Item = NamePart<'_>> {
     )
 }
 
+/// Returns the UpperCamelCase name for an HTTP status code, used for
+/// result-enum variants and status-suffixed inline type names.
+///
+/// Statuses with well-known reason phrases map to those phrases
+/// (`200` → `Ok`, `304` → `NotModified`); anything else falls back
+/// to `Status{code}`.
+pub(crate) fn status_variant_name(status: u16) -> String {
+    match status {
+        100 => "Continue".to_owned(),
+        101 => "SwitchingProtocols".to_owned(),
+        102 => "Processing".to_owned(),
+        103 => "EarlyHints".to_owned(),
+        200 => "Ok".to_owned(),
+        201 => "Created".to_owned(),
+        202 => "Accepted".to_owned(),
+        203 => "NonAuthoritativeInformation".to_owned(),
+        204 => "NoContent".to_owned(),
+        205 => "ResetContent".to_owned(),
+        206 => "PartialContent".to_owned(),
+        207 => "MultiStatus".to_owned(),
+        208 => "AlreadyReported".to_owned(),
+        226 => "ImUsed".to_owned(),
+        300 => "MultipleChoices".to_owned(),
+        301 => "MovedPermanently".to_owned(),
+        302 => "Found".to_owned(),
+        303 => "SeeOther".to_owned(),
+        304 => "NotModified".to_owned(),
+        305 => "UseProxy".to_owned(),
+        307 => "TemporaryRedirect".to_owned(),
+        308 => "PermanentRedirect".to_owned(),
+        _ => format!("Status{status}"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/ploidy-codegen-rust/src/operation.rs
+++ b/ploidy-codegen-rust/src/operation.rs
@@ -1,6 +1,9 @@
 use itertools::Itertools;
 use ploidy_core::{
-    ir::{HasTypeId, OperationView, RequestView, ResponseView, TypeId, TypeView},
+    ir::{
+        HasTypeId, InlineTypeView, OperationView, RequestView, Required, ResponseView,
+        SchemaTypeView, StructFieldName, TypeId, TypeView,
+    },
     parse::{
         Method,
         path::{PathFragment, PathRun},
@@ -13,7 +16,7 @@ use syn::Ident;
 use super::{
     doc_attrs,
     graph::{CodegenGraph, IdentMapping},
-    naming::CodegenIdentUsage,
+    naming::{CodegenIdentUsage, status_variant_name},
     ref_::CodegenRef,
 };
 
@@ -171,7 +174,7 @@ impl ToTokens for CodegenOperation<'_> {
         let mut response_shapes: Vec<Option<TypeId>> = vec![];
         for case in self.op.response_cases() {
             let shape = case.body().map(|body| match body {
-                ResponseView::Json(view) => match view {
+                ResponseView::Json(view) | ResponseView::Headers(view) => match view {
                     TypeView::Schema(view) => view.id(),
                     TypeView::Inline(view) => view.id(),
                 },
@@ -190,7 +193,7 @@ impl ToTokens for CodegenOperation<'_> {
         } else {
             match self.op.response() {
                 Some(response) => match response {
-                    ResponseView::Json(view) => {
+                    ResponseView::Json(view) | ResponseView::Headers(view) => {
                         CodegenRef::new(self.graph, &view).into_token_stream()
                     }
                 },
@@ -255,22 +258,7 @@ impl ToTokens for CodegenOperation<'_> {
             );
             let arms = self.op.response_cases().map(|case| {
                 let status = case.status();
-                let variant_name = format_ident!(
-                    "{}",
-                    match status {
-                        200 => "Ok".to_owned(),
-                        201 => "Created".to_owned(),
-                        202 => "Accepted".to_owned(),
-                        203 => "NonAuthoritativeInformation".to_owned(),
-                        204 => "NoContent".to_owned(),
-                        205 => "ResetContent".to_owned(),
-                        206 => "PartialContent".to_owned(),
-                        207 => "MultiStatus".to_owned(),
-                        208 => "AlreadyReported".to_owned(),
-                        226 => "ImUsed".to_owned(),
-                        _ => format!("Status{status}"),
-                    }
-                );
+                let variant_name = format_ident!("{}", status_variant_name(status));
                 match case.body() {
                     Some(ResponseView::Json(_)) => quote! {
                         #status => {
@@ -280,6 +268,16 @@ impl ToTokens for CodegenOperation<'_> {
                             Ok(crate::types::#type_name::#variant_name(result))
                         }
                     },
+                    Some(ResponseView::Headers(view)) => {
+                        let ty = CodegenRef::new(self.graph, &view);
+                        let fields = CodegenHeaderFields::new(self.graph, &view);
+                        quote! {
+                            #status => {
+                                let headers = response.headers();
+                                Ok(crate::types::#type_name::#variant_name(#ty { #fields }))
+                            }
+                        }
+                    }
                     None => quote! {
                         #status => Ok(crate::types::#type_name::#variant_name),
                     },
@@ -291,17 +289,29 @@ impl ToTokens for CodegenOperation<'_> {
                     _ => Err(crate::error::Error::Status(status)),
                 }
             }
-        } else if self.op.response().is_some() {
-            quote! {
-                let body = response.bytes().await?;
-                let deserializer = &mut ::ploidy_util::serde_json::Deserializer::from_slice(&body);
-                let result = ::ploidy_util::serde_path_to_error::deserialize(deserializer)?;
-                Ok(result)
-            }
         } else {
-            quote! {
-                let _ = response;
-                Ok(())
+            match self.op.response() {
+                Some(ResponseView::Json(_)) => quote! {
+                    let body = response.bytes().await?;
+                    let deserializer = &mut ::ploidy_util::serde_json::Deserializer::from_slice(&body);
+                    let result = ::ploidy_util::serde_path_to_error::deserialize(deserializer)?;
+                    Ok(result)
+                },
+                // Like the JSON path, decode without checking the status:
+                // a response with an unexpected status surfaces as a
+                // missing-header error.
+                Some(ResponseView::Headers(view)) => {
+                    let ty = CodegenRef::new(self.graph, &view);
+                    let fields = CodegenHeaderFields::new(self.graph, &view);
+                    quote! {
+                        let headers = response.headers();
+                        Ok(#ty { #fields })
+                    }
+                }
+                None => quote! {
+                    let _ = response;
+                    Ok(())
+                },
             }
         };
 
@@ -371,6 +381,66 @@ impl ToTokens for CodegenOperation<'_> {
                 result
             }
         });
+    }
+}
+
+/// Generates the field initializers that decode a headers response struct
+/// from an in-scope `headers` binding holding the response's header map.
+#[derive(Clone, Copy, Debug)]
+struct CodegenHeaderFields<'a> {
+    graph: &'a CodegenGraph<'a>,
+    ty: &'a TypeView<'a, 'a>,
+}
+
+impl<'a> CodegenHeaderFields<'a> {
+    fn new(graph: &'a CodegenGraph<'a>, ty: &'a TypeView<'a, 'a>) -> Self {
+        Self { graph, ty }
+    }
+}
+
+impl ToTokens for CodegenHeaderFields<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let view = match self.ty {
+            TypeView::Inline(InlineTypeView::Struct(_, view)) => view,
+            TypeView::Schema(SchemaTypeView::Struct(_, view)) => view,
+            ty => panic!("expected a struct for a headers response; got `{ty:?}`"),
+        };
+        let fields = view.fields().map(|field| {
+            let ident = CodegenIdentUsage::Field(
+                self.graph
+                    .ident(IdentMapping::StructField(view.id(), field.name())),
+            );
+            let StructFieldName::Name(header) = field.name() else {
+                panic!("expected a named header field; got `{:?}`", field.name());
+            };
+            match field.required() {
+                Required::Required { nullable: false } => quote! {
+                    #ident: headers
+                        .get(#header)
+                        .ok_or_else(|| crate::error::Error::missing_header(#header))?
+                        .to_str()
+                        .map_err(|_| crate::error::Error::invalid_header(#header))?
+                        .to_owned()
+                },
+                Required::Required { nullable: true } => quote! {
+                    #ident: match headers.get(#header) {
+                        ::std::option::Option::Some(value) => ::std::option::Option::Some(
+                            value
+                                .to_str()
+                                .map_err(|_| crate::error::Error::invalid_header(#header))?
+                                .to_owned(),
+                        ),
+                        ::std::option::Option::None => ::std::option::Option::None,
+                    }
+                },
+                // `Spec::from_doc` only synthesizes required or nullable
+                // header fields.
+                Required::Optional => {
+                    panic!("expected a required or nullable header field; got `{field:?}`")
+                }
+            }
+        });
+        tokens.append_all(quote! { #(#fields),* });
     }
 }
 
@@ -1112,6 +1182,215 @@ mod tests {
         assert_eq!(*match_.arms[0].body, expected_200_body);
         assert_eq!(*match_.arms[1].body, expected_202_body);
         assert_eq!(*match_.arms[2].body, expected_fallback_body);
+    }
+
+    // MARK: Header-only responses
+
+    #[test]
+    fn test_operation_with_header_only_response_returns_header_struct() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths:
+              /archives:
+                get:
+                  operationId: getArchive
+                  responses:
+                    '307':
+                      description: Redirect to the archive URL.
+                      headers:
+                        location:
+                          required: true
+                          schema:
+                            type: string
+        "})
+        .unwrap();
+
+        let arena = Arena::new();
+        let spec = Spec::from_doc(&arena, &doc).unwrap();
+        let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
+
+        let op = graph.operations().next().unwrap();
+        let codegen = CodegenOperation::new(&graph, &op);
+
+        let actual: syn::ImplItemFn = parse_quote!(#codegen);
+        let expected_return: syn::ReturnType = parse_quote!(
+            -> Result<crate::client::default::types::GetArchiveResponse, crate::error::Error>
+        );
+        assert_eq!(actual.sig.output, expected_return);
+
+        let syn::Stmt::Local(result) = &actual.block.stmts[0] else {
+            panic!("expected result local; got `{actual:?}`");
+        };
+        let Some(init) = &result.init else {
+            panic!("expected result initializer; got `{result:?}`");
+        };
+        let syn::Expr::Await(await_) = &*init.expr else {
+            panic!("expected awaited async block; got `{init:?}`");
+        };
+        let syn::Expr::Async(async_) = &*await_.base else {
+            panic!("expected async block; got `{await_:?}`");
+        };
+        let stmts = &async_.block.stmts;
+        let expected_headers: syn::Stmt = parse_quote!(let headers = response.headers(););
+        assert_eq!(stmts[stmts.len() - 2], expected_headers);
+        let Some(syn::Stmt::Expr(decode, None)) = stmts.last() else {
+            panic!("expected decode expression; got `{async_:?}`");
+        };
+        let expected_decode: syn::Expr = parse_quote! {
+            Ok(crate::client::default::types::GetArchiveResponse {
+                location: headers
+                    .get("location")
+                    .ok_or_else(|| crate::error::Error::missing_header("location"))?
+                    .to_str()
+                    .map_err(|_| crate::error::Error::invalid_header("location"))?
+                    .to_owned()
+            })
+        };
+        assert_eq!(*decode, expected_decode);
+    }
+
+    #[test]
+    fn test_operation_with_body_and_header_responses_matches_status() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths:
+              /jobs:
+                get:
+                  operationId: getJob
+                  responses:
+                    '200':
+                      description: Complete
+                      content:
+                        application/json:
+                          schema:
+                            $ref: '#/components/schemas/Job'
+                    '304':
+                      description: Not modified.
+                      headers:
+                        etag:
+                          required: true
+                          schema:
+                            type: string
+            components:
+              schemas:
+                Job:
+                  type: object
+        "})
+        .unwrap();
+
+        let arena = Arena::new();
+        let spec = Spec::from_doc(&arena, &doc).unwrap();
+        let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
+
+        let op = graph.operations().next().unwrap();
+        let codegen = CodegenOperation::new(&graph, &op);
+
+        let actual: syn::ImplItemFn = parse_quote!(#codegen);
+        let expected_return: syn::ReturnType =
+            parse_quote!(-> Result<crate::types::GetJobResult, crate::error::Error>);
+        assert_eq!(actual.sig.output, expected_return);
+
+        let syn::Stmt::Local(result) = &actual.block.stmts[0] else {
+            panic!("expected result local; got `{actual:?}`");
+        };
+        let Some(init) = &result.init else {
+            panic!("expected result initializer; got `{result:?}`");
+        };
+        let syn::Expr::Await(await_) = &*init.expr else {
+            panic!("expected awaited async block; got `{init:?}`");
+        };
+        let syn::Expr::Async(async_) = &*await_.base else {
+            panic!("expected async block; got `{await_:?}`");
+        };
+        let Some(syn::Stmt::Expr(syn::Expr::Match(match_), None)) = async_.block.stmts.last()
+        else {
+            panic!("expected status match; got `{async_:?}`");
+        };
+
+        let expected_304_pat: syn::Pat = parse_quote!(304u16);
+        assert_eq!(match_.arms[1].pat, expected_304_pat);
+        // Brace-delimited so rustfmt leaves the tokens alone; in the
+        // paren form it adds trailing commas, which change the AST.
+        let expected_304_body: syn::Expr = parse_quote! {{
+            let headers = response.headers();
+            Ok(crate::types::GetJobResult::NotModified(
+                crate::client::default::types::GetJobResponseNotModified {
+                    etag: headers
+                        .get("etag")
+                        .ok_or_else(|| crate::error::Error::missing_header("etag"))?
+                        .to_str()
+                        .map_err(|_| crate::error::Error::invalid_header("etag"))?
+                        .to_owned()
+                }
+            ))
+        }};
+        assert_eq!(*match_.arms[1].body, expected_304_body);
+    }
+
+    #[test]
+    fn test_operation_header_decode_handles_optional_and_hyphenated_headers() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths:
+              /jobs:
+                get:
+                  operationId: getJob
+                  responses:
+                    '304':
+                      description: Not modified.
+                      headers:
+                        cache-control:
+                          schema:
+                            type: string
+        "})
+        .unwrap();
+
+        let arena = Arena::new();
+        let spec = Spec::from_doc(&arena, &doc).unwrap();
+        let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
+
+        let op = graph.operations().next().unwrap();
+        let codegen = CodegenOperation::new(&graph, &op);
+
+        let actual: syn::ImplItemFn = parse_quote!(#codegen);
+        let syn::Stmt::Local(result) = &actual.block.stmts[0] else {
+            panic!("expected result local; got `{actual:?}`");
+        };
+        let Some(init) = &result.init else {
+            panic!("expected result initializer; got `{result:?}`");
+        };
+        let syn::Expr::Await(await_) = &*init.expr else {
+            panic!("expected awaited async block; got `{init:?}`");
+        };
+        let syn::Expr::Async(async_) = &*await_.base else {
+            panic!("expected async block; got `{await_:?}`");
+        };
+        let Some(syn::Stmt::Expr(decode, None)) = async_.block.stmts.last() else {
+            panic!("expected decode expression; got `{async_:?}`");
+        };
+        let expected_decode: syn::Expr = parse_quote! {
+            Ok(crate::client::default::types::GetJobResponse {
+                cache_control: match headers.get("cache-control") {
+                    ::std::option::Option::Some(value) => ::std::option::Option::Some(
+                        value
+                            .to_str()
+                            .map_err(|_| crate::error::Error::invalid_header("cache-control"))?
+                            .to_owned(),
+                    ),
+                    ::std::option::Option::None => ::std::option::Option::None,
+                }
+            })
+        };
+        assert_eq!(*decode, expected_decode);
     }
 
     // MARK: Synthesized path params

--- a/ploidy-codegen-rust/src/operation.rs
+++ b/ploidy-codegen-rust/src/operation.rs
@@ -1,6 +1,6 @@
 use itertools::Itertools;
 use ploidy_core::{
-    ir::{OperationView, RequestView, ResponseView},
+    ir::{HasTypeId, OperationView, RequestView, ResponseView, TypeId, TypeView},
     parse::{
         Method,
         path::{PathFragment, PathRun},
@@ -168,17 +168,45 @@ impl ToTokens for CodegenOperation<'_> {
             }
         }
 
-        let return_type = match self.op.response() {
-            Some(response) => match response {
-                ResponseView::Json(view) => CodegenRef::new(self.graph, &view).into_token_stream(),
-            },
-            None => quote! { () },
+        let mut response_shapes: Vec<Option<TypeId>> = vec![];
+        for case in self.op.response_cases() {
+            let shape = case.body().map(|body| match body {
+                ResponseView::Json(view) => match view {
+                    TypeView::Schema(view) => view.id(),
+                    TypeView::Inline(view) => view.id(),
+                },
+            });
+            if !response_shapes.contains(&shape) {
+                response_shapes.push(shape);
+            }
+        }
+
+        let return_type = if response_shapes.len() > 1 {
+            let type_name = format_ident!(
+                "{}Result",
+                CodegenIdentUsage::Type(self.graph.ident(self.op.id()))
+            );
+            quote! { crate::types::#type_name }
+        } else {
+            match self.op.response() {
+                Some(response) => match response {
+                    ResponseView::Json(view) => {
+                        CodegenRef::new(self.graph, &view).into_token_stream()
+                    }
+                },
+                None => quote! { () },
+            }
         };
 
         let url = self.url();
 
         let request = {
             let method = CodegenMethod(self.op.method());
+            let status = (response_shapes.len() > 1).then(|| {
+                quote! {
+                    let status = response.status();
+                }
+            });
             let builder = match self.op.request() {
                 Some(RequestView::Json(_)) => quote! {
                     let request = self.client
@@ -209,6 +237,7 @@ impl ToTokens for CodegenOperation<'_> {
                     request
                 };
                 let response = request.send().await?;
+                #status
                 #[cfg(feature = "tracing")]
                 {
                     ::tracing::record_all!(::tracing::Span::current(),
@@ -219,7 +248,50 @@ impl ToTokens for CodegenOperation<'_> {
             }
         };
 
-        let response = if self.op.response().is_some() {
+        let response = if response_shapes.len() > 1 {
+            let type_name = format_ident!(
+                "{}Result",
+                CodegenIdentUsage::Type(self.graph.ident(self.op.id()))
+            );
+            let arms = self.op.response_cases().map(|case| {
+                let status = case.status();
+                let variant_name = format_ident!(
+                    "{}",
+                    match status {
+                        200 => "Ok".to_owned(),
+                        201 => "Created".to_owned(),
+                        202 => "Accepted".to_owned(),
+                        203 => "NonAuthoritativeInformation".to_owned(),
+                        204 => "NoContent".to_owned(),
+                        205 => "ResetContent".to_owned(),
+                        206 => "PartialContent".to_owned(),
+                        207 => "MultiStatus".to_owned(),
+                        208 => "AlreadyReported".to_owned(),
+                        226 => "ImUsed".to_owned(),
+                        _ => format!("Status{status}"),
+                    }
+                );
+                match case.body() {
+                    Some(ResponseView::Json(_)) => quote! {
+                        #status => {
+                            let body = response.bytes().await?;
+                            let deserializer = &mut ::ploidy_util::serde_json::Deserializer::from_slice(&body);
+                            let result = ::ploidy_util::serde_path_to_error::deserialize(deserializer)?;
+                            Ok(crate::types::#type_name::#variant_name(result))
+                        }
+                    },
+                    None => quote! {
+                        #status => Ok(crate::types::#type_name::#variant_name),
+                    },
+                }
+            });
+            quote! {
+                match status.as_u16() {
+                    #(#arms)*
+                    _ => Err(crate::error::Error::Status(status)),
+                }
+            }
+        } else if self.op.response().is_some() {
             quote! {
                 let body = response.bytes().await?;
                 let deserializer = &mut ::ploidy_util::serde_json::Deserializer::from_slice(&body);
@@ -950,6 +1022,96 @@ mod tests {
             }
         };
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_operation_with_distinct_success_responses_matches_status() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths:
+              /jobs:
+                post:
+                  operationId: startJob
+                  responses:
+                    '200':
+                      description: Complete
+                      content:
+                        application/json:
+                          schema:
+                            $ref: '#/components/schemas/Job'
+                    '202':
+                      description: Accepted
+                      content:
+                        application/json:
+                          schema:
+                            $ref: '#/components/schemas/PendingJob'
+            components:
+              schemas:
+                Job:
+                  type: object
+                PendingJob:
+                  type: object
+        "})
+        .unwrap();
+
+        let arena = Arena::new();
+        let spec = Spec::from_doc(&arena, &doc).unwrap();
+        let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
+
+        let op = graph.operations().next().unwrap();
+        let codegen = CodegenOperation::new(&graph, &op);
+
+        let actual: syn::ImplItemFn = parse_quote!(#codegen);
+        let expected_return: syn::ReturnType =
+            parse_quote!(-> Result<crate::types::StartJobResult, crate::error::Error>);
+        assert_eq!(actual.sig.output, expected_return);
+
+        let syn::Stmt::Local(result) = &actual.block.stmts[0] else {
+            panic!("expected result local; got `{actual:?}`");
+        };
+        let Some(init) = &result.init else {
+            panic!("expected result initializer; got `{result:?}`");
+        };
+        let syn::Expr::Await(await_) = &*init.expr else {
+            panic!("expected awaited async block; got `{init:?}`");
+        };
+        let syn::Expr::Async(async_) = &*await_.base else {
+            panic!("expected async block; got `{await_:?}`");
+        };
+        let Some(syn::Stmt::Expr(syn::Expr::Match(match_), None)) = async_.block.stmts.last()
+        else {
+            panic!("expected status match; got `{async_:?}`");
+        };
+        let expected_match_expr: syn::Expr = parse_quote!(status.as_u16());
+        assert_eq!(*match_.expr, expected_match_expr);
+
+        let expected_200_pat: syn::Pat = parse_quote!(200u16);
+        let expected_202_pat: syn::Pat = parse_quote!(202u16);
+        let expected_fallback_pat: syn::Pat = parse_quote!(_);
+        assert_eq!(match_.arms[0].pat, expected_200_pat);
+        assert_eq!(match_.arms[1].pat, expected_202_pat);
+        assert_eq!(match_.arms[2].pat, expected_fallback_pat);
+
+        let expected_200_body: syn::Expr = parse_quote!({
+            let body = response.bytes().await?;
+            let deserializer = &mut ::ploidy_util::serde_json::Deserializer::from_slice(&body);
+            let result = ::ploidy_util::serde_path_to_error::deserialize(deserializer)?;
+            Ok(crate::types::StartJobResult::Ok(result))
+        });
+        let expected_202_body: syn::Expr = parse_quote!({
+            let body = response.bytes().await?;
+            let deserializer = &mut ::ploidy_util::serde_json::Deserializer::from_slice(&body);
+            let result = ::ploidy_util::serde_path_to_error::deserialize(deserializer)?;
+            Ok(crate::types::StartJobResult::Accepted(result))
+        });
+        let expected_fallback_body: syn::Expr =
+            parse_quote!(Err(crate::error::Error::Status(status)));
+        assert_eq!(*match_.arms[0].body, expected_200_body);
+        assert_eq!(*match_.arms[1].body, expected_202_body);
+        assert_eq!(*match_.arms[2].body, expected_fallback_body);
     }
 
     // MARK: Synthesized path params

--- a/ploidy-codegen-rust/src/resource.rs
+++ b/ploidy-codegen-rust/src/resource.rs
@@ -1,7 +1,4 @@
-use ploidy_core::{
-    codegen::IntoCode,
-    ir::{OperationView, View},
-};
+use ploidy_core::{codegen::IntoCode, ir::OperationView};
 use proc_macro2::TokenStream;
 use quote::{ToTokens, TokenStreamExt, format_ident, quote};
 
@@ -52,10 +49,7 @@ impl ToTokens for CodegenResource<'_> {
             }
         });
 
-        let inlines = CodegenInlines::for_resource_inlines(
-            self.graph,
-            self.ops.iter().flat_map(|op| op.inlines()).collect(),
-        );
+        let inlines = CodegenInlines::for_resource_types(self.graph, self.ops);
 
         let params = self
             .ops

--- a/ploidy-codegen-rust/src/types.rs
+++ b/ploidy-codegen-rust/src/types.rs
@@ -1,9 +1,12 @@
 use itertools::Itertools;
-use ploidy_core::{codegen::IntoCode, ir::HasTypeId};
+use ploidy_core::{
+    codegen::IntoCode,
+    ir::{HasTypeId, OperationView, ResponseView, TypeId, TypeView},
+};
 use proc_macro2::TokenStream;
-use quote::{ToTokens, TokenStreamExt, quote};
+use quote::{ToTokens, TokenStreamExt, format_ident, quote};
 
-use super::{cfg::CfgFeature, graph::CodegenGraph, naming::CodegenIdentUsage};
+use super::{cfg::CfgFeature, graph::CodegenGraph, naming::CodegenIdentUsage, ref_::CodegenRef};
 
 /// Generates the `types/mod.rs` module.
 pub struct CodegenTypesModule<'a> {
@@ -20,10 +23,41 @@ impl ToTokens for CodegenTypesModule<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let mut tys = self.graph.schemas().collect_vec();
         tys.sort_by_key(|s| self.graph.ident(s.id()));
+        let mut result_ops = self
+            .graph
+            .operations()
+            .filter(|op| {
+                let mut shapes: Vec<Option<TypeId>> = vec![];
+                for case in op.response_cases() {
+                    let shape = case.body().map(|body| match body {
+                        ResponseView::Json(view) => match view {
+                            TypeView::Schema(view) => view.id(),
+                            TypeView::Inline(view) => view.id(),
+                        },
+                    });
+                    if !shapes.contains(&shape) {
+                        shapes.push(shape);
+                    }
+                }
+                shapes.len() > 1
+            })
+            .collect_vec();
+        result_ops.sort_by_key(|op| self.graph.ident(op.id()));
 
         let mods = tys.iter().map(|schema| {
             let cfg = CfgFeature::for_schema_type(self.graph, schema);
             let mod_name = CodegenIdentUsage::Module(self.graph.ident(schema.id()));
+            quote! {
+                #cfg
+                pub mod #mod_name;
+            }
+        });
+        let result_mods = result_ops.iter().map(|op| {
+            let cfg = CfgFeature::for_operation(self.graph, op);
+            let mod_name = format_ident!(
+                "{}_result",
+                CodegenIdentUsage::Module(self.graph.ident(op.id()))
+            );
             quote! {
                 #cfg
                 pub mod #mod_name;
@@ -39,10 +73,27 @@ impl ToTokens for CodegenTypesModule<'_> {
                 pub use #mod_name::#ty_name;
             }
         });
+        let result_uses = result_ops.iter().map(|op| {
+            let cfg = CfgFeature::for_operation(self.graph, op);
+            let type_name = format_ident!(
+                "{}Result",
+                CodegenIdentUsage::Type(self.graph.ident(op.id()))
+            );
+            let mod_name = format_ident!(
+                "{}_result",
+                CodegenIdentUsage::Module(self.graph.ident(op.id()))
+            );
+            quote! {
+                #cfg
+                pub use #mod_name::#type_name;
+            }
+        });
 
         tokens.append_all(quote! {
             #(#mods)*
+            #(#result_mods)*
             #(#uses)*
+            #(#result_uses)*
         });
     }
 }
@@ -52,5 +103,280 @@ impl IntoCode for CodegenTypesModule<'_> {
 
     fn into_code(self) -> Self::Code {
         ("src/types/mod.rs", self.into_token_stream())
+    }
+}
+
+/// Generates an operation result enum for multiple successful response shapes.
+#[derive(Debug)]
+pub struct CodegenOperationResult<'a> {
+    graph: &'a CodegenGraph<'a>,
+    op: &'a OperationView<'a, 'a>,
+}
+
+impl<'a> CodegenOperationResult<'a> {
+    pub fn new(graph: &'a CodegenGraph<'a>, op: &'a OperationView<'a, 'a>) -> Self {
+        Self { graph, op }
+    }
+}
+
+impl ToTokens for CodegenOperationResult<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let type_name = format_ident!(
+            "{}Result",
+            CodegenIdentUsage::Type(self.graph.ident(self.op.id()))
+        );
+        let variants = self.op.response_cases().map(|case| {
+            let status = case.status();
+            let variant_name = format_ident!(
+                "{}",
+                match status {
+                    200 => "Ok".to_owned(),
+                    201 => "Created".to_owned(),
+                    202 => "Accepted".to_owned(),
+                    203 => "NonAuthoritativeInformation".to_owned(),
+                    204 => "NoContent".to_owned(),
+                    205 => "ResetContent".to_owned(),
+                    206 => "PartialContent".to_owned(),
+                    207 => "MultiStatus".to_owned(),
+                    208 => "AlreadyReported".to_owned(),
+                    226 => "ImUsed".to_owned(),
+                    _ => format!("Status{status}"),
+                }
+            );
+            match case.body() {
+                Some(ResponseView::Json(view)) => {
+                    let ty = CodegenRef::new(self.graph, &view);
+                    quote! { #variant_name(#ty) }
+                }
+                None => quote! { #variant_name },
+            }
+        });
+        tokens.append_all(quote! {
+            #[derive(Clone, Debug, PartialEq)]
+            pub enum #type_name {
+                #(#variants),*
+            }
+        });
+    }
+}
+
+impl IntoCode for CodegenOperationResult<'_> {
+    type Code = (String, TokenStream);
+
+    fn into_code(self) -> Self::Code {
+        let mod_name = format_ident!(
+            "{}_result",
+            CodegenIdentUsage::Module(self.graph.ident(self.op.id()))
+        );
+        (
+            format!("src/types/{}.rs", mod_name),
+            self.into_token_stream(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use ploidy_core::{
+        arena::Arena,
+        ir::{RawGraph, Spec},
+        parse::Document,
+    };
+    use pretty_assertions::assert_eq;
+    use syn::parse_quote;
+
+    use crate::graph::CodegenGraph;
+
+    #[test]
+    fn test_operation_result_file_for_distinct_success_bodies() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths:
+              /jobs:
+                post:
+                  operationId: startJob
+                  responses:
+                    '200':
+                      description: Complete
+                      content:
+                        application/json:
+                          schema:
+                            $ref: '#/components/schemas/Job'
+                    '202':
+                      description: Accepted
+                      content:
+                        application/json:
+                          schema:
+                            $ref: '#/components/schemas/PendingJob'
+            components:
+              schemas:
+                Job:
+                  type: object
+                PendingJob:
+                  type: object
+        "})
+        .unwrap();
+
+        let arena = Arena::new();
+        let spec = Spec::from_doc(&arena, &doc).unwrap();
+        let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
+
+        let op = graph.operations().next().unwrap();
+        let (path, tokens) = CodegenOperationResult::new(&graph, &op).into_code();
+
+        assert_eq!(path, "src/types/start_job_result.rs");
+        let actual: syn::File = parse_quote!(#tokens);
+        let expected: syn::File = parse_quote! {
+            #[derive(Clone, Debug, PartialEq)]
+            pub enum StartJobResult {
+                Ok(crate::types::Job),
+                Accepted(crate::types::PendingJob)
+            }
+        };
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_types_module_exports_operation_result() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths:
+              /jobs:
+                post:
+                  operationId: startJob
+                  responses:
+                    '200':
+                      description: Complete
+                      content:
+                        application/json:
+                          schema:
+                            $ref: '#/components/schemas/Job'
+                    '202':
+                      description: Accepted
+                      content:
+                        application/json:
+                          schema:
+                            $ref: '#/components/schemas/PendingJob'
+            components:
+              schemas:
+                Job:
+                  type: object
+                PendingJob:
+                  type: object
+        "})
+        .unwrap();
+
+        let arena = Arena::new();
+        let spec = Spec::from_doc(&arena, &doc).unwrap();
+        let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
+
+        let codegen = CodegenTypesModule::new(&graph);
+        let actual: syn::File = parse_quote!(#codegen);
+        let expected: syn::File = parse_quote! {
+            pub mod job;
+            pub mod pending_job;
+            pub mod start_job_result;
+            pub use job::Job;
+            pub use pending_job::PendingJob;
+            pub use start_job_result::StartJobResult;
+        };
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_operation_result_file_for_bodyless_success() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths:
+              /jobs:
+                post:
+                  operationId: startJob
+                  responses:
+                    '200':
+                      description: Complete
+                      content:
+                        application/json:
+                          schema:
+                            $ref: '#/components/schemas/Job'
+                    '204':
+                      description: No content
+            components:
+              schemas:
+                Job:
+                  type: object
+        "})
+        .unwrap();
+
+        let arena = Arena::new();
+        let spec = Spec::from_doc(&arena, &doc).unwrap();
+        let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
+
+        let op = graph.operations().next().unwrap();
+        let codegen = CodegenOperationResult::new(&graph, &op);
+
+        let actual: syn::File = parse_quote!(#codegen);
+        let expected: syn::File = parse_quote! {
+            #[derive(Clone, Debug, PartialEq)]
+            pub enum StartJobResult {
+                Ok(crate::types::Job),
+                NoContent
+            }
+        };
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_types_module_omits_result_for_same_success_body() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths:
+              /jobs:
+                post:
+                  operationId: startJob
+                  responses:
+                    '200':
+                      description: Complete
+                      content:
+                        application/json:
+                          schema:
+                            $ref: '#/components/schemas/Job'
+                    '202':
+                      description: Accepted
+                      content:
+                        application/json:
+                          schema:
+                            $ref: '#/components/schemas/Job'
+            components:
+              schemas:
+                Job:
+                  type: object
+        "})
+        .unwrap();
+
+        let arena = Arena::new();
+        let spec = Spec::from_doc(&arena, &doc).unwrap();
+        let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
+
+        let codegen = CodegenTypesModule::new(&graph);
+        let actual: syn::File = parse_quote!(#codegen);
+        let expected: syn::File = parse_quote! {
+            pub mod job;
+            pub use job::Job;
+        };
+        assert_eq!(actual, expected);
     }
 }

--- a/ploidy-codegen-rust/src/types.rs
+++ b/ploidy-codegen-rust/src/types.rs
@@ -6,7 +6,12 @@ use ploidy_core::{
 use proc_macro2::TokenStream;
 use quote::{ToTokens, TokenStreamExt, format_ident, quote};
 
-use super::{cfg::CfgFeature, graph::CodegenGraph, naming::CodegenIdentUsage, ref_::CodegenRef};
+use super::{
+    cfg::CfgFeature,
+    graph::CodegenGraph,
+    naming::{CodegenIdentUsage, status_variant_name},
+    ref_::CodegenRef,
+};
 
 /// Generates the `types/mod.rs` module.
 pub struct CodegenTypesModule<'a> {
@@ -30,7 +35,7 @@ impl ToTokens for CodegenTypesModule<'_> {
                 let mut shapes: Vec<Option<TypeId>> = vec![];
                 for case in op.response_cases() {
                     let shape = case.body().map(|body| match body {
-                        ResponseView::Json(view) => match view {
+                        ResponseView::Json(view) | ResponseView::Headers(view) => match view {
                             TypeView::Schema(view) => view.id(),
                             TypeView::Inline(view) => view.id(),
                         },
@@ -127,24 +132,9 @@ impl ToTokens for CodegenOperationResult<'_> {
         );
         let variants = self.op.response_cases().map(|case| {
             let status = case.status();
-            let variant_name = format_ident!(
-                "{}",
-                match status {
-                    200 => "Ok".to_owned(),
-                    201 => "Created".to_owned(),
-                    202 => "Accepted".to_owned(),
-                    203 => "NonAuthoritativeInformation".to_owned(),
-                    204 => "NoContent".to_owned(),
-                    205 => "ResetContent".to_owned(),
-                    206 => "PartialContent".to_owned(),
-                    207 => "MultiStatus".to_owned(),
-                    208 => "AlreadyReported".to_owned(),
-                    226 => "ImUsed".to_owned(),
-                    _ => format!("Status{status}"),
-                }
-            );
+            let variant_name = format_ident!("{}", status_variant_name(status));
             match case.body() {
-                Some(ResponseView::Json(view)) => {
+                Some(ResponseView::Json(view) | ResponseView::Headers(view)) => {
                     let ty = CodegenRef::new(self.graph, &view);
                     quote! { #variant_name(#ty) }
                 }
@@ -287,6 +277,104 @@ mod tests {
             pub use job::Job;
             pub use pending_job::PendingJob;
             pub use start_job_result::StartJobResult;
+        };
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_operation_result_variant_for_header_only_response() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths:
+              /jobs:
+                get:
+                  operationId: getJob
+                  responses:
+                    '200':
+                      description: Complete
+                      content:
+                        application/json:
+                          schema:
+                            $ref: '#/components/schemas/Job'
+                    '304':
+                      description: Not modified.
+                      headers:
+                        etag:
+                          required: true
+                          schema:
+                            type: string
+            components:
+              schemas:
+                Job:
+                  type: object
+        "})
+        .unwrap();
+
+        let arena = Arena::new();
+        let spec = Spec::from_doc(&arena, &doc).unwrap();
+        let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
+
+        let op = graph.operations().next().unwrap();
+        let (path, tokens) = CodegenOperationResult::new(&graph, &op).into_code();
+
+        assert_eq!(path, "src/types/get_job_result.rs");
+        let actual: syn::File = parse_quote!(#tokens);
+        let expected: syn::File = parse_quote! {
+            #[derive(Clone, Debug, PartialEq)]
+            pub enum GetJobResult {
+                Ok(crate::types::Job),
+                NotModified(crate::client::default::types::GetJobResponseNotModified)
+            }
+        };
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_types_module_exports_result_for_body_and_header_shapes() {
+        let doc = Document::from_yaml(indoc::indoc! {"
+            openapi: 3.0.0
+            info:
+              title: Test API
+              version: 1.0.0
+            paths:
+              /jobs:
+                get:
+                  operationId: getJob
+                  responses:
+                    '200':
+                      description: Complete
+                      content:
+                        application/json:
+                          schema:
+                            $ref: '#/components/schemas/Job'
+                    '304':
+                      description: Not modified.
+                      headers:
+                        etag:
+                          required: true
+                          schema:
+                            type: string
+            components:
+              schemas:
+                Job:
+                  type: object
+        "})
+        .unwrap();
+
+        let arena = Arena::new();
+        let spec = Spec::from_doc(&arena, &doc).unwrap();
+        let graph = CodegenGraph::new(RawGraph::new(&arena, &spec).cook());
+
+        let codegen = CodegenTypesModule::new(&graph);
+        let actual: syn::File = parse_quote!(#codegen);
+        let expected: syn::File = parse_quote! {
+            pub mod job;
+            pub mod get_job_result;
+            pub use job::Job;
+            pub use get_job_result::GetJobResult;
         };
         assert_eq!(actual, expected);
     }

--- a/ploidy-core/src/ir/graph.rs
+++ b/ploidy-core/src/ir/graph.rs
@@ -161,6 +161,11 @@ impl<'a> RawGraph<'a> {
                         SpecType::Inline(i) => indices[&ResolvedSpecType::Inline(i)],
                         SpecType::Ref(r) => schemas[&*r.name()],
                     }),
+                    Response::Headers(ty) => Response::Headers(match ty {
+                        SpecType::Schema(s) => indices[&ResolvedSpecType::Schema(s)],
+                        SpecType::Inline(i) => indices[&ResolvedSpecType::Inline(i)],
+                        SpecType::Ref(r) => schemas[&*r.name()],
+                    }),
                 }),
             }));
 
@@ -528,6 +533,10 @@ impl<'a> RawGraph<'a> {
                                     let &ty = collapsed_to.get(&ty)?;
                                     Some(Response::Json(ty))
                                 }
+                                Response::Headers(ty) => {
+                                    let &ty = collapsed_to.get(&ty)?;
+                                    Some(Response::Headers(ty))
+                                }
                             })
                             .or(response.body),
                     })
@@ -844,6 +853,7 @@ impl<'a> CookedGraph<'a> {
                         status: response.status,
                         body: response.body.as_ref().map(|r| match r {
                             Response::Json(ty) => Response::Json(indices[ty]),
+                            Response::Headers(ty) => Response::Headers(indices[ty]),
                         }),
                     })),
             })
@@ -1270,7 +1280,7 @@ impl<'graph, 'a> MetadataBuilder<'graph, 'a> {
                 .filter(|response| response.body.is_some())
                 .count();
             for response in op.responses {
-                if let Some(Response::Json(index)) = response.body
+                if let Some(Response::Json(index) | Response::Headers(index)) = response.body
                     && matches!(self.graph[index], GraphType::Inline(_))
                     && bfs.discover(index)
                 {

--- a/ploidy-core/src/ir/graph.rs
+++ b/ploidy-core/src/ir/graph.rs
@@ -32,7 +32,7 @@ use super::{
         GraphTagged, GraphType, GraphUntagged, InlineTypeId, InlineTypeIds, InlineTypePathRoot,
         OperationUsage, PrimitiveType, SpecInlineType, SpecSchemaType, SpecType, StructFieldName,
         TaggedVariantMeta, UntaggedVariantMeta, VariantMeta,
-        shape::{Operation, Parameter, ParameterInfo, Request, Response},
+        shape::{Operation, Parameter, ParameterInfo, Request, Response, ResponseCase},
     },
     views::{TypeId, operation::OperationView, primitive::PrimitiveView, schema::SchemaTypeView},
 };
@@ -153,13 +153,16 @@ impl<'a> RawGraph<'a> {
                 Request::Multipart => Request::Multipart,
             });
 
-            let response = op.response.as_ref().map(|r| match r {
-                Response::Json(ty) => Response::Json(match ty {
-                    SpecType::Schema(s) => indices[&ResolvedSpecType::Schema(s)],
-                    SpecType::Inline(i) => indices[&ResolvedSpecType::Inline(i)],
-                    SpecType::Ref(r) => schemas[&*r.name()],
+            let responses = arena.alloc_slice_exact(op.responses.iter().map(|case| ResponseCase {
+                status: case.status,
+                body: case.body.as_ref().map(|r| match r {
+                    Response::Json(ty) => Response::Json(match ty {
+                        SpecType::Schema(s) => indices[&ResolvedSpecType::Schema(s)],
+                        SpecType::Inline(i) => indices[&ResolvedSpecType::Inline(i)],
+                        SpecType::Ref(r) => schemas[&*r.name()],
+                    }),
                 }),
-            });
+            }));
 
             &*arena.alloc(Operation {
                 id: op.id,
@@ -169,7 +172,7 @@ impl<'a> RawGraph<'a> {
                 description: op.description,
                 params,
                 request,
-                response,
+                responses,
             })
         }));
 
@@ -513,23 +516,30 @@ impl<'a> RawGraph<'a> {
                     })
                     .or(op.request);
 
-                let response = op
-                    .response
-                    .and_then(|response| match response {
-                        Response::Json(ty) => {
-                            let &ty = collapsed_to.get(&ty)?;
-                            Some(Response::Json(ty))
-                        }
+                let responses = op
+                    .responses
+                    .iter()
+                    .map(|response| ResponseCase {
+                        status: response.status,
+                        body: response
+                            .body
+                            .and_then(|body| match body {
+                                Response::Json(ty) => {
+                                    let &ty = collapsed_to.get(&ty)?;
+                                    Some(Response::Json(ty))
+                                }
+                            })
+                            .or(response.body),
                     })
-                    .or(op.response);
+                    .collect_vec();
 
-                if params == op.params && request == op.request && response == op.response {
+                if params == op.params && request == op.request && responses == op.responses {
                     op
                 } else {
                     self.arena.alloc(Operation {
                         params: self.arena.alloc_slice_copy(&params),
                         request,
-                        response,
+                        responses: self.arena.alloc_slice_copy(&responses),
                         ..*op
                     })
                 }
@@ -828,9 +838,14 @@ impl<'a> CookedGraph<'a> {
                     Request::Json(ty) => Request::Json(indices[ty]),
                     Request::Multipart => Request::Multipart,
                 }),
-                response: op.response.as_ref().map(|r| match r {
-                    Response::Json(ty) => Response::Json(indices[ty]),
-                }),
+                responses: raw
+                    .arena
+                    .alloc_slice_exact(op.responses.iter().map(|response| ResponseCase {
+                        status: response.status,
+                        body: response.body.as_ref().map(|r| match r {
+                            Response::Json(ty) => Response::Json(indices[ty]),
+                        }),
+                    })),
             })
         }));
 
@@ -1249,21 +1264,30 @@ impl<'graph, 'a> MetadataBuilder<'graph, 'a> {
                     },
                 );
             }
-            if let Some(Response::Json(index)) = op.response
-                && matches!(self.graph[index], GraphType::Inline(_))
-                && bfs.discover(index)
-            {
-                by_node.insert(
-                    index,
-                    PartialPath {
-                        root: InlineTypePathRoot::Operation {
-                            id: op.id,
-                            resource: op.resource,
-                            usage: OperationUsage::Response,
+            let response_body_count = op
+                .responses
+                .iter()
+                .filter(|response| response.body.is_some())
+                .count();
+            for response in op.responses {
+                if let Some(Response::Json(index)) = response.body
+                    && matches!(self.graph[index], GraphType::Inline(_))
+                    && bfs.discover(index)
+                {
+                    by_node.insert(
+                        index,
+                        PartialPath {
+                            root: InlineTypePathRoot::Operation {
+                                id: op.id,
+                                resource: op.resource,
+                                usage: OperationUsage::Response {
+                                    status: (response_body_count > 1).then_some(response.status),
+                                },
+                            },
+                            edges: vec![],
                         },
-                        edges: vec![],
-                    },
-                );
+                    );
+                }
             }
             while let Some(edge) = bfs.next() {
                 let parent = &by_node[&edge.source()];

--- a/ploidy-core/src/ir/spec.rs
+++ b/ploidy-core/src/ir/spec.rs
@@ -19,7 +19,7 @@ use super::{
     types::{
         InlineTypeIds, ParameterStyle as IrParameterStyle, SchemaTypeInfo, SpecInlineType,
         SpecOperation, SpecParameter, SpecParameterInfo, SpecRequest, SpecResponse, SpecSchemaType,
-        SpecType,
+        SpecType, shape::ResponseCase,
     },
 };
 
@@ -248,60 +248,70 @@ impl<'a> Spec<'a> {
                         }
                     });
 
-                let response = {
+                let responses = {
                     let mut statuses = item
                         .op
                         .responses
                         .keys()
                         .filter_map(|status| Some((status.as_str(), status.parse::<u16>().ok()?)))
+                        .filter(|&(_, status)| matches!(status, 200..300))
                         .collect_vec();
                     statuses.sort_unstable_by_key(|&(_, code)| code);
-                    let key = statuses
-                        .iter()
-                        .find(|&(_, code)| matches!(code, 200..300))
-                        .map(|&(key, _)| key)
-                        .unwrap_or("default");
 
-                    item.op
-                        .responses
-                        .get(key)
-                        .and_then(|response_or_ref| {
+                    if statuses.is_empty() {
+                        statuses.extend(
+                            item.op
+                                .responses
+                                .contains_key("default")
+                                .then_some(("default", 200)),
+                        );
+                    }
+
+                    let responses = statuses
+                        .into_iter()
+                        .filter_map(|(key, status)| {
+                            let response_or_ref = item.op.responses.get(key)?;
                             let response = match response_or_ref {
                                 RefOrResponse::Other(r) => r,
                                 RefOrResponse::Ref(r) => {
                                     r.ref_.pointer().follow::<&Response>(doc).ok()?
                                 }
                             };
-                            response.content.as_ref()
+                            let body = response
+                                .content
+                                .as_ref()
+                                .map(|content| {
+                                    if let Some(content) = content.get("application/json")
+                                        && let Some(schema) = &content.schema
+                                    {
+                                        ResponseContent::Json(schema)
+                                    } else if let Some(content) = content.get("*/*")
+                                        && let Some(schema) = &content.schema
+                                    {
+                                        ResponseContent::Json(schema)
+                                    } else {
+                                        ResponseContent::Any
+                                    }
+                                })
+                                .map(|content| match content {
+                                    ResponseContent::Json(RefOrSchema::Ref(r)) => {
+                                        SpecResponse::Json(arena.alloc(SpecType::Ref(r)))
+                                    }
+                                    ResponseContent::Json(RefOrSchema::Inline(schema)) => {
+                                        SpecResponse::Json(arena.alloc(transform_with_context(
+                                            &context,
+                                            ids.next(),
+                                            schema,
+                                        )))
+                                    }
+                                    ResponseContent::Any => SpecResponse::Json(
+                                        arena.alloc(SpecInlineType::Any(ids.next()).into()),
+                                    ),
+                                });
+                            Some(ResponseCase { status, body })
                         })
-                        .map(|content| {
-                            if let Some(content) = content.get("application/json")
-                                && let Some(schema) = &content.schema
-                            {
-                                ResponseContent::Json(schema)
-                            } else if let Some(content) = content.get("*/*")
-                                && let Some(schema) = &content.schema
-                            {
-                                ResponseContent::Json(schema)
-                            } else {
-                                ResponseContent::Any
-                            }
-                        })
-                        .map(|content| match content {
-                            ResponseContent::Json(RefOrSchema::Ref(r)) => {
-                                SpecResponse::Json(arena.alloc(SpecType::Ref(r)))
-                            }
-                            ResponseContent::Json(RefOrSchema::Inline(schema)) => {
-                                SpecResponse::Json(arena.alloc(transform_with_context(
-                                    &context,
-                                    ids.next(),
-                                    schema,
-                                )))
-                            }
-                            ResponseContent::Any => SpecResponse::Json(
-                                arena.alloc(SpecInlineType::Any(ids.next()).into()),
-                            ),
-                        })
+                        .collect_vec();
+                    arena.alloc_slice_copy(&responses)
                 };
 
                 Ok(SpecOperation {
@@ -312,7 +322,7 @@ impl<'a> Spec<'a> {
                     description: item.op.description.as_deref(),
                     params,
                     request,
-                    response,
+                    responses,
                 })
             })
             .flatten_ok()

--- a/ploidy-core/src/ir/spec.rs
+++ b/ploidy-core/src/ir/spec.rs
@@ -6,9 +6,9 @@ use crate::{
     arena::Arena,
     ir::OperationId,
     parse::{
-        self, Document, Info, Method, Operation, Parameter, ParameterLocation,
-        ParameterStyle as ParsedParameterStyle, RefOrParameter, RefOrRequestBody, RefOrResponse,
-        RefOrSchema, RequestBody, Response,
+        self, Document, Header, Info, Method, Operation, Parameter, ParameterLocation,
+        ParameterStyle as ParsedParameterStyle, RefOrHeader, RefOrParameter, RefOrRequestBody,
+        RefOrResponse, RefOrSchema, RequestBody, Response,
         path::{ParsedPath, PathFragment, PathSegment},
     },
 };
@@ -17,9 +17,10 @@ use super::{
     error::IrError,
     transform::{TransformContext, TypeInfo, transform_with_context},
     types::{
-        InlineTypeIds, ParameterStyle as IrParameterStyle, SchemaTypeInfo, SpecInlineType,
-        SpecOperation, SpecParameter, SpecParameterInfo, SpecRequest, SpecResponse, SpecSchemaType,
-        SpecType, shape::ResponseCase,
+        InlineTypeIds, ParameterStyle as IrParameterStyle, PrimitiveType, SchemaTypeInfo,
+        SpecContainer, SpecInlineType, SpecInner, SpecOperation, SpecParameter, SpecParameterInfo,
+        SpecRequest, SpecResponse, SpecSchemaType, SpecStruct, SpecStructField, SpecType,
+        StructFieldName, shape::ResponseCase,
     },
 };
 
@@ -254,7 +255,7 @@ impl<'a> Spec<'a> {
                         .responses
                         .keys()
                         .filter_map(|status| Some((status.as_str(), status.parse::<u16>().ok()?)))
-                        .filter(|&(_, status)| matches!(status, 200..300))
+                        .filter(|&(_, status)| matches!(status, 100..400))
                         .collect_vec();
                     statuses.sort_unstable_by_key(|&(_, code)| code);
 
@@ -308,6 +309,75 @@ impl<'a> Spec<'a> {
                                         arena.alloc(SpecInlineType::Any(ids.next()).into()),
                                     ),
                                 });
+                            let body = body.or_else(|| {
+                                let fields = response
+                                    .headers
+                                    .as_ref()?
+                                    .iter()
+                                    // Per OpenAPI, a `Content-Type` header
+                                    // definition SHALL be ignored.
+                                    .filter(|(name, _)| !name.eq_ignore_ascii_case("content-type"))
+                                    .filter_map(|(name, header)| {
+                                        let header = match header {
+                                            RefOrHeader::Other(header) => header,
+                                            RefOrHeader::Ref(r) => {
+                                                r.ref_.pointer().follow::<&Header>(doc).ok()?
+                                            }
+                                        };
+                                        let name: &_ = arena.alloc_str(&name.to_ascii_lowercase());
+                                        // Header values arrive as strings on
+                                        // the wire, so every header field is a
+                                        // string regardless of its declared
+                                        // schema type.
+                                        let string: &_ = arena.alloc(
+                                            SpecInlineType::Primitive(
+                                                ids.next(),
+                                                PrimitiveType::String,
+                                            )
+                                            .into(),
+                                        );
+                                        // Optional headers become nullable
+                                        // fields, so the generated struct
+                                        // holds `Option<String>`.
+                                        let ty: &_ = if header.required {
+                                            string
+                                        } else {
+                                            arena.alloc(
+                                                SpecInlineType::Container(
+                                                    ids.next(),
+                                                    SpecContainer::Optional(SpecInner {
+                                                        description: None,
+                                                        ty: string,
+                                                    }),
+                                                )
+                                                .into(),
+                                            )
+                                        };
+                                        Some(SpecStructField {
+                                            name: StructFieldName::Name(name),
+                                            ty,
+                                            required: true,
+                                            description: header.description.as_deref(),
+                                            flattened: false,
+                                        })
+                                    })
+                                    .collect_vec();
+                                (!fields.is_empty()).then(|| {
+                                    SpecResponse::Headers(
+                                        arena.alloc(
+                                            SpecInlineType::Struct(
+                                                ids.next(),
+                                                SpecStruct {
+                                                    description: response.description.as_deref(),
+                                                    fields: arena.alloc_slice_copy(&fields),
+                                                    parents: &[],
+                                                },
+                                            )
+                                            .into(),
+                                        ),
+                                    )
+                                })
+                            });
                             Some(ResponseCase { status, body })
                         })
                         .collect_vec();

--- a/ploidy-core/src/ir/tests/graph.rs
+++ b/ploidy-core/src/ir/tests/graph.rs
@@ -5,8 +5,8 @@ use itertools::Itertools;
 use crate::{
     arena::Arena,
     ir::{
-        ContainerView, HasResource, InlineTypeView, RawGraph, RequestView, ResponseView,
-        SchemaTypeView, Spec, StructFieldName, TypeView, View,
+        ContainerView, HasResource, InlineTypeView, PrimitiveType, RawGraph, RequestView,
+        ResponseView, SchemaTypeView, Spec, StructFieldName, TypeView, View,
     },
     parse::Document,
     tests::assert_matches,
@@ -1124,6 +1124,73 @@ fn test_operation_dependencies_include_all_successful_responses() {
         .collect_vec();
     deps.sort();
     assert_matches!(&*deps, ["Job", "PendingJob"]);
+}
+
+#[test]
+fn test_operation_dependencies_include_header_struct() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test
+          version: 1.0
+        paths:
+          /jobs:
+            get:
+              operationId: getJob
+              responses:
+                '200':
+                  description: Complete
+                  content:
+                    application/json:
+                      schema:
+                        $ref: '#/components/schemas/Job'
+                '304':
+                  description: Not modified.
+                  headers:
+                    etag:
+                      required: true
+                      schema:
+                        type: string
+        components:
+          schemas:
+            Job:
+              type: object
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let spec = Spec::from_doc(&arena, &doc).unwrap();
+    let graph = RawGraph::new(&arena, &spec).cook();
+
+    let operation = graph.operations().next().unwrap();
+    let deps = operation
+        .dependencies()
+        .filter_map(|v| v.into_schema().right())
+        .map(|schema| schema.name())
+        .collect_vec();
+    assert_matches!(&*deps, ["Job"]);
+
+    // The synthesized header struct is an operation inline with a
+    // field edge to a string primitive.
+    let structs = operation
+        .inlines()
+        .filter_map(|inline| match inline {
+            InlineTypeView::Struct(_, view) => Some(view),
+            _ => None,
+        })
+        .collect_vec();
+    let [headers] = &*structs else {
+        panic!("expected one inline struct; got `{structs:?}`");
+    };
+    let fields = headers.fields().collect_vec();
+    let [etag] = &*fields else {
+        panic!("expected one header field; got `{fields:?}`");
+    };
+    assert_matches!(etag.name(), StructFieldName::Name("etag"));
+    assert_matches!(
+        etag.ty(),
+        TypeView::Inline(InlineTypeView::Primitive(_, p)) if p.ty() == PrimitiveType::String,
+    );
 }
 
 // MARK: Backward propagation

--- a/ploidy-core/src/ir/tests/graph.rs
+++ b/ploidy-core/src/ir/tests/graph.rs
@@ -1079,6 +1079,53 @@ fn test_dependencies_propagation() {
     assert_eq!(other_used_by, ["getData"]);
 }
 
+#[test]
+fn test_operation_dependencies_include_all_successful_responses() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test API
+          version: 1.0
+        paths:
+          /jobs:
+            post:
+              operationId: startJob
+              responses:
+                '200':
+                  description: Complete
+                  content:
+                    application/json:
+                      schema:
+                        $ref: '#/components/schemas/Job'
+                '202':
+                  description: Accepted
+                  content:
+                    application/json:
+                      schema:
+                        $ref: '#/components/schemas/PendingJob'
+        components:
+          schemas:
+            Job:
+              type: object
+            PendingJob:
+              type: object
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let spec = Spec::from_doc(&arena, &doc).unwrap();
+    let graph = RawGraph::new(&arena, &spec).cook();
+
+    let operation = graph.operations().next().unwrap();
+    let mut deps = operation
+        .dependencies()
+        .filter_map(|v| v.into_schema().right())
+        .map(|schema| schema.name())
+        .collect_vec();
+    deps.sort();
+    assert_matches!(&*deps, ["Job", "PendingJob"]);
+}
+
 // MARK: Backward propagation
 
 #[test]

--- a/ploidy-core/src/ir/tests/spec.rs
+++ b/ploidy-core/src/ir/tests/spec.rs
@@ -8,7 +8,7 @@ use crate::{
         spec::Spec,
         types::{
             ParameterStyle, PrimitiveType, SpecInlineType, SpecOperation, SpecParameter,
-            SpecParameterInfo, SpecRequest, SpecResponse, SpecType,
+            SpecParameterInfo, SpecRequest, SpecResponse, SpecType, shape::ResponseCase,
         },
     },
     parse::{Document, Method, path::ParsedPath},
@@ -850,7 +850,10 @@ fn test_parses_response_json_reference() {
     assert_matches!(
         &*ir.operations,
         [SpecOperation {
-            response: Some(SpecResponse::Json(_)),
+            responses: [ResponseCase {
+                status: 200,
+                body: Some(SpecResponse::Json(_)),
+            }],
             ..
         }],
     );
@@ -886,7 +889,10 @@ fn test_parses_response_json_inline_schema() {
     assert_matches!(
         &*ir.operations,
         [SpecOperation {
-            response: Some(SpecResponse::Json(_)),
+            responses: [ResponseCase {
+                status: 200,
+                body: Some(SpecResponse::Json(_)),
+            }],
             ..
         }],
     );
@@ -938,7 +944,10 @@ fn test_prioritizes_2xx_status_over_default_response() {
     assert_matches!(
         &*ir.operations,
         [SpecOperation {
-            response: Some(SpecResponse::Json(SpecType::Ref(component_ref))),
+            responses: [ResponseCase {
+                status: 200,
+                body: Some(SpecResponse::Json(SpecType::Ref(component_ref))),
+            }],
             ..
         }] if component_ref.name() == "User",
     );
@@ -974,7 +983,10 @@ fn test_falls_back_to_default_response_when_no_2xx_status() {
     assert_matches!(
         &*ir.operations,
         [SpecOperation {
-            response: Some(_),
+            responses: [ResponseCase {
+                status: 200,
+                body: Some(_),
+            }],
             ..
         }],
     );
@@ -1007,14 +1019,17 @@ fn test_parses_response_with_wildcard_content_type() {
     assert_matches!(
         &*ir.operations,
         [SpecOperation {
-            response: Some(SpecResponse::Json(_)),
+            responses: [ResponseCase {
+                status: 200,
+                body: Some(SpecResponse::Json(_)),
+            }],
             ..
         }],
     );
 }
 
 #[test]
-fn test_selects_first_2xx_status_when_multiple_exist() {
+fn test_preserves_multiple_2xx_responses() {
     let doc = Document::from_yaml(indoc::indoc! {"
         openapi: 3.0.0
         info:
@@ -1057,13 +1072,21 @@ fn test_selects_first_2xx_status_when_multiple_exist() {
     let arena = Arena::new();
     let ir = Spec::from_doc(&arena, &doc).unwrap();
 
-    // The response should be from the first 2xx status (200), not 202.
     assert_matches!(
         &*ir.operations,
         [SpecOperation {
-            response: Some(SpecResponse::Json(SpecType::Ref(component_ref))),
+            responses: [
+                ResponseCase {
+                    status: 200,
+                    body: Some(SpecResponse::Json(SpecType::Ref(first))),
+                },
+                ResponseCase {
+                    status: 202,
+                    body: Some(SpecResponse::Json(SpecType::Ref(second))),
+                },
+            ],
             ..
-        }] if component_ref.name() == "UserList",
+        }] if first.name() == "UserList" && second.name() == "AcceptedResponse",
     );
 }
 
@@ -1085,7 +1108,7 @@ fn test_operation_without_response() {
     let arena = Arena::new();
     let ir = Spec::from_doc(&arena, &doc).unwrap();
 
-    assert_matches!(&*ir.operations, [SpecOperation { response: None, .. }]);
+    assert_matches!(&*ir.operations, [SpecOperation { responses: [], .. }]);
 }
 
 // MARK: `x-resource-name` extension
@@ -1368,7 +1391,7 @@ fn test_operation_with_all_components() {
             resource: Some("users"),
             description: Some("Update an existing user"),
             request: Some(_),
-            response: Some(_),
+            responses: [_],
             params: [_, _],
             ..
         }],

--- a/ploidy-core/src/ir/tests/spec.rs
+++ b/ploidy-core/src/ir/tests/spec.rs
@@ -7,8 +7,9 @@ use crate::{
     ir::{
         spec::Spec,
         types::{
-            ParameterStyle, PrimitiveType, SpecInlineType, SpecOperation, SpecParameter,
-            SpecParameterInfo, SpecRequest, SpecResponse, SpecType, shape::ResponseCase,
+            ParameterStyle, PrimitiveType, SpecContainer, SpecInlineType, SpecInner, SpecOperation,
+            SpecParameter, SpecParameterInfo, SpecRequest, SpecResponse, SpecStructField, SpecType,
+            StructFieldName, shape::ResponseCase,
         },
     },
     parse::{Document, Method, path::ParsedPath},
@@ -954,7 +955,7 @@ fn test_prioritizes_2xx_status_over_default_response() {
 }
 
 #[test]
-fn test_falls_back_to_default_response_when_no_2xx_status() {
+fn test_falls_back_to_default_response_when_no_success_status() {
     let doc = Document::from_yaml(indoc::indoc! {"
         openapi: 3.0.0
         info:
@@ -965,6 +966,15 @@ fn test_falls_back_to_default_response_when_no_2xx_status() {
             get:
               operationId: listUsers
               responses:
+                '404':
+                  description: Not found
+                  content:
+                    application/json:
+                      schema:
+                        type: object
+                        properties:
+                          code:
+                            type: string
                 'default':
                   description: Default response
                   content:
@@ -1087,6 +1097,353 @@ fn test_preserves_multiple_2xx_responses() {
             ],
             ..
         }] if first.name() == "UserList" && second.name() == "AcceptedResponse",
+    );
+}
+
+#[test]
+fn test_parses_header_only_response_as_headers_struct() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test API
+          version: 1.0
+        paths:
+          /archives:
+            get:
+              operationId: getArchive
+              responses:
+                '307':
+                  description: Redirect to the archive URL.
+                  headers:
+                    location:
+                      required: true
+                      schema:
+                        type: string
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let ir = Spec::from_doc(&arena, &doc).unwrap();
+
+    assert_matches!(
+        &*ir.operations,
+        [SpecOperation {
+            responses: [ResponseCase {
+                status: 307,
+                body: Some(SpecResponse::Headers(SpecType::Inline(
+                    SpecInlineType::Struct(_, response),
+                ))),
+            }],
+            ..
+        }] if matches!(
+            response.fields,
+            [SpecStructField {
+                name: StructFieldName::Name("location"),
+                ty: SpecType::Inline(SpecInlineType::Primitive(_, PrimitiveType::String)),
+                required: true,
+                ..
+            }]
+        ),
+    );
+}
+
+#[test]
+fn test_parses_optional_header_as_nullable_field() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test API
+          version: 1.0
+        paths:
+          /users:
+            get:
+              operationId: getUser
+              responses:
+                '304':
+                  description: Not modified.
+                  headers:
+                    etag:
+                      schema:
+                        type: string
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let ir = Spec::from_doc(&arena, &doc).unwrap();
+
+    assert_matches!(
+        &*ir.operations,
+        [SpecOperation {
+            responses: [ResponseCase {
+                status: 304,
+                body: Some(SpecResponse::Headers(SpecType::Inline(
+                    SpecInlineType::Struct(_, response),
+                ))),
+            }],
+            ..
+        }] if matches!(
+            response.fields,
+            [SpecStructField {
+                name: StructFieldName::Name("etag"),
+                ty: SpecType::Inline(SpecInlineType::Container(
+                    _,
+                    SpecContainer::Optional(SpecInner {
+                        ty: SpecType::Inline(SpecInlineType::Primitive(_, PrimitiveType::String)),
+                        ..
+                    }),
+                )),
+                required: true,
+                ..
+            }]
+        ),
+    );
+}
+
+#[test]
+fn test_ignores_headers_on_response_with_body() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test API
+          version: 1.0
+        paths:
+          /users:
+            get:
+              operationId: getUser
+              responses:
+                '200':
+                  description: Success
+                  headers:
+                    etag:
+                      required: true
+                      schema:
+                        type: string
+                  content:
+                    application/json:
+                      schema:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let ir = Spec::from_doc(&arena, &doc).unwrap();
+
+    assert_matches!(
+        &*ir.operations,
+        [SpecOperation {
+            responses: [ResponseCase {
+                status: 200,
+                body: Some(SpecResponse::Json(_)),
+            }],
+            ..
+        }],
+    );
+}
+
+#[test]
+fn test_preserves_3xx_and_2xx_success_responses() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test API
+          version: 1.0
+        paths:
+          /users:
+            get:
+              operationId: getUser
+              responses:
+                '200':
+                  description: Success
+                  content:
+                    application/json:
+                      schema:
+                        $ref: '#/components/schemas/User'
+                '304':
+                  description: Not modified.
+                  headers:
+                    ETag:
+                      required: true
+                      schema:
+                        type: string
+                '404':
+                  description: Not found
+                  content:
+                    application/json:
+                      schema:
+                        $ref: '#/components/schemas/User'
+        components:
+          schemas:
+            User:
+              type: object
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let ir = Spec::from_doc(&arena, &doc).unwrap();
+
+    // The 404 is excluded, and the capitalized `ETag` header
+    // becomes a lowercased field name.
+    assert_matches!(
+        &*ir.operations,
+        [SpecOperation {
+            responses: [
+                ResponseCase {
+                    status: 200,
+                    body: Some(SpecResponse::Json(_)),
+                },
+                ResponseCase {
+                    status: 304,
+                    body: Some(SpecResponse::Headers(SpecType::Inline(
+                        SpecInlineType::Struct(_, response),
+                    ))),
+                },
+            ],
+            ..
+        }] if matches!(
+            response.fields,
+            [SpecStructField {
+                name: StructFieldName::Name("etag"),
+                ..
+            }]
+        ),
+    );
+}
+
+#[test]
+fn test_resolves_header_component_ref() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test API
+          version: 1.0
+        paths:
+          /users:
+            delete:
+              operationId: deleteUser
+              responses:
+                '204':
+                  description: Deleted
+                  headers:
+                    x-rate-limit:
+                      $ref: '#/components/headers/RateLimit'
+        components:
+          headers:
+            RateLimit:
+              required: true
+              schema:
+                type: integer
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let ir = Spec::from_doc(&arena, &doc).unwrap();
+
+    // The referenced header resolves, and its `integer` schema is
+    // still represented as a string field.
+    assert_matches!(
+        &*ir.operations,
+        [SpecOperation {
+            responses: [ResponseCase {
+                status: 204,
+                body: Some(SpecResponse::Headers(SpecType::Inline(
+                    SpecInlineType::Struct(_, response),
+                ))),
+            }],
+            ..
+        }] if matches!(
+            response.fields,
+            [SpecStructField {
+                name: StructFieldName::Name("x-rate-limit"),
+                ty: SpecType::Inline(SpecInlineType::Primitive(_, PrimitiveType::String)),
+                required: true,
+                ..
+            }]
+        ),
+    );
+}
+
+#[test]
+fn test_ignores_content_type_header() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test API
+          version: 1.0
+        paths:
+          /archives:
+            get:
+              operationId: getArchive
+              responses:
+                '307':
+                  description: Redirect to the archive URL.
+                  headers:
+                    Content-Type:
+                      required: true
+                      schema:
+                        type: string
+                    location:
+                      required: true
+                      schema:
+                        type: string
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let ir = Spec::from_doc(&arena, &doc).unwrap();
+
+    assert_matches!(
+        &*ir.operations,
+        [SpecOperation {
+            responses: [ResponseCase {
+                status: 307,
+                body: Some(SpecResponse::Headers(SpecType::Inline(
+                    SpecInlineType::Struct(_, response),
+                ))),
+            }],
+            ..
+        }] if matches!(
+            response.fields,
+            [SpecStructField {
+                name: StructFieldName::Name("location"),
+                ..
+            }]
+        ),
+    );
+}
+
+#[test]
+fn test_header_only_response_without_headers_stays_bodyless() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test API
+          version: 1.0
+        paths:
+          /users:
+            delete:
+              operationId: deleteUser
+              responses:
+                '204':
+                  description: Deleted
+                  headers: {}
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let ir = Spec::from_doc(&arena, &doc).unwrap();
+
+    assert_matches!(
+        &*ir.operations,
+        [SpecOperation {
+            responses: [ResponseCase {
+                status: 204,
+                body: None,
+            }],
+            ..
+        }],
     );
 }
 

--- a/ploidy-core/src/ir/tests/views.rs
+++ b/ploidy-core/src/ir/tests/views.rs
@@ -2738,7 +2738,7 @@ fn test_operation_view_inlines_finds_inline_types() {
                     && matches!(
                         inline.path().root(),
                         InlineTypePathRoot::Operation {
-                            usage: OperationUsage::Response,
+                            usage: OperationUsage::Response { status: None },
                             ..
                         },
                     )
@@ -2815,10 +2815,124 @@ fn test_operation_request_and_response() {
         InlineTypePathRoot::Operation {
             id,
             resource: None,
-            usage: OperationUsage::Response,
+            usage: OperationUsage::Response { status: None },
         } if id == "createUser",
     );
     assert!(resp_path.segments().next().is_none());
+}
+
+#[test]
+fn test_operation_response_cases_preserve_statuses() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test
+          version: 1.0
+        paths:
+          /jobs:
+            post:
+              operationId: startJob
+              responses:
+                '200':
+                  description: Complete
+                  content:
+                    application/json:
+                      schema:
+                        $ref: '#/components/schemas/Job'
+                '202':
+                  description: Accepted
+                  content:
+                    application/json:
+                      schema:
+                        $ref: '#/components/schemas/PendingJob'
+        components:
+          schemas:
+            Job:
+              type: object
+            PendingJob:
+              type: object
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let spec = Spec::from_doc(&arena, &doc).unwrap();
+    let graph = RawGraph::new(&arena, &spec).cook();
+
+    let operation = graph.operations().next().unwrap();
+    let cases = operation.response_cases().collect_vec();
+    let [complete, pending] = &*cases else {
+        panic!("expected two response cases; got `{cases:?}`");
+    };
+    assert_eq!(complete.status(), 200);
+    let Some(ResponseView::Json(TypeView::Schema(complete))) = complete.body() else {
+        panic!("expected `Job` response body; got `{:?}`", complete.body());
+    };
+    assert_eq!(complete.name(), "Job");
+    assert_eq!(pending.status(), 202);
+    let Some(ResponseView::Json(TypeView::Schema(pending))) = pending.body() else {
+        panic!(
+            "expected `PendingJob` response body; got `{:?}`",
+            pending.body(),
+        );
+    };
+    assert_eq!(pending.name(), "PendingJob");
+}
+
+#[test]
+fn test_operation_response_inline_paths_include_status_when_needed() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test
+          version: 1.0
+        paths:
+          /jobs:
+            post:
+              operationId: startJob
+              responses:
+                '200':
+                  description: Complete
+                  content:
+                    application/json:
+                      schema:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                '202':
+                  description: Accepted
+                  content:
+                    application/json:
+                      schema:
+                        type: object
+                        properties:
+                          token:
+                            type: string
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let spec = Spec::from_doc(&arena, &doc).unwrap();
+    let graph = RawGraph::new(&arena, &spec).cook();
+
+    let operation = graph.operations().next().unwrap();
+    let mut statuses = operation
+        .inlines()
+        .filter_map(|inline| match inline {
+            InlineTypeView::Struct(_, _) if inline.path().segments().next().is_none() => {
+                match inline.path().root() {
+                    InlineTypePathRoot::Operation {
+                        usage: OperationUsage::Response { status },
+                        ..
+                    } => status,
+                    _ => None,
+                }
+            }
+            _ => None,
+        })
+        .collect_vec();
+    statuses.sort();
+    assert_matches!(&*statuses, [200, 202]);
 }
 
 // MARK: Parameter views

--- a/ploidy-core/src/ir/tests/views.rs
+++ b/ploidy-core/src/ir/tests/views.rs
@@ -2935,6 +2935,150 @@ fn test_operation_response_inline_paths_include_status_when_needed() {
     assert_matches!(&*statuses, [200, 202]);
 }
 
+#[test]
+fn test_operation_response_case_with_headers_body() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test
+          version: 1.0
+        paths:
+          /jobs/{id}:
+            get:
+              operationId: getJob
+              responses:
+                '200':
+                  description: Complete
+                  content:
+                    application/json:
+                      schema:
+                        $ref: '#/components/schemas/Job'
+                '304':
+                  description: Not modified.
+                  headers:
+                    etag:
+                      required: true
+                      schema:
+                        type: string
+                    cache-control:
+                      schema:
+                        type: string
+        components:
+          schemas:
+            Job:
+              type: object
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let spec = Spec::from_doc(&arena, &doc).unwrap();
+    let graph = RawGraph::new(&arena, &spec).cook();
+
+    let operation = graph.operations().next().unwrap();
+    let cases = operation.response_cases().collect_vec();
+    let [complete, not_modified] = &*cases else {
+        panic!("expected two response cases; got `{cases:?}`");
+    };
+    assert_eq!(complete.status(), 200);
+    assert_eq!(not_modified.status(), 304);
+    let Some(ResponseView::Headers(TypeView::Inline(InlineTypeView::Struct(_, headers)))) =
+        not_modified.body()
+    else {
+        panic!(
+            "expected inline headers struct; got `{:?}`",
+            not_modified.body(),
+        );
+    };
+    let fields = headers.fields().collect_vec();
+    let [etag, cache_control] = &*fields else {
+        panic!("expected two header fields; got `{fields:?}`");
+    };
+    assert_matches!(etag.name(), StructFieldName::Name("etag"));
+    assert_matches!(etag.required(), Required::Required { nullable: false });
+    assert_matches!(
+        etag.ty(),
+        TypeView::Inline(InlineTypeView::Primitive(_, p)) if p.ty() == PrimitiveType::String,
+    );
+    assert_matches!(cache_control.name(), StructFieldName::Name("cache-control"));
+    assert_matches!(
+        cache_control.required(),
+        Required::Required { nullable: true }
+    );
+}
+
+#[test]
+fn test_operation_header_struct_path_includes_status_when_needed() {
+    let doc = Document::from_yaml(indoc::indoc! {"
+        openapi: 3.0.0
+        info:
+          title: Test
+          version: 1.0
+        paths:
+          /jobs:
+            get:
+              operationId: getJob
+              responses:
+                '200':
+                  description: Complete
+                  content:
+                    application/json:
+                      schema:
+                        $ref: '#/components/schemas/Job'
+                '304':
+                  description: Not modified.
+                  headers:
+                    etag:
+                      required: true
+                      schema:
+                        type: string
+          /archives:
+            get:
+              operationId: getArchive
+              responses:
+                '307':
+                  description: Redirect to the archive URL.
+                  headers:
+                    location:
+                      required: true
+                      schema:
+                        type: string
+        components:
+          schemas:
+            Job:
+              type: object
+    "})
+    .unwrap();
+
+    let arena = Arena::new();
+    let spec = Spec::from_doc(&arena, &doc).unwrap();
+    let graph = RawGraph::new(&arena, &spec).cook();
+
+    // `getJob` has two payloads, so its header struct's path carries the
+    // status; `getArchive` has one, so its path omits the status.
+    for (id, expected) in [("getJob", Some(304)), ("getArchive", None)] {
+        let operation = graph
+            .operations()
+            .find(|op| op.id() == id)
+            .unwrap_or_else(|| panic!("expected operation `{id}`"));
+        let Some(ResponseView::Headers(TypeView::Inline(headers))) = operation
+            .response_cases()
+            .find_map(|case| match case.body() {
+                Some(ResponseView::Headers(_)) => case.body(),
+                _ => None,
+            })
+        else {
+            panic!("expected a headers response case for `{id}`");
+        };
+        assert_matches!(
+            headers.path().root(),
+            InlineTypePathRoot::Operation {
+                usage: OperationUsage::Response { status },
+                ..
+            } if status == expected,
+        );
+    }
+}
+
 // MARK: Parameter views
 
 #[test]

--- a/ploidy-core/src/ir/types/mod.rs
+++ b/ploidy-core/src/ir/types/mod.rs
@@ -103,7 +103,10 @@ pub enum OperationUsage<'a> {
     /// The request body.
     Request,
     /// The response body.
-    Response,
+    Response {
+        /// The response status code, when needed to distinguish response bodies.
+        status: Option<u16>,
+    },
 }
 
 /// A segment in an inline type path.

--- a/ploidy-core/src/ir/types/shape.rs
+++ b/ploidy-core/src/ir/types/shape.rs
@@ -32,7 +32,7 @@ impl<'a, Ty> Operation<'a, Ty> {
             }),
             self.responses.iter().filter_map(|response| {
                 response.body.as_ref().map(|body| match body {
-                    Response::Json(ty) => ty,
+                    Response::Json(ty) | Response::Headers(ty) => ty,
                 })
             })
         )
@@ -43,13 +43,17 @@ impl<'a, Ty> Operation<'a, Ty> {
 pub struct ResponseCase<Ty> {
     /// The numeric HTTP status code for this successful response.
     pub status: u16,
-    /// The response body, if this status documents one.
+    /// The response payload, if this status documents a body or headers.
     pub body: Option<Response<Ty>>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum Response<Ty> {
+    /// A JSON body.
     Json(Ty),
+    /// A struct decoded from response headers, for cases that document
+    /// headers but no body.
+    Headers(Ty),
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]

--- a/ploidy-core/src/ir/types/shape.rs
+++ b/ploidy-core/src/ir/types/shape.rs
@@ -14,7 +14,7 @@ pub struct Operation<'a, Ty> {
     pub description: Option<&'a str>,
     pub params: &'a [Parameter<'a, Ty>],
     pub request: Option<Request<Ty>>,
-    pub response: Option<Response<Ty>>,
+    pub responses: &'a [ResponseCase<Ty>],
 }
 
 impl<'a, Ty> Operation<'a, Ty> {
@@ -30,11 +30,21 @@ impl<'a, Ty> Operation<'a, Ty> {
                 Request::Json(ty) => Some(ty),
                 Request::Multipart => None,
             }),
-            self.response.as_ref().map(|response| match response {
-                Response::Json(ty) => ty,
+            self.responses.iter().filter_map(|response| {
+                response.body.as_ref().map(|body| match body {
+                    Response::Json(ty) => ty,
+                })
             })
         )
     }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct ResponseCase<Ty> {
+    /// The numeric HTTP status code for this successful response.
+    pub status: u16,
+    /// The response body, if this status documents one.
+    pub body: Option<Response<Ty>>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]

--- a/ploidy-core/src/ir/views/operation.rs
+++ b/ploidy-core/src/ir/views/operation.rs
@@ -39,7 +39,8 @@
 //! * [Query parameters], each with a name, type, and
 //!   optional serialization style.
 //! * An optional [request] body and successful [response cases], wrapping
-//!   [`TypeView`]s of body schemas when present.
+//!   [`TypeView`]s of body schemas when present. A case that documents
+//!   headers but no body wraps a struct synthesized from its headers.
 //! * An optional [resource name] from the `x-resource-name` extension,
 //!   used to group operations by resource.
 //!
@@ -401,10 +402,14 @@ pub enum RequestView<'graph, 'a> {
     Multipart,
 }
 
-/// A graph-aware view of an operation's response body.
+/// A graph-aware view of an operation's response payload.
 #[derive(Debug)]
 pub enum ResponseView<'graph, 'a> {
+    /// A JSON body.
     Json(TypeView<'graph, 'a>),
+    /// A struct decoded from response headers, for cases that document
+    /// headers but no body.
+    Headers(TypeView<'graph, 'a>),
 }
 
 /// A graph-aware view of an operation response case.
@@ -435,11 +440,14 @@ impl<'graph, 'a> ResponseCaseView<'graph, 'a> {
         self.status
     }
 
-    /// Returns the response body, if present.
+    /// Returns the response payload, if present.
     #[inline]
     pub fn body(&self) -> Option<ResponseView<'graph, 'a>> {
         self.body.map(|ty| match ty {
             GraphResponse::Json(index) => ResponseView::Json(TypeView::new(self.cooked, index)),
+            GraphResponse::Headers(index) => {
+                ResponseView::Headers(TypeView::new(self.cooked, index))
+            }
         })
     }
 }

--- a/ploidy-core/src/ir/views/operation.rs
+++ b/ploidy-core/src/ir/views/operation.rs
@@ -2,7 +2,7 @@
 //!
 //! In OpenAPI, each path item defines operations for HTTP methods like
 //! `GET` and `POST`. An operation has path and query parameters, an
-//! optional request body, and an optional response body:
+//! optional request body, and successful response bodies:
 //!
 //! ```yaml
 //! paths:
@@ -38,8 +38,8 @@
 //!   segments and path parameters.
 //! * [Query parameters], each with a name, type, and
 //!   optional serialization style.
-//! * An optional [request] and [response] body, each wrapping
-//!   a [`TypeView`] of the body schema.
+//! * An optional [request] body and successful [response cases], wrapping
+//!   [`TypeView`]s of body schemas when present.
 //! * An optional [resource name] from the `x-resource-name` extension,
 //!   used to group operations by resource.
 //!
@@ -51,7 +51,7 @@
 //! [path template]: OperationView::path
 //! [Query parameters]: OperationView::query
 //! [request]: OperationView::request
-//! [response]: OperationView::response
+//! [response cases]: OperationView::response_cases
 //! [resource name]: OperationView::resource
 
 use std::{
@@ -142,9 +142,16 @@ impl<'graph, 'a> OperationView<'graph, 'a> {
     /// Returns a view of the response body, if present.
     #[inline]
     pub fn response(&self) -> Option<ResponseView<'graph, 'a>> {
-        self.op.response.as_ref().map(|ty| match ty {
-            GraphResponse::Json(index) => ResponseView::Json(TypeView::new(self.cooked, *index)),
-        })
+        self.response_cases().find_map(|case| case.body())
+    }
+
+    /// Returns an iterator over this operation's successful response cases.
+    #[inline]
+    pub fn response_cases(&self) -> impl Iterator<Item = ResponseCaseView<'graph, 'a>> {
+        self.op
+            .responses
+            .iter()
+            .map(|case| ResponseCaseView::new(self.cooked, case.status, case.body))
     }
 }
 
@@ -398,4 +405,41 @@ pub enum RequestView<'graph, 'a> {
 #[derive(Debug)]
 pub enum ResponseView<'graph, 'a> {
     Json(TypeView<'graph, 'a>),
+}
+
+/// A graph-aware view of an operation response case.
+#[derive(Clone, Copy, Debug)]
+pub struct ResponseCaseView<'graph, 'a> {
+    cooked: &'graph CookedGraph<'a>,
+    status: u16,
+    body: Option<GraphResponse>,
+}
+
+impl<'graph, 'a> ResponseCaseView<'graph, 'a> {
+    #[inline]
+    pub(in crate::ir) fn new(
+        cooked: &'graph CookedGraph<'a>,
+        status: u16,
+        body: Option<GraphResponse>,
+    ) -> Self {
+        Self {
+            cooked,
+            status,
+            body,
+        }
+    }
+
+    /// Returns the HTTP status code for this response case.
+    #[inline]
+    pub fn status(&self) -> u16 {
+        self.status
+    }
+
+    /// Returns the response body, if present.
+    #[inline]
+    pub fn body(&self) -> Option<ResponseView<'graph, 'a>> {
+        self.body.map(|ty| match ty {
+            GraphResponse::Json(index) => ResponseView::Json(TypeView::new(self.cooked, index)),
+        })
+    }
 }

--- a/ploidy-core/src/parse/types.rs
+++ b/ploidy-core/src/parse/types.rs
@@ -204,6 +204,8 @@ pub struct Response {
     pub description: Option<String>,
     #[serde(default)]
     pub content: Option<IndexMap<String, MediaType>>,
+    #[serde(default)]
+    pub headers: Option<IndexMap<String, RefOrHeader>>,
 }
 
 /// Example definition (placeholder).
@@ -213,11 +215,15 @@ pub struct Example {
     pub extensions: IndexMap<String, JsonValue>,
 }
 
-/// Header definition (placeholder).
-#[derive(Debug, Deserialize, JsonPointee, JsonPointerTarget)]
+/// Response header definition.
+#[derive(Clone, Debug, Deserialize, JsonPointee, JsonPointerTarget)]
 pub struct Header {
-    #[serde(flatten)]
-    pub extensions: IndexMap<String, JsonValue>,
+    #[serde(default)]
+    pub required: bool,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub schema: Option<RefOrSchema>,
 }
 
 /// Security scheme definition (placeholder).
@@ -342,6 +348,9 @@ pub type RefOrRequestBody = RefOr<ComponentRef, RequestBody>;
 
 /// Either a reference or a response definition.
 pub type RefOrResponse = RefOr<ComponentRef, Response>;
+
+/// Either a reference or a header definition.
+pub type RefOrHeader = RefOr<ComponentRef, Header>;
 
 /// A reference to another definition.
 #[derive(Clone, Debug, Deserialize)]

--- a/ploidy-util/src/error.rs
+++ b/ploidy-util/src/error.rs
@@ -19,6 +19,9 @@ pub enum Error {
 
     #[error("invalid or unexpected response body")]
     Body(#[from] BodyError),
+
+    #[error("invalid or missing response header")]
+    Header(#[from] HeaderError),
 }
 
 impl Error {
@@ -34,6 +37,18 @@ impl Error {
         Self::Build(BuildError::HeaderValue(name, err.into()))
     }
 
+    /// Creates an error for a required response header that's missing.
+    #[cold]
+    pub fn missing_header(name: &'static str) -> Self {
+        Self::Header(HeaderError::Missing(name))
+    }
+
+    /// Creates an error for a response header whose value isn't valid UTF-8.
+    #[cold]
+    pub fn invalid_header(name: &'static str) -> Self {
+        Self::Header(HeaderError::NotUtf8(name))
+    }
+
     /// Returns the telemetry category for this error.
     pub fn category(&self) -> ErrorCategory {
         match self {
@@ -43,6 +58,7 @@ impl Error {
             Self::Transport(_) => ErrorCategory::Transport,
             &Self::Status(status) => ErrorCategory::Status(status),
             Self::Body(_) => ErrorCategory::Body,
+            Self::Header(_) => ErrorCategory::Header,
         }
     }
 }
@@ -118,6 +134,20 @@ pub enum BodyError {
     JsonWithPath(serde_path_to_error::Error<serde_json::Error>),
 }
 
+/// A missing or invalid header on a documented response.
+///
+/// Unlike [`BuildError::HeaderName`] and [`BuildError::HeaderValue`],
+/// which describe *request* headers rejected while building a request,
+/// [`HeaderError`] describes *response* headers that don't match the
+/// API's documented shape.
+#[derive(Debug, thiserror::Error)]
+pub enum HeaderError {
+    #[error("missing required header `{0}`")]
+    Missing(&'static str),
+    #[error("header `{0}` isn't valid UTF-8")]
+    NotUtf8(&'static str),
+}
+
 /// The telemetry category for an [`Error`].
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ErrorCategory {
@@ -127,6 +157,7 @@ pub enum ErrorCategory {
     Transport,
     Status(StatusCode),
     Body,
+    Header,
 }
 
 impl Display for ErrorCategory {
@@ -138,6 +169,32 @@ impl Display for ErrorCategory {
             Self::Transport => "transport",
             Self::Status(status) => status.as_str(),
             Self::Body => "body",
+            Self::Header => "header",
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_missing_header_error_category_is_header() {
+        let err = Error::missing_header("location");
+        assert!(matches!(
+            err,
+            Error::Header(HeaderError::Missing("location")),
+        ));
+        assert_eq!(err.category(), ErrorCategory::Header);
+        assert_eq!(err.category().to_string(), "header");
+    }
+
+    #[test]
+    fn test_invalid_header_error_display_names_header() {
+        let err = Error::invalid_header("etag");
+        let Error::Header(inner) = err else {
+            panic!("expected header error; got `{err:?}`");
+        };
+        assert_eq!(inner.to_string(), "header `etag` isn't valid UTF-8");
     }
 }


### PR DESCRIPTION
Preserve every documented successful response for an operation and generate a status-dispatched result enum when those responses have distinct body shapes. This keeps simple operations on their existing return types while letting clients handle APIs that document multiple meaningful 2xx outcomes.

The core operation IR now stores successful response cases with their numeric status codes. Graph construction treats every successful response body as an operation dependency, and inline response bodies include the status in their operation path when that is needed for stable distinct names.

Rust codegen emits each multi-success `{OperationName}Result` enum as a top-level generated type under `src/types/{operation}_result.rs` and exports it from `src/types/mod.rs`. Generated client methods return `crate::types::{OperationName}Result` so consumers can name the result type through the public types module.

The generated client captures the response status before consuming the body, matches documented success statuses, deserializes body variants, returns unit variants for bodyless successes, and reports unexpected success statuses as `Error::Status`.

Note: I needed this to handle an API was sending different response bodies for 200 and 202 as well as sending different headers for various redirect cases. Please advise on the approaches!