### PR TITLE
Let applications choose the rustls crypto provider

### DIFF
--- a/ploidy-util/Cargo.toml
+++ b/ploidy-util/Cargo.toml
@@ -51,10 +51,7 @@ uuid = { version = "1", features = ["serde", "v4"] }
 [features]
 default = ["tls"]
 # Bundles reqwest's default rustls crypto provider (aws-lc-rs), so
-# generated clients work over HTTPS with no further setup. Disable
-# default features to choose a provider instead: enable one of rustls's
-# provider features, or install a process-default `CryptoProvider`
-# before constructing clients.
+# generated clients work over HTTPS with no further setup.
 tls = ["reqwest/rustls"]
 did-you-mean = ["ploidy-pointer/did-you-mean"]
 tracing = ["dep:tracing"]

--- a/ploidy-util/Cargo.toml
+++ b/ploidy-util/Cargo.toml
@@ -32,7 +32,11 @@ reqwest = { version = "0.13", default-features = false, features = [
     "json",
     "multipart",
     "query",
-    "rustls",
+    # rustls without a bundled crypto provider: the embedding
+    # application installs a process-default CryptoProvider itself.
+    # (Boltzmann pins ring; reqwest's plain "rustls" feature would
+    # force aws-lc-rs into every consumer via feature unification.)
+    "rustls-no-provider",
 ] }
 serde = { workspace = true, features = ["derive"] }
 serde_bytes = "0.11"

--- a/ploidy-util/Cargo.toml
+++ b/ploidy-util/Cargo.toml
@@ -32,10 +32,10 @@ reqwest = { version = "0.13", default-features = false, features = [
     "json",
     "multipart",
     "query",
-    # rustls without a bundled crypto provider: the embedding
-    # application installs a process-default CryptoProvider itself.
-    # (Boltzmann pins ring; reqwest's plain "rustls" feature would
-    # force aws-lc-rs into every consumer via feature unification.)
+    # rustls without a bundled crypto provider. The default `tls`
+    # feature below adds reqwest's default provider (aws-lc-rs);
+    # applications that build with `default-features = false` install
+    # a process-default `CryptoProvider` themselves.
     "rustls-no-provider",
 ] }
 serde = { workspace = true, features = ["derive"] }
@@ -49,6 +49,13 @@ url = { version = "2", features = ["serde"] }
 uuid = { version = "1", features = ["serde", "v4"] }
 
 [features]
+default = ["tls"]
+# Bundles reqwest's default rustls crypto provider (aws-lc-rs), so
+# generated clients work over HTTPS with no further setup. Disable
+# default features to choose a provider instead: enable one of rustls's
+# provider features, or install a process-default `CryptoProvider`
+# before constructing clients.
+tls = ["reqwest/rustls"]
 did-you-mean = ["ploidy-pointer/did-you-mean"]
 tracing = ["dep:tracing"]
 trace-context = [


### PR DESCRIPTION
## Motivation

`ploidy-util` requests reqwest's `rustls` feature, which hardwires rustls to the aws-lc-rs crypto provider. Because cargo unifies features across the whole graph, every application that depends on a Ploidy-generated client inherits aws-lc-rs — and with it the aws-lc-sys cmake/C build, which is painful when cross-compiling. There's currently no way to opt out, even for applications that inject their own `reqwest::Client` via `with_reqwest_client`.

reqwest 0.13's `rustls-no-provider` feature (see seanmonstar/reqwest#2924) keeps the rustls TLS stack but leaves provider selection to the application.

## Changes

- `ploidy-util`'s reqwest dependency now requests `rustls-no-provider` instead of `rustls`.
- A new default `tls` feature enables `reqwest/rustls`, so **default behavior is unchanged**: generated clients speak HTTPS out of the box with reqwest's default provider, and the resolved dependency graph is identical (`Cargo.lock` untouched).

Applications that want a different provider build with `default-features = false` and either enable a rustls provider feature themselves (rustls auto-installs when exactly one provider feature is present in the final graph) or install a process-default `CryptoProvider` before constructing clients:

```rust
rustls::crypto::ring::default_provider()
    .install_default()
    .expect("failed to install rustls crypto provider");
```

## Possible follow-up

Generated crates depend on `ploidy-util` with default features, so consumers of a *generated* client can't reach this opt-out yet. A follow-up could teach `ploidy-codegen-rust` to emit `ploidy-util = { version, default-features = false }` plus a forwarded `default = ["tls"]` / `tls = ["ploidy-util/tls"]` feature pair in generated manifests. Happy to send that separately if this direction looks good to you.